### PR TITLE
Improve stacking

### DIFF
--- a/volatility/framework/automagic/linux.py
+++ b/volatility/framework/automagic/linux.py
@@ -31,7 +31,7 @@ class LinuxSymbolFinder(symbol_finder.SymbolFinder):
 
 
 class LintelStacker(interfaces.automagic.StackerLayerInterface):
-    stack_order = 12
+    stack_order = 45
 
     @classmethod
     def stack(cls,

--- a/volatility/framework/automagic/mac.py
+++ b/volatility/framework/automagic/mac.py
@@ -31,7 +31,7 @@ class MacSymbolFinder(symbol_finder.SymbolFinder):
 
 
 class MacintelStacker(interfaces.automagic.StackerLayerInterface):
-    stack_order = 12
+    stack_order = 45
 
     @classmethod
     def stack(cls,

--- a/volatility/framework/automagic/windows.py
+++ b/volatility/framework/automagic/windows.py
@@ -287,6 +287,7 @@ class WintelHelper(interfaces.automagic.AutomagicInterface):
 
 
 class WintelStacker(interfaces.automagic.StackerLayerInterface):
+    stack_order = 40
 
     @classmethod
     def stack(cls,

--- a/volatility/framework/layers/crash.py
+++ b/volatility/framework/layers/crash.py
@@ -22,7 +22,6 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
     """
 
     provides = {"type": "physical"}
-    priority = 23
 
     SIGNATURE = 0x45474150
     VALIDDUMP = 0x504d5544

--- a/volatility/framework/layers/intel.py
+++ b/volatility/framework/layers/intel.py
@@ -20,7 +20,6 @@ vollog = logging.getLogger(__name__)
 class Intel(linear.LinearlyMappedLayer):
     """Translation Layer for the Intel IA32 memory mapping."""
 
-    priority = 40
     _entry_format = "<I"
     _page_size_in_bits = 12
     _bits_per_register = 32
@@ -233,7 +232,6 @@ class IntelPAE(Intel):
     """Class for handling Physical Address Extensions for Intel
     architectures."""
 
-    priority = 35
     _entry_format = "<Q"
     _bits_per_register = 32
     _maxphyaddr = 40
@@ -245,7 +243,6 @@ class Intel32e(Intel):
     """Class for handling 64-bit (32-bit extensions) for Intel
     architectures."""
 
-    priority = 30
     _direct_metadata = collections.ChainMap({'architecture': 'Intel64'}, Intel._direct_metadata)
     _entry_format = "<Q"
     _bits_per_register = 64

--- a/volatility/framework/layers/lime.py
+++ b/volatility/framework/layers/lime.py
@@ -20,8 +20,6 @@ class LimeLayer(segmented.SegmentedLayer):
     are large holes in the physical layer
     """
 
-    priority = 21
-
     MAGIC = 0x4c694d45
     VERSION = 1
 

--- a/volatility/framework/layers/physical.py
+++ b/volatility/framework/layers/physical.py
@@ -13,8 +13,6 @@ class BufferDataLayer(interfaces.layers.DataLayerInterface):
     """A DataLayer class backed by a buffer in memory, designed for testing and
     swift data access."""
 
-    priority = 10
-
     def __init__(self,
                  context: interfaces.context.ContextInterface,
                  config_path: str,
@@ -74,8 +72,6 @@ class DummyLock:
 
 class FileLayer(interfaces.layers.DataLayerInterface):
     """a DataLayer backed by a file on the filesystem."""
-
-    priority = 20
 
     def __init__(self,
                  context: interfaces.context.ContextInterface,

--- a/volatility/framework/layers/vmware.py
+++ b/volatility/framework/layers/vmware.py
@@ -16,8 +16,6 @@ class VmwareFormatException(exceptions.LayerException):
 
 
 class VmwareLayer(segmented.SegmentedLayer):
-    priority = 22
-
     header_structure = "<4sII"
     group_structure = "64sQQ"
 


### PR DESCRIPTION
Rejig the ordering for stackers.  Ensures the (slow) Wintel/Linux/Mac stackers aren't attempted until simpler (header check) lower layers are tested.

This is pretty small, but I figured I'd make a pull request just in case anything crops up...