### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Context**
+Volatility Version:  
+Operating System:  
+Python Version:  
+Suspected Operating System:  
+Command:  
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Use command '...'
+2. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional information**
+Add any other information about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for Volatility
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional information**
+Add any other information or screenshots about the feature request here.


### PR DESCRIPTION
This will add issue templates to help try and standardise bug reports. These templates are modified versions of the default GitHub ones to include the information mentioned in [README](README.md), but they should serve the purpose. Of course more than open to any suggestions.

With these files in the respository, when the `New Issue` button is pressed, the below menu will be displayed, allowing users to use a template or just create a blank issue like they can now.
![image](https://user-images.githubusercontent.com/3729048/68129138-f49cff00-ff10-11e9-8dce-17c8e2928598.png)

# Bug report:
**Describe the bug**
A clear and concise description of what the bug is.

**Context**
Volatility Version:  
Operating System:  
Python Version:  
Suspected Operating System:  
Command:  

**To Reproduce**
Steps to reproduce the behavior:

1. Use command '...'
2. See error

**Expected behavior**
A clear and concise description of what you expected to happen.

**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional information**
Add any other information about the problem here.

# Feature request:
**Is your feature request related to a problem? Please describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you'd like**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional information**
Add any other information or screenshots about the feature request here.