### PR TITLE
Add init_order_modules and mem_order_modules to EPROCESS class

### DIFF
--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -706,7 +706,6 @@ class EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
 
         return True
 
-
     def add_process_layer(self, config_prefix: str = None, preferred_name: str = None):
         """Constructs a new layer based on the process's DirectoryTableBase."""
 

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -734,14 +734,14 @@ class EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
         if constants.BANG not in self.vol.type_name:
             raise ValueError("Invalid symbol table name syntax (no {} found)".format(constants.BANG))
 
-        try:
-            proc_layer_name = self.add_process_layer()
-        except exceptions.InvalidAddressException:
-            return
+        # add_process_layer can raise InvalidAddressException.
+        # if that happens, we let the exception propagate upwards
+        proc_layer_name = self.add_process_layer()
 
         proc_layer = self._context.layers[proc_layer_name]
         if not proc_layer.is_valid(self.Peb):
-            return
+            raise exceptions.InvalidAddressException(proc_layer_name, self.Peb, 
+                                                     "Invalid address at {:0x}".format(self.Peb))
 
         sym_table = self.vol.type_name.split(constants.BANG)[0]
         peb = self._context.object("{}{}_PEB".format(sym_table, constants.BANG),

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -750,6 +750,48 @@ class EPROCESS(generic.GenericIntelProcess, ExecutiveObject):
                 "{}{}_LDR_DATA_TABLE_ENTRY".format(sym_table, constants.BANG), "InLoadOrderLinks"):
             yield entry
 
+    def init_order_modules(self) -> Iterable[int]:
+        """Generator for DLLs in the order that they were loaded."""
+
+        if constants.BANG not in self.vol.type_name:
+            raise ValueError("Invalid symbol table name syntax (no {} found)".format(constants.BANG))
+
+        proc_layer_name = self.add_process_layer()
+
+        proc_layer = self._context.layers[proc_layer_name]
+        if not proc_layer.is_valid(self.Peb):
+            return
+
+        sym_table = self.vol.type_name.split(constants.BANG)[0]
+        peb = self._context.object("{}{}_PEB".format(sym_table, constants.BANG),
+                                   layer_name = proc_layer_name,
+                                   offset = self.Peb)
+
+        for entry in peb.Ldr.InInitializationOrderModuleList.to_list(
+                "{}{}_LDR_DATA_TABLE_ENTRY".format(sym_table, constants.BANG), "InInitializationOrderLinks"):
+            yield entry
+
+    def mem_order_modules(self) -> Iterable[int]:
+        """Generator for DLLs in the order that they were loaded."""
+
+        if constants.BANG not in self.vol.type_name:
+            raise ValueError("Invalid symbol table name syntax (no {} found)".format(constants.BANG))
+
+        proc_layer_name = self.add_process_layer()
+
+        proc_layer = self._context.layers[proc_layer_name]
+        if not proc_layer.is_valid(self.Peb):
+            return
+
+        sym_table = self.vol.type_name.split(constants.BANG)[0]
+        peb = self._context.object("{}{}_PEB".format(sym_table, constants.BANG),
+                                   layer_name = proc_layer_name,
+                                   offset = self.Peb)
+
+        for entry in peb.Ldr.InMemoryOrderModuleList.to_list(
+                "{}{}_LDR_DATA_TABLE_ENTRY".format(sym_table, constants.BANG), "InMemoryOrderLinks"):
+            yield entry
+
     def get_handle_count(self):
         try:
             if self.has_member("ObjectTable"):


### PR DESCRIPTION
This PR adds functions init_order_modules and mem_order_modules, equivalent to load_order_modules for the other 2 linked lists present in the PEB. I don't know if these where intentionally excluded, but since the equivalents were present in volatility2 and I was using them in PyREBox, I just added them to the class.