### PR TITLE
Is valid exception catching

### DIFF
--- a/volatility/framework/layers/msf.py
+++ b/volatility/framework/layers/msf.py
@@ -199,7 +199,7 @@ class PdbMSFStream(linear.LinearlyMappedLayer):
         return [self._base_layer]
 
     def is_valid(self, offset: int, length: int = 1) -> bool:
-        return self.minimum_address <= offset and offset + length < self.maximum_address
+        return self.context.layers[self._base_layer].is_valid(offset, length)
 
     @property
     def minimum_address(self) -> int:

--- a/volatility/framework/layers/registry.py
+++ b/volatility/framework/layers/registry.py
@@ -227,13 +227,14 @@ class RegistryHive(linear.LinearlyMappedLayer):
 
     def is_valid(self, offset: int, length: int = 1) -> bool:
         """Returns a boolean based on whether the offset is valid or not."""
-        # TODO: Fix me
-
-        # Pass this to the lower layers for now
-        return all([
-            self.context.layers[layer].is_valid(offset, length)
-            for (_, offset, length, layer) in self.mapping(offset, length)
-        ])
+        try:
+            # Pass this to the lower layers for now
+            return all([
+                self.context.layers[layer].is_valid(offset, length)
+                for (_, offset, length, layer) in self.mapping(offset, length)
+            ])
+        except exceptions.InvalidAddressException:
+            return False
 
     @property
     def minimum_address(self) -> int:

--- a/volatility/framework/layers/registry.py
+++ b/volatility/framework/layers/registry.py
@@ -228,7 +228,12 @@ class RegistryHive(linear.LinearlyMappedLayer):
     def is_valid(self, offset: int, length: int = 1) -> bool:
         """Returns a boolean based on whether the offset is valid or not."""
         # TODO: Fix me
-        return True
+
+        # Pass this to the lower layers for now
+        return all([
+            self.context.layers[layer].is_valid(offset, length)
+            for (_, offset, length, layer) in self.mapping(offset, length)
+        ])
 
     @property
     def minimum_address(self) -> int:

--- a/volatility/framework/objects/__init__.py
+++ b/volatility/framework/objects/__init__.py
@@ -305,7 +305,7 @@ class Pointer(Integer):
         """Determines whether the address of this pointer can be read from
         memory."""
         layer_name = layer_name or self.vol.layer_name
