### PR TITLE
Fix a logging on add_process_layer exceptions.

### DIFF
--- a/volatility/framework/plugins/windows/cmdline.py
+++ b/volatility/framework/plugins/windows/cmdline.py
@@ -1,13 +1,15 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-
+import logging
 from typing import List
 
 from volatility.framework import constants, exceptions, renderers, interfaces
 from volatility.framework.configuration import requirements
 from volatility.framework.objects import utility
 from volatility.plugins.windows import pslist
+
+vollog = logging.getLogger(__name__)
 
 
 class CmdLine(interfaces.plugins.PluginInterface):
@@ -31,9 +33,13 @@ class CmdLine(interfaces.plugins.PluginInterface):
 
         for proc in procs:
             process_name = utility.array_to_string(proc.ImageFileName)
+            proc_id = "Unknown"
             try:
+                proc_id = proc.UniqueProcessId
                 proc_layer_name = proc.add_process_layer()
-            except exceptions.InvalidAddressException:
+            except exceptions.InvalidAddressException as excp:
+                vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
+                                                                                 excp.layer_name))
                 continue
 
             try:

--- a/volatility/framework/plugins/windows/dlldump.py
+++ b/volatility/framework/plugins/windows/dlldump.py
@@ -6,7 +6,7 @@ import logging
 import ntpath
 from typing import List
 
-from volatility.framework import interfaces, constants
+from volatility.framework import interfaces, constants, exceptions
 from volatility.framework import renderers
 from volatility.framework.configuration import requirements
 from volatility.framework.objects import utility
@@ -53,10 +53,14 @@ class DllDump(interfaces.plugins.PluginInterface):
 
         for proc in procs:
             process_name = utility.array_to_string(proc.ImageFileName)
-            
+
+            proc_id = "Unknown"
             try:
+                proc_id = proc.UniqueProcessId
                 proc_layer_name = proc.add_process_layer()
-            except exceptions.InvalidAddressException:
+            except exceptions.InvalidAddressException as excp:
+                vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
+                                                                                 excp.layer_name))
                 continue
 
             for vad in vadinfo.VadInfo.list_vads(proc, filter_func = filter_func):

--- a/volatility/framework/plugins/windows/malfind.py
+++ b/volatility/framework/plugins/windows/malfind.py
@@ -1,14 +1,17 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
+import logging
 from typing import Iterable, Tuple
 
-from volatility.framework import interfaces, symbols
+from volatility.framework import interfaces, symbols, exceptions
 from volatility.framework import renderers
 from volatility.framework.configuration import requirements
 from volatility.framework.objects import utility
 from volatility.framework.renderers import format_hints
 from volatility.plugins.windows import pslist, vadinfo
+
+vollog = logging.getLogger(__name__)
 
 
 class Malfind(interfaces.plugins.PluginInterface):
