### PR TITLE
Add Missing Word to Readme

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -50,7 +50,7 @@ Quick Start
 
 3. To get more information on a Windows memory sample and to make sure
 Volatility supports that sample type, run
-'python -f <imagepath> windows.info’
+'python vol.py -f <imagepath> windows.info’
 
    Example:
 


### PR DESCRIPTION
Add a missing `vol.py` from the command `python -f <imagepath> windows.info` in README.txt. If the README is being re-done by #89, this would need to be changed there as well.