### PR TITLE
Update windows extensions to ensure they're documented.

### DIFF
--- a/volatility/framework/plugins/windows/poolscanner.py
+++ b/volatility/framework/plugins/windows/poolscanner.py
@@ -435,7 +435,7 @@ class PoolScanner(plugins.PluginInterface):
                 sub_path = "windows",
                 filename = pool_header_json_filename,
                 table_mapping = {'nt_symbols': symbol_table},
-                class_types = {'_POOL_HEADER': extensions._POOL_HEADER})
+                class_types = {'_POOL_HEADER': extensions.POOL_HEADER})
             module = context.module(new_table_name, layer_name, offset = 0)
         return module
 

--- a/volatility/framework/symbols/__init__.py
+++ b/volatility/framework/symbols/__init__.py
@@ -94,7 +94,7 @@ class SymbolSpace(interfaces.symbols.SymbolSpaceInterface):
 
     ### Resolution functions
 
-    class _UnresolvedTemplate(objects.templates.ReferenceTemplate):
+    class UnresolvedTemplate(objects.templates.ReferenceTemplate):
         """Class to highlight when missing symbols are present.
 
         This class is identical to a reference template, but differentiable by its classname.
@@ -150,7 +150,7 @@ class SymbolSpace(interfaces.symbols.SymbolSpaceInterface):
                                 self._resolved[child.vol.type_name] = self._weak_resolve(
                                     SymbolType.TYPE, child.vol.type_name)
                             except exceptions.SymbolError:
-                                self._resolved[child.vol.type_name] = self._UnresolvedTemplate(child.vol.type_name)
+                                self._resolved[child.vol.type_name] = self.UnresolvedTemplate(child.vol.type_name)
                         # Stash the replacement
                         replacements.add((traverser, child))
                     elif child.children:

--- a/volatility/framework/symbols/windows/__init__.py
+++ b/volatility/framework/symbols/windows/__init__.py
@@ -14,46 +14,46 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         super().__init__(context = context, config_path = config_path, name = name, isf_url = isf_url)
 
         # Set-up windows specific types
-        self.set_type_class('_ETHREAD', extensions._ETHREAD)
-        self.set_type_class('_LIST_ENTRY', extensions._LIST_ENTRY)
-        self.set_type_class('_EPROCESS', extensions._EPROCESS)
-        self.set_type_class('_UNICODE_STRING', extensions._UNICODE_STRING)
-        self.set_type_class('_EX_FAST_REF', extensions._EX_FAST_REF)
-        self.set_type_class('_OBJECT_HEADER', extensions._OBJECT_HEADER)
-        self.set_type_class('_FILE_OBJECT', extensions._FILE_OBJECT)
-        self.set_type_class('_DEVICE_OBJECT', extensions._DEVICE_OBJECT)
-        self.set_type_class('_CM_KEY_BODY', registry._CM_KEY_BODY)
-        self.set_type_class('_CMHIVE', registry._CMHIVE)
-        self.set_type_class('_CM_KEY_NODE', registry._CM_KEY_NODE)
-        self.set_type_class('_CM_KEY_VALUE', registry._CM_KEY_VALUE)
-        self.set_type_class('_HMAP_ENTRY', registry._HMAP_ENTRY)
-        self.set_type_class('_MMVAD_SHORT', extensions._MMVAD_SHORT)
-        self.set_type_class('_MMVAD', extensions._MMVAD)
-        self.set_type_class('_KSYSTEM_TIME', extensions._KSYSTEM_TIME)
-        self.set_type_class('_KMUTANT', extensions._KMUTANT)
-        self.set_type_class('_DRIVER_OBJECT', extensions._DRIVER_OBJECT)
-        self.set_type_class('_OBJECT_SYMBOLIC_LINK', extensions._OBJECT_SYMBOLIC_LINK)
+        self.set_type_class('_ETHREAD', extensions.ETHREAD)
+        self.set_type_class('_LIST_ENTRY', extensions.LIST_ENTRY)
+        self.set_type_class('_EPROCESS', extensions.EPROCESS)
+        self.set_type_class('_UNICODE_STRING', extensions.UNICODE_STRING)
+        self.set_type_class('_EX_FAST_REF', extensions.EX_FAST_REF)
+        self.set_type_class('_OBJECT_HEADER', extensions.OBJECT_HEADER)
+        self.set_type_class('_FILE_OBJECT', extensions.FILE_OBJECT)
+        self.set_type_class('_DEVICE_OBJECT', extensions.DEVICE_OBJECT)
+        self.set_type_class('_CM_KEY_BODY', registry.CM_KEY_BODY)
+        self.set_type_class('_CMHIVE', registry.CMHIVE)
+        self.set_type_class('_CM_KEY_NODE', registry.CM_KEY_NODE)
+        self.set_type_class('_CM_KEY_VALUE', registry.CM_KEY_VALUE)
+        self.set_type_class('_HMAP_ENTRY', registry.HMAP_ENTRY)
+        self.set_type_class('_MMVAD_SHORT', extensions.MMVAD_SHORT)
+        self.set_type_class('_MMVAD', extensions.MMVAD)
+        self.set_type_class('_KSYSTEM_TIME', extensions.KSYSTEM_TIME)
+        self.set_type_class('_KMUTANT', extensions.KMUTANT)
+        self.set_type_class('_DRIVER_OBJECT', extensions.DRIVER_OBJECT)
+        self.set_type_class('_OBJECT_SYMBOLIC_LINK', extensions.OBJECT_SYMBOLIC_LINK)
 
         # This doesn't exist in very specific versions of windows
         try:
-            self.set_type_class('_POOL_HEADER', extensions._POOL_HEADER)
+            self.set_type_class('_POOL_HEADER', extensions.POOL_HEADER)
         except ValueError:
             pass
 
         # these don't exist in windows XP
         try:
-            self.set_type_class('_MMADDRESS_NODE', extensions._MMVAD_SHORT)
+            self.set_type_class('_MMADDRESS_NODE', extensions.MMVAD_SHORT)
         except ValueError:
             pass
 
         # these were introduced starting in windows 8
         try:
-            self.set_type_class('_MM_AVL_NODE', extensions._MMVAD_SHORT)
+            self.set_type_class('_MM_AVL_NODE', extensions.MMVAD_SHORT)
         except ValueError:
             pass
 
         # these were introduced starting in windows 7
         try:
-            self.set_type_class('_RTL_BALANCED_NODE', extensions._MMVAD_SHORT)
+            self.set_type_class('_RTL_BALANCED_NODE', extensions.MMVAD_SHORT)
         except ValueError:
             pass

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -19,7 +19,7 @@ vollog = logging.getLogger(__name__)
 # Keep these in a basic module, to prevent import cycles when symbol providers require them
 
 
-class _POOL_HEADER(objects.StructType):
+class POOL_HEADER(objects.StructType):
     """A kernel pool allocation header.
 
     Exists at the base of the allocation and provides a tag that we can
