### PR TITLE
Fix on 'end_bit' computation

### DIFF
--- a/volatility/framework/symbols/intermed.py
+++ b/volatility/framework/symbols/intermed.py
@@ -369,7 +369,7 @@ class Version1Format(ISFormatTable):
             elif type_name == 'enum':
                 update = self._lookup_enum(dictionary['name'])
             elif type_name == 'bitfield':
-                update = {'start_bit': dictionary['bit_position'], 'end_bit': dictionary['bit_length']}
+                update = {'start_bit': dictionary['bit_position'], 'end_bit': dictionary['bit_position'] + dictionary['bit_length']}
                 update['base_type'] = self._interdict_to_template(dictionary['type'])
             # We do *not* call native_template.clone(), since it slows everything down a lot
             # We require that the native.get_type method always returns a newly constructed python object


### PR DESCRIPTION
Hi, I was looking at the code for managing symbols and found this line:
https://github.com/volatilityfoundation/volatility3/blob/master/volatility/framework/symbols/intermed.py#L372

I think there might be a semantic inconsistency there: the ‘end_bit’ keyword is populated with the bit_length of the field, instead of the end_bit.

I have looked at the symbol json file, and it seems that bitfields contain ‘start_bit’ and ‘bit_length’. On the contrary, volatility2 vtypes seem to represent bitfields with their ‘start_bit’ and ‘end_bit’. (E.g.: https://github.com/volatilityfoundation/volatility/blob/aa6b960c1077e447bda9d64df507ec02f8fcc958/volatility/plugins/overlays/windows/win2003_sp0_x86_vtypes.py#L1814)

Given that the BitField class on framework/objects/_ _ init _ .py stores start_bit and end_bit, I’d lean towards updating  https://github.com/volatilityfoundation/volatility3/blob/master/volatility/framework/symbols/intermed.py#L372
That would be consistent with volatility2 and how the BitField class is defined in volatility3.

Thanks,