### PR TITLE
vadyarascan: Ensure we scan the right layer

### DIFF
--- a/volatility/framework/plugins/windows/vadyarascan.py
+++ b/volatility/framework/plugins/windows/vadyarascan.py
@@ -73,10 +73,12 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
                                                  layer_name = self.config['primary'],
                                                  symbol_table = self.config['nt_symbols'],
                                                  filter_func = filter_func):
+            layer_name = task.add_process_layer()
+            layer = self.context.layers[layer_name]
             for offset, name in layer.scan(context = self.context,
                                            scanner = yarascan.YaraScanner(rules = rules),
                                            sections = self.get_vad_maps(task)):
-                yield format_hints.Hex(offset), name
+                yield (0, (format_hints.Hex(offset), task.UniqueProcessId, name))
 
     @staticmethod
     def get_vad_maps(task: interfaces.objects.ObjectInterface) -> Iterable[Tuple[int, int]]:
@@ -96,4 +98,4 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
             yield (start, end - start)
 
     def run(self):
-        return renderers.TreeGrid([('Offset', format_hints.Hex), ('Rule', str)], self._generator())
+        return renderers.TreeGrid([('Offset', format_hints.Hex), ('Pid', int), ('Rule', str)], self._generator())


### PR DESCRIPTION
This patch ensures we scan the vad segments within the correct layer
(the process layer, not the kernel layer) and lists the pid in the
output.

Just for confirmation, asking @iMHLv2 for a quick review.  I'll commit this on the 31st October if I don't hear any objections...  5;)