-        return self._context.layers[layer_name].is_valid(self)
+        return self._context.layers[layer_name].is_valid(self, self.vol.size)
 
     def __getattr__(self, attr: str) -> Any:
         """Convenience function to access unknown attributes by getting them

--- a/volatility/framework/plugins/mac/bash.py
+++ b/volatility/framework/plugins/mac/bash.py
@@ -90,18 +90,18 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
                                    ("Command", str)],
                                   self._generator(
                                       tasks.Tasks.list_tasks(self.context,
-                                                               self.config['primary'],
-                                                               self.config['darwin'],
-                                                               filter_func = filter_func)))
+                                                             self.config['primary'],
+                                                             self.config['darwin'],
+                                                             filter_func = filter_func)))
 
     def generate_timeline(self):
         filter_func = tasks.Tasks.create_pid_filter([self.config.get('pid', None)])
 
         for row in self._generator(
                 tasks.Tasks.list_tasks(self.context,
-                                         self.config['primary'],
-                                         self.config['darwin'],
-                                         filter_func = filter_func)):
+                                       self.config['primary'],
+                                       self.config['darwin'],
+                                       filter_func = filter_func)):
             _depth, row_data = row
             description = "{} ({}): \"{}\"".format(row_data[0], row_data[1], row_data[3])
             yield (description, timeliner.TimeLinerType.CREATED, row_data[2])

--- a/volatility/framework/plugins/mac/psaux.py
+++ b/volatility/framework/plugins/mac/psaux.py
@@ -91,6 +91,6 @@ class Psaux(plugins.PluginInterface):
         return renderers.TreeGrid([("PID", int), ("Process", str), ("Argc", int), ("Arguments", str)],
                                   self._generator(
                                       tasks.Tasks.list_tasks(self.context,
-                                                               self.config['primary'],
-                                                               self.config['darwin'],
-                                                               filter_func = filter_func)))
+                                                             self.config['primary'],
+                                                             self.config['darwin'],
+                                                             filter_func = filter_func)))

--- a/volatility/framework/plugins/mac/pslist.py
+++ b/volatility/framework/plugins/mac/pslist.py
@@ -87,7 +87,7 @@ class PsList(interfaces.plugins.PluginInterface):
             else:
                 seen[proc.vol.offset] = 1
 
-            if not filter_func(proc) and kernel_as.is_valid(proc.vol.offset):
+            if not filter_func(proc) and kernel_as.is_valid(proc.vol.offset, proc.vol.size):
                 yield proc
 
             try:

--- a/volatility/framework/plugins/mac/tasks.py
+++ b/volatility/framework/plugins/mac/tasks.py
@@ -50,7 +50,7 @@ class Tasks(pslist.PsList):
 
             proc = task.bsd_info.dereference().cast("proc")
 
-            if not context.layers[layer_name].is_valid(proc.vol.offset):
+            if not context.layers[layer_name].is_valid(proc.vol.offset, proc.vol.size):
                 break
 
             if not filter_func(proc):

--- a/volatility/framework/plugins/windows/callbacks.py
+++ b/volatility/framework/plugins/windows/callbacks.py
@@ -185,9 +185,7 @@ class Callbacks(interfaces.plugins.PluginInterface):
                                          layer_name = layer_name)
 
         for callback in callback_record.Entry:
-            try:
-                context.layers[layer_name].is_valid(callback.CallbackRoutine)
-            except exceptions.InvalidAddressException:
+            if not context.layers[layer_name].is_valid(callback.CallbackRoutine, 64):
                 continue
 
             try:
@@ -228,9 +226,7 @@ class Callbacks(interfaces.plugins.PluginInterface):
 
         for callback in callback_record.Entry:
 
-            try:
-                context.layers[layer_name].is_valid(callback.CallbackRoutine)
-            except exceptions.InvalidAddressException:
+            if not context.layers[layer_name].is_valid(callback.CallbackRoutine, 64):
                 continue
 
             try:

--- a/volatility/framework/plugins/windows/handles.py
+++ b/volatility/framework/plugins/windows/handles.py
@@ -298,7 +298,6 @@ class Handles(interfaces.plugins.PluginInterface):
 
             for entry in self.handles(object_table):
                 try:
-                    self.context.layers[self.config["primary"]].is_valid(entry.vol.offset)
                     obj_type = entry.get_object_type(type_map, cookie)
                     if obj_type is None:
                         continue

--- a/volatility/framework/plugins/windows/malfind.py
+++ b/volatility/framework/plugins/windows/malfind.py
@@ -55,7 +55,7 @@ class Malfind(interfaces.plugins.PluginInterface):
 
         while offset < vad_length:
             next_addr = vad.get_start() + offset
-            if proc_layer.is_valid(next_addr) and proc_layer.read(next_addr, CHUNK_SIZE) != all_zero_page:
+            if proc_layer.is_valid(next_addr, CHUNK_SIZE) and proc_layer.read(next_addr, CHUNK_SIZE) != all_zero_page:
                 return False
             offset += CHUNK_SIZE
 

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -841,15 +841,14 @@ class LIST_ENTRY(objects.StructType, collections.abc.Iterable):
         direction = 'Blink'
         if forward:
             direction = 'Flink'
-       
+
         trans_layer = self._context.layers[layer]
 
         try:
-            trans_layer.is_valid(self.vol.offset)
             link = getattr(self, direction).dereference()
         except exceptions.InvalidAddressException:
             return
-        
+
         if not sentinel:
             yield self._context.object(symbol_type,
                                        layer,
@@ -860,10 +859,8 @@ class LIST_ENTRY(objects.StructType, collections.abc.Iterable):
         while link.vol.offset not in seen:
             obj_offset = link.vol.offset - relative_offset
 
-            try:
-                trans_layer.is_valid(obj_offset)
-            except exceptions.InvalidAddressException:
-                return 
+            if not trans_layer.is_valid(obj_offset):
+                return
 
             obj = self._context.object(symbol_type,
                                        layer,


### PR DESCRIPTION
This makes the layer `is_valid` method a little more robust.

Coverts all calls to is_valid to boolean checks (any exceptions thrown now should likely still be thrown and/or should be caught by the is_valid method).

Adds some lengths in where the liable length is known.

Removes checks that are already wrapped in a try/except call (there's no point doing the check if we're still going to catch an exception for something else).

This feels like it could potentially trip something up, so not putting a merge deadline on this.