### PR TITLE
Fix on eprocess is_valid

### DIFF
--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -696,7 +696,7 @@ class EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
                 return False
 
             # check for all 0s besides the PCID entries
-            if self.Pcb.DirectoryTableBase & ~0xfff == 0:
+            if self.Pcb.DirectoryTableBase[0] & ~0xfff == 0:
                 return False
 
             ## TODO: we can also add the thread Flink and Blink tests if necessary

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -694,7 +694,7 @@ class EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
 
             # check for all 0s besides the PCID entries
             if isinstance(self.Pcb.DirectoryTableBase, objects.Array):
-                dtb = self.Pcb.DirectoryTableBase.cast("unsigned long long")
+                dtb = self.Pcb.DirectoryTableBase.cast("pointer")
             else:
                 dtb = self.Pcb.DirectoryTableBase
 

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -692,11 +692,17 @@ class EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
             if self.UniqueProcessId % 4 != 0:
                 return False
 
-            if self.Pcb.DirectoryTableBase == 0:
+            # check for all 0s besides the PCID entries
+            if isinstance(self.Pcb.DirectoryTableBase, objects.Array):
+                dtb = self.Pcb.DirectoryTableBase.cast("unsigned long long")
+            else:
+                dtb = self.Pcb.DirectoryTableBase
+
+            if dtb == 0:
                 return False
 
             # check for all 0s besides the PCID entries
-            if self.Pcb.DirectoryTableBase[0] & ~0xfff == 0:
+            if dtb & ~0xfff == 0:
                 return False
 
             ## TODO: we can also add the thread Flink and Blink tests if necessary


### PR DESCRIPTION
It seems that Windows symbols sometimes represent the DirectoryTableBase in KPROCESS as an array, others as an unsigned long, others as an unsigned long long. This fix deals with these discrepancies in the is_valid method for the EPROCESS class, just like it is done in the add_process_layer method.