@@ -73,9 +76,13 @@ class Malfind(interfaces.plugins.PluginInterface):
         Returns:
             An iterable of VAD instances and the first 64 bytes of data containing in that region
         """
+        proc_id = "Unknown"
         try:
+            proc_id = proc.UniqueProcessId
             proc_layer_name = proc.add_process_layer()
-        except exceptions.InvalidAddressException:
+        except exceptions.InvalidAddressException as excp:
+            vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
+                                                                             excp.layer_name))
             return
 
         proc_layer = context.layers[proc_layer_name]

--- a/volatility/framework/plugins/windows/strings.py
+++ b/volatility/framework/plugins/windows/strings.py
@@ -6,7 +6,7 @@ import logging
 import re
 from typing import Dict, Generator, List, Set, Tuple
 
-from volatility.framework import interfaces, renderers
+from volatility.framework import interfaces, renderers, exceptions
 from volatility.framework.configuration import requirements
 from volatility.framework.layers import intel, resources, linear
 from volatility.framework.renderers import format_hints
@@ -95,9 +95,13 @@ class Strings(interfaces.plugins.PluginInterface):
 
             for process in pslist.PsList.list_processes(self.context, self.config['primary'],
                                                         self.config['nt_symbols']):
+                proc_id = "Unknown"
                 try:
+                    proc_id = process.UniqueProcessId
                     proc_layer_name = process.add_process_layer()
-                except exceptions.InvalidAddressException:
+                except exceptions.InvalidAddressException as excp:
+                    vollog.debug("Process {}: invalid address {} in layer {}".format(
+                        proc_id, excp.invalid_address, excp.layer_name))
                     continue
 
                 proc_layer = self.context.layers[proc_layer_name]

--- a/volatility/framework/plugins/windows/svcscan.py
+++ b/volatility/framework/plugins/windows/svcscan.py
@@ -5,7 +5,7 @@
 import logging
 from typing import List
 
-from volatility.framework import interfaces, renderers, constants, symbols
+from volatility.framework import interfaces, renderers, constants, symbols, exceptions
 from volatility.framework.configuration import requirements
 from volatility.framework.layers import scanners
 from volatility.framework.renderers import format_hints
@@ -131,9 +131,13 @@ class SvcScan(interfaces.plugins.PluginInterface):
                                                  symbol_table = self.config['nt_symbols'],
                                                  filter_func = filter_func):
 
+            proc_id = "Unknown"
             try:
+                proc_id = task.UniqueProcessId
                 proc_layer_name = task.add_process_layer()
-            except exceptions.InvalidAddressException:
+            except exceptions.InvalidAddressException as excp:
+                vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
+                                                                                 excp.layer_name))
                 continue
 
             layer = self.context.layers[proc_layer_name]

--- a/volatility/framework/plugins/windows/vaddump.py
+++ b/volatility/framework/plugins/windows/vaddump.py
@@ -47,9 +47,13 @@ class VadDump(interfaces.plugins.PluginInterface):
         for proc in procs:
             process_name = utility.array_to_string(proc.ImageFileName)
 
+            proc_id = "Unknown"
             try:
+                proc_id = proc.UniqueProcessId
                 proc_layer_name = proc.add_process_layer()
-            except exceptions.InvalidAddressException:
+            except exceptions.InvalidAddressException as excp:
+                vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
+                                                                                 excp.layer_name))
                 continue
 
             proc_layer = self.context.layers[proc_layer_name]

--- a/volatility/framework/plugins/windows/verinfo.py
+++ b/volatility/framework/plugins/windows/verinfo.py
@@ -123,10 +123,14 @@ class VerInfo(interfaces.plugins.PluginInterface):
 
         # now go through the process and dll lists
         for proc in procs:
+            proc_id = "Unknown"
             try:
+                proc_id = proc.UniqueProcessId
                 proc_layer_name = proc.add_process_layer()
-            except exceptions.InvalidAddressException:
-                continue            
+            except exceptions.InvalidAddressException as excp:
+                vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
+                                                                                 excp.layer_name))
+                continue
 
             for entry in proc.load_order_modules():
 
@@ -135,8 +139,6 @@ class VerInfo(interfaces.plugins.PluginInterface):
                 except exceptions.InvalidAddressException:
                     BaseDllName = renderers.UnreadableValue()
 
-                session_layer_name = moddump.ModDump.find_session_layer(self.context, session_layers, mod.DllBase)
-                (major, minor, product, build) = [renderers.NotAvailableValue()] * 4
                 try:
                     (major, minor, product, build) = self.get_version_information(self._context, pe_table_name,
                                                                                   proc_layer_name, entry.DllBase)


### PR DESCRIPTION
There were a number of issues with commit 3df5e995 that was applied in
haste (notably, that exceptions wasn't imported in several cases, which
would break the code if it were ever run).

We now give debugging output when a process can't be constructed and
provide as much available information as possible and/or have merged several try/excepts into a single one (to reduce costs of setting up the try block).

Two unused lines were also removed from verinfo.