### PR TITLE
CLI: Don't output the title for structured output.

### DIFF
--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -77,7 +77,6 @@ class CommandLine(interfaces.plugins.FileConsumerInterface):
     def run(self):
         """Executes the command line module, taking the system arguments,
         determining the plugin to run and then running it."""
-        sys.stdout.write("Volatility 3 Framework {}\n".format(constants.PACKAGE_VERSION))
 
         volatility.framework.require_interface_version(1, 0, 0)
 
@@ -144,6 +143,12 @@ class CommandLine(interfaces.plugins.FileConsumerInterface):
         # processed the plugin choice or had the plugin subparser added.
         known_args = [arg for arg in sys.argv if arg != '--help' and arg != '-h']
         partial_args, _ = parser.parse_known_args(known_args)
+
+        banner_output = sys.stdout
+        if renderers[partial_args.renderer].structured_output:
+            banner_output = sys.stderr
+        banner_output.write("Volatility 3 Framework {}\n".format(constants.PACKAGE_VERSION))
+
         if partial_args.plugin_dirs:
             volatility.plugins.__path__ = [os.path.abspath(p)
                                            for p in partial_args.plugin_dirs.split(";")] + constants.PLUGINS_PATH

--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -107,6 +107,7 @@ def display_disassembly(disasm: interfaces.renderers.Disassembly) -> str:
 class CLIRenderer(interfaces.renderers.Renderer):
     """Class to add specific requirements for CLI renderers."""
     name = "unnamed"
+    structured_output = False
 
 
 class QuickTextRenderer(CLIRenderer):
@@ -176,6 +177,7 @@ class CSVRenderer(CLIRenderer):
     }
 
     name = "csv"
+    structured_output = True
 
     def get_render_options(self):
         pass
@@ -192,7 +194,7 @@ class CSVRenderer(CLIRenderer):
         for column in grid.columns:
             # Ignore the type because namedtuples don't realize they have accessible attributes
             line.append("{}".format('"' + column.name + '"'))
-        outfd.write("\n{}".format(",".join(line)))
+        outfd.write("{}".format(",".join(line)))
 
         def visitor(node, accumulator):
             accumulator.write("\n")
@@ -218,6 +220,7 @@ class PrettyTextRenderer(CLIRenderer):
     _type_renderers = QuickTextRenderer._type_renderers
 
     name = "pretty"
+    structured_output = True
 
     def get_render_options(self):
         pass

--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -236,7 +236,7 @@ class PrettyTextRenderer(CLIRenderer):
         # TODO: Improve text output
         outfd = sys.stdout
 
-        outfd.write("Formatting...\r")
+        sys.stderr.write("Formatting...\n")
 
         display_alignment = ">"
         column_separator = " | "

--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -220,7 +220,6 @@ class PrettyTextRenderer(CLIRenderer):
     _type_renderers = QuickTextRenderer._type_renderers
 
     name = "pretty"
-    structured_output = True
 
     def get_render_options(self):
         pass


### PR DESCRIPTION
This ensures that renderers like CSV and the upcoming JSON renderer don't output the title line in stdout, but that all other plugins do output it as a normal part of the output.