### PR TITLE
CLI: Move progress output to stderr from stdout.

### DIFF
--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -57,7 +57,7 @@ class PrintedProgress(object):
         message = "\rProgress: {0: 7.2f}\t\t{1:}".format(round(progress, 2), description or '')
         message_len = len(message)
         self._max_message_len = max([self._max_message_len, message_len])
-        print(message, end = (' ' * (self._max_message_len - message_len)) + '\r')
+        sys.stderr.write(message + (' ' * (self._max_message_len - message_len)) + '\r')
 
 
 class MuteProgress(PrintedProgress):


### PR DESCRIPTION
Fixes issue #104.

I can't think of any issues, and POSIX defines stderr to be for diagnostics output as well as for errors.  This is also where all our logging messages go, so seems like it should be ok.  I'm not sure who else should review this, so I'll just merge this, but this information is in case that was the wrong move.  5;)