@@ -190,7 +190,7 @@ class _POOL_HEADER(objects.StructType):
         return headers, sizes
 
 
-class _KSYSTEM_TIME(objects.StructType):
+class KSYSTEM_TIME(objects.StructType):
     """A system time structure that stores a high and low part."""
 
     def get_time(self):
@@ -198,7 +198,7 @@ class _KSYSTEM_TIME(objects.StructType):
         return conversion.wintime_to_datetime(wintime)
 
 
-class _MMVAD_SHORT(objects.StructType):
+class MMVAD_SHORT(objects.StructType):
     """A class that represents process virtual memory ranges.
 
     Each instance is a node in a binary tree structure and is pointed to
@@ -430,7 +430,7 @@ class _MMVAD_SHORT(objects.StructType):
         return renderers.NotApplicableValue()
 
 
-class _MMVAD(_MMVAD_SHORT):
+class MMVAD(MMVAD_SHORT):
     """A version of the process virtual memory range structure that contains
     additional fields necessary to map files from disk."""
 
@@ -455,7 +455,7 @@ class _MMVAD(_MMVAD_SHORT):
         return file_name
 
 
-class _EX_FAST_REF(objects.StructType):
+class EX_FAST_REF(objects.StructType):
     """This is a standard Windows structure that stores a pointer to an object
     but also leverages the least significant bits to encode additional details.
 
@@ -484,7 +484,7 @@ class ExecutiveObject(interfaces.objects.ObjectInterface):
     """This is used as a "mixin" that provides all kernel executive objects
     with a means of finding their own object header."""
 
-    def object_header(self) -> '_OBJECT_HEADER':
+    def object_header(self) -> 'OBJECT_HEADER':
         if constants.BANG not in self.vol.type_name:
             raise ValueError("Invalid symbol table name syntax (no {} found)".format(constants.BANG))
         symbol_table_name = self.vol.type_name.split(constants.BANG)[0]
@@ -496,7 +496,7 @@ class ExecutiveObject(interfaces.objects.ObjectInterface):
                                     native_layer_name = self.vol.native_layer_name)
 
 
-class _DEVICE_OBJECT(objects.StructType, ExecutiveObject):
+class DEVICE_OBJECT(objects.StructType, ExecutiveObject):
     """A class for kernel device objects."""
 
     def get_device_name(self) -> str:
