### PR TITLE
Move to the SemVer versioning scheme.

### DIFF
--- a/volatility/framework/__init__.py
+++ b/volatility/framework/__init__.py
@@ -7,32 +7,29 @@ import inspect
 import logging
 import os
 import sys
-from typing import Any, Dict, Generator, List, Type, TypeVar, Callable
+from typing import Any, Dict, Generator, List, Type, TypeVar
 
 from volatility.framework import constants, interfaces
 
 # ##
 #
-# Libtool version scheme
+# SemVer version scheme
 #
-# Current - The number of the current interface exported by the library
-# Revision - The implementation number of the most recent interface exported by this library
-# Age - The number of previous additional interfaces supported by this library
+# Increment the:
 #
-# 1. If the source changes, increment the revision
-# 2. If the interface has changed, increment current, set revision to 0
-# 3. If only additions to the interface have been made, increment age
-# 4. If changes or removals of the interface have been made, set age to 0
+#     MAJOR version when you make incompatible API changes,
+#     MINOR version when you add functionality in a backwards compatible manner, and
+#     PATCH version when you make backwards compatible bug fixes.
 
-# We use the libtool library versioning
-CURRENT = 0  # Number of releases of the library with any change
-REVISION = 0  # Number of changes that don't affect the interface
-AGE = 0  # Number of consecutive versions of the interface the current version supports
+# We use the SemVer 2.0.0 versioning scheme
+MAJOR = 0  # Number of releases of the library with a breaking change
+MINOR = 0  # Number of changes that only add to the interface
+PATCH = 0  # Number of changes that do not change the interface
 
 
 def interface_version():
     """Provides the so version number of the library"""
-    return CURRENT - AGE, AGE, REVISION
+    return MAJOR, MINOR, PATCH
 
 
 vollog = logging.getLogger(__name__)

--- a/volatility/framework/symbols/intermed.py
+++ b/volatility/framework/symbols/intermed.py
@@ -130,12 +130,12 @@ class IntermediateSymbolTable(interfaces.symbols.SymbolTableInterface):
             -> Type['ISFormatTable']:
         """Determines the highest suitable handler for specified version format
 
-        An interface version such as (Current-Age).Age.Revision means that (Current - Age) of the provider must be equal to that of the
-          consumer, and the provider (the JSON in this instance) must have a greater age (indicating that only additive
+        An interface version such as Major.Minor.Patch means that Major of the provider must be equal to that of the
+          consumer, and the provider (the JSON in this instance) must have a greater minor (indicating that only additive
           changes have been made) than the consumer (in this case, the file reader).
         """
-        supported, age, revision = [int(x) for x in version.split(".")]
-        supported_versions = [x for x in versions if x[0] == supported and x[1] >= age]
+        major, minor, patch = [int(x) for x in version.split(".")]
+        supported_versions = [x for x in versions if x[0] == major and x[1] >= minor]
         if not supported_versions:
             raise ValueError(
                 "No Intermediate Format interface versions support file interface version: {}".format(version))
@@ -294,10 +294,7 @@ class ISFormatTable(interfaces.symbols.SymbolTableInterface, metaclass = ABCMeta
 
 class Version1Format(ISFormatTable):
     """Class for storing intermediate debugging data as objects and classes"""
-    current = 1
-    revision = 0
-    age = 1
-    version = (current - age, age, revision)
+    version = (0, 0, 1)
 
     def get_symbol(self, name: str) -> interfaces.symbols.SymbolInterface:
         """Returns the location offset given by the symbol name"""
@@ -436,10 +433,7 @@ class Version1Format(ISFormatTable):
 
 class Version2Format(Version1Format):
     """Class for storing intermediate debugging data as objects and classes"""
-    current = 2
-    revision = 0
-    age = 0
-    version = (current - age, age, revision)
+    version = (2, 0, 0)
 
     def _get_natives(self) -> Optional[interfaces.symbols.NativeTableInterface]:
         """Determines the appropriate native_types to use from the JSON data"""
@@ -488,10 +482,7 @@ class Version2Format(Version1Format):
 
 class Version3Format(Version2Format):
     """Class for storing intermediate debugging data as objects and classes"""
-    current = 3
-    revision = 0
-    age = 1
-    version = (current - age, age, revision)
+    version = (2, 0, 1)
 
     def get_symbol(self, name: str) -> interfaces.symbols.SymbolInterface:
         """Returns the symbol given by the symbol name"""
@@ -510,10 +501,7 @@ class Version3Format(Version2Format):
 
 class Version4Format(Version3Format):
     """Class for storing intermediate debugging data as objects and classes"""
-    current = 4
-    revision = 0
-    age = 0
-    version = (current - age, age, revision)
+    version = (4, 0, 0)
 
     format_mapping = {
         'int': objects.Integer,
@@ -544,10 +532,7 @@ class Version4Format(Version3Format):
 
 class Version5Format(Version4Format):
     """Class for storing intermediate debugging data as objects and classes"""
-    current = 5
-    revision = 0
-    age = 1
-    version = (current - age, age, revision)
+    version = (4, 0, 1)
 
     def get_symbol(self, name: str) -> interfaces.symbols.SymbolInterface:
         """Returns the symbol given by the symbol name"""
@@ -569,10 +554,7 @@ class Version5Format(Version4Format):
 
 class Version6Format(Version5Format):
     """Class for storing intermediate debugging data as objects and classes"""
-    current = 6
-    revision = 0
-    age = 0
-    version = (current - age, age, revision)
+    version = (6, 0, 0)
 
     @property
     def metadata(self) -> Optional[interfaces.symbols.MetadataInterface]:
@@ -586,7 +568,4 @@ class Version6Format(Version5Format):
 
 class Version7Format(Version6Format):
     """Class for storing intermediate debugging data as objects and classes"""
-    current = 7
-    revision = 0
-    age = 1
-    version = (current - age, age, revision)
+    version = (6, 0, 1)


### PR DESCRIPTION
There's not that much difference between SemVer and library .so versioning, just less maths to calculate.  Essentially we keep the numbers we had, but in the future we'll make single major version number jumps (as opposed to the jumps by the number of updates we made previously).