### PR TITLE
Ensure we use configured paths at import.

### DIFF
--- a/volatility/plugins/linux/__init__.py
+++ b/volatility/plugins/linux/__init__.py
@@ -8,12 +8,12 @@ are dependent upon, please DO NOT alter or remove this file unless you know the 
 
 The framework is configured this way to allow plugin developers/users to override any plugin functionality whether
 existing or new.
+
+When overriding the plugins directory, you must include a file like this in any subdirectories that may be necessary.
 """
-
 import os
-
-from volatility.framework import constants
+import sys
 
 # This is necessary to ensure the core plugins are available, whilst still be overridable
-plugin_path_components = __name__.split('.')[2:]
-__path__ = [os.path.join(x, *plugin_path_components) for x in constants.PLUGINS_PATH]
+parent_module, module_name = ".".join(__name__.split(".")[:-1]), __name__.split(".")[-1]
+__path__ = [os.path.join(x, module_name) for x in sys.modules[parent_module].__path__]

--- a/volatility/plugins/mac/__init__.py
+++ b/volatility/plugins/mac/__init__.py
@@ -8,12 +8,12 @@ are dependent upon, please DO NOT alter or remove this file unless you know the 
 
 The framework is configured this way to allow plugin developers/users to override any plugin functionality whether
 existing or new.
+
+When overriding the plugins directory, you must include a file like this in any subdirectories that may be necessary.
 """
-
 import os
-
-from volatility.framework import constants
+import sys
 
 # This is necessary to ensure the core plugins are available, whilst still be overridable
-plugin_path_components = __name__.split('.')[2:]
-__path__ = [os.path.join(x, *plugin_path_components) for x in constants.PLUGINS_PATH]
+parent_module, module_name = ".".join(__name__.split(".")[:-1]), __name__.split(".")[-1]
+__path__ = [os.path.join(x, module_name) for x in sys.modules[parent_module].__path__]

--- a/volatility/plugins/windows/__init__.py
+++ b/volatility/plugins/windows/__init__.py
@@ -8,12 +8,12 @@ are dependent upon, please DO NOT alter or remove this file unless you know the 
 
 The framework is configured this way to allow plugin developers/users to override any plugin functionality whether
 existing or new.
+
+When overriding the plugins directory, you must include a file like this in any subdirectories that may be necessary.
 """
-
 import os
-
-from volatility.framework import constants
+import sys
 
 # This is necessary to ensure the core plugins are available, whilst still be overridable
-plugin_path_components = __name__.split('.')[2:]
-__path__ = [os.path.join(x, *plugin_path_components) for x in constants.PLUGINS_PATH]
+parent_module, module_name = ".".join(__name__.split(".")[:-1]), __name__.split(".")[-1]
+__path__ = [os.path.join(x, module_name) for x in sys.modules[parent_module].__path__]

--- a/volatility/plugins/windows/registry/__init__.py
+++ b/volatility/plugins/windows/registry/__init__.py
@@ -8,12 +8,12 @@ are dependent upon, please DO NOT alter or remove this file unless you know the 
 
 The framework is configured this way to allow plugin developers/users to override any plugin functionality whether
 existing or new.
+
+When overriding the plugins directory, you must include a file like this in any subdirectories that may be necessary.
 """
-
 import os
-
-from volatility.framework import constants
+import sys
 
 # This is necessary to ensure the core plugins are available, whilst still be overridable
-plugin_path_components = __name__.split('.')[2:]
-__path__ = [os.path.join(x, *plugin_path_components) for x in constants.PLUGINS_PATH]
+parent_module, module_name = ".".join(__name__.split(".")[:-1]), __name__.split(".")[-1]
+__path__ = [os.path.join(x, module_name) for x in sys.modules[parent_module].__path__]


### PR DESCRIPTION
Previously if submodules were imported after the plugin/symbol __path__s had
been set, it would only use the __path__s from the constants module.

We now use the parent module's __path__s to ensure we get the right
sub__path__s.

This seems better/more flexible than changing the original constants
(since they'd no longer be constant) and allows people more chance to
override things.  It brings with it potential confusion as a local
plugin directory will need __init__ files with this magic to allow the
core modules to run (since they come first in the path list).

This should be unnoticeable by most, but is a fairly big change so could do with discussion (I'm pretty sure the code works fine, it's more if there's a better way of handling things so that the plugin path can be overridden the user needing special files to get it working)...

I'll merge this on the 4th if there's no discussion.