@@ -504,7 +504,7 @@ class _DEVICE_OBJECT(objects.StructType, ExecutiveObject):
         return header.NameInfo.Name.String  # type: ignore
 
 
-class _DRIVER_OBJECT(objects.StructType, ExecutiveObject):
+class DRIVER_OBJECT(objects.StructType, ExecutiveObject):
     """A class for kernel driver objects."""
 
     def get_driver_name(self) -> str:
@@ -516,7 +516,7 @@ class _DRIVER_OBJECT(objects.StructType, ExecutiveObject):
         return True
 
 
-class _OBJECT_SYMBOLIC_LINK(objects.StructType, ExecutiveObject):
+class OBJECT_SYMBOLIC_LINK(objects.StructType, ExecutiveObject):
     """A class for kernel link objects."""
 
     def get_link_name(self) -> str:
@@ -531,7 +531,7 @@ class _OBJECT_SYMBOLIC_LINK(objects.StructType, ExecutiveObject):
         return conversion.wintime_to_datetime(self.CreationTime.QuadPart)
 
 
-class _FILE_OBJECT(objects.StructType, ExecutiveObject):
+class FILE_OBJECT(objects.StructType, ExecutiveObject):
     """A class for windows file objects."""
 
     def is_valid(self) -> bool:
@@ -552,7 +552,7 @@ class _FILE_OBJECT(objects.StructType, ExecutiveObject):
         return name
 
 
-class _KMUTANT(objects.StructType, ExecutiveObject):
+class KMUTANT(objects.StructType, ExecutiveObject):
     """A class for windows mutant objects."""
 
     def is_valid(self) -> bool:
@@ -565,7 +565,7 @@ class _KMUTANT(objects.StructType, ExecutiveObject):
         return header.NameInfo.Name.String  # type: ignore
 
 
-class _OBJECT_HEADER(objects.StructType):
+class OBJECT_HEADER(objects.StructType):
     """A class for the headers for executive kernel objects, which contains
     quota information, ownership details, naming data, and ACLs."""
 
@@ -642,7 +642,7 @@ class _OBJECT_HEADER(objects.StructType):
         return header
 
 
-class _ETHREAD(objects.StructType):
+class ETHREAD(objects.StructType):
     """A class for executive thread objects."""
 
     def owning_process(self, kernel_layer: str = None) -> interfaces.objects.ObjectInterface:
@@ -650,7 +650,7 @@ class _ETHREAD(objects.StructType):
         return self.ThreadsProcess.dereference(kernel_layer)
 
 
-class _UNICODE_STRING(objects.StructType):
+class UNICODE_STRING(objects.StructType):
     """A class for Windows unicode string structures."""
 
     def get_string(self) -> interfaces.objects.ObjectInterface:
@@ -665,7 +665,7 @@ class _UNICODE_STRING(objects.StructType):
     String = property(get_string)
 
 
-class _EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
+class EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
     """A class for executive kernel processes objects."""
 
     def is_valid(self) -> bool:
@@ -823,7 +823,7 @@ class _EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
             return self.VadRoot.dereference().cast("_MMVAD")
 
 
-class _LIST_ENTRY(objects.StructType, collections.abc.Iterable):
+class LIST_ENTRY(objects.StructType, collections.abc.Iterable):
     """A class for double-linked lists on Windows."""
 
     def to_list(self,

--- a/volatility/framework/symbols/windows/extensions/kdbg.py
+++ b/volatility/framework/symbols/windows/extensions/kdbg.py
@@ -6,7 +6,7 @@ from volatility.framework import constants
 from volatility.framework import objects
 
 
-class _KDDEBUGGER_DATA64(objects.StructType):
+class KDDEBUGGER_DATA64(objects.StructType):
 
     def get_build_lab(self):
         """Returns the NT build lab string from the KDBG."""
@@ -33,4 +33,4 @@ class _KDDEBUGGER_DATA64(objects.StructType):
         return (csdresult >> 8) & 0xffffffff
 
 
-class_types = {'_KDDEBUGGER_DATA64': _KDDEBUGGER_DATA64}
+class_types = {'_KDDEBUGGER_DATA64': KDDEBUGGER_DATA64}

--- a/volatility/framework/symbols/windows/extensions/pe.py
+++ b/volatility/framework/symbols/windows/extensions/pe.py
@@ -9,7 +9,7 @@ from volatility.framework import objects, interfaces
 from volatility.framework.renderers import conversion
 
 
-class _IMAGE_DOS_HEADER(objects.StructType):
+class IMAGE_DOS_HEADER(objects.StructType):
 
     def get_nt_header(self) -> interfaces.objects.ObjectInterface:
         """Carve out the NT header from this DOS header. This reflects on the
@@ -145,7 +145,7 @@ class _IMAGE_DOS_HEADER(objects.StructType):
             counter += 1
 
 
-class _IMAGE_NT_HEADERS(objects.StructType):
+class IMAGE_NT_HEADERS(objects.StructType):
 
     def get_sections(self) -> Generator[interfaces.objects.ObjectInterface, None, None]:
         """Iterate through the section headers for this PE file.
@@ -168,8 +168,8 @@ class _IMAGE_NT_HEADERS(objects.StructType):
 
 
 class_types = {
-    '_IMAGE_DOS_HEADER': _IMAGE_DOS_HEADER,
+    '_IMAGE_DOS_HEADER': IMAGE_DOS_HEADER,
     # the 32- and 64-bit extensions behave the same way, but the underlying structure is different
-    '_IMAGE_NT_HEADERS': _IMAGE_NT_HEADERS,
-    '_IMAGE_NT_HEADERS64': _IMAGE_NT_HEADERS
+    '_IMAGE_NT_HEADERS': IMAGE_NT_HEADERS,
+    '_IMAGE_NT_HEADERS64': IMAGE_NT_HEADERS
 }

--- a/volatility/framework/symbols/windows/extensions/registry.py
+++ b/volatility/framework/symbols/windows/extensions/registry.py
@@ -62,7 +62,7 @@ class RegKeyFlags(enum.IntEnum):
     KEY_VIRTUAL_STORE = 0x200
 
 
-class _HMAP_ENTRY(objects.StructType):
+class HMAP_ENTRY(objects.StructType):
 
     def get_block_offset(self) -> int:
         try:
@@ -71,7 +71,7 @@ class _HMAP_ENTRY(objects.StructType):
             return self.BlockAddress
 
 
-class _CMHIVE(objects.StructType):
+class CMHIVE(objects.StructType):
 
     def get_name(self) -> Optional[interfaces.objects.ObjectInterface]:
         """Determine a name for the hive.
@@ -92,7 +92,7 @@ class _CMHIVE(objects.StructType):
     name = property(get_name)
 
 
-class _CM_KEY_BODY(objects.StructType):
+class CM_KEY_BODY(objects.StructType):
     """This represents an open handle to a registry key and is not tied to the
     registry hive file format on disk."""
 
@@ -127,7 +127,7 @@ class _CM_KEY_BODY(objects.StructType):
         return "\\".join(reversed(output))
 
 
-class _CM_KEY_NODE(objects.StructType):
+class CM_KEY_NODE(objects.StructType):
     """Extension to allow traversal of registry keys."""
 
     def get_volatile(self) -> bool:
@@ -220,7 +220,7 @@ class _CM_KEY_NODE(objects.StructType):
         return reg.get_node(self.Parent).get_key_path() + '\\' + self.get_name()
 
 
-class _CM_KEY_VALUE(objects.StructType):
+class CM_KEY_VALUE(objects.StructType):
     """Extensions to extract data from CM_KEY_VALUE nodes."""
 
     def get_name(self) -> interfaces.objects.ObjectInterface:

--- a/volatility/framework/symbols/windows/extensions/services.py
+++ b/volatility/framework/symbols/windows/extensions/services.py
@@ -9,7 +9,7 @@ from volatility.framework import renderers
 from typing import Union
 
 
-class _SERVICE_RECORD(objects.StructType):
+class SERVICE_RECORD(objects.StructType):
     """A service record structure."""
 
     def is_valid(self) -> bool:
@@ -114,7 +114,7 @@ class _SERVICE_RECORD(objects.StructType):
             raise StopIteration
 
 
-class _SERVICE_HEADER(objects.StructType):
+class SERVICE_HEADER(objects.StructType):
     """A service header structure."""
 
     def is_valid(self) -> bool:
@@ -125,4 +125,4 @@ class _SERVICE_HEADER(objects.StructType):
             return False
 
 
-class_types = {'_SERVICE_RECORD': _SERVICE_RECORD, '_SERVICE_HEADER': _SERVICE_HEADER}
+class_types = {'_SERVICE_RECORD': SERVICE_RECORD, '_SERVICE_HEADER': SERVICE_HEADER}


### PR DESCRIPTION
By keeping the class names in sync with their symbol names, we inadvertently prevented the classes being documented properly (because they were considered by python to be private, since they started with an underscore).  There is no technical reason that the classes need to match the symbol names exactly.  The upshot of this is that we'll have the classes documented, but it may cause slight confusion for people grepping the source code of volatility if they don't understand the convention change.  It should also be noted that developers who are not aware of the need to carry out class overrides may be confused if they try to cast as the un-underscored name, but I'm not sure the convenience that keeping them in sync causes is worth the cost of the documentation...