### PR TITLE
Add in JSON renderer

### DIFF
--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -296,6 +296,7 @@ class JsonRenderer(CLIRenderer):
     }
 
     name = 'JSON'
+    structured_output = True
 
     def get_render_options(self) -> List[RenderOption]:
         pass

--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -301,6 +301,10 @@ class JsonRenderer(CLIRenderer):
     def get_render_options(self) -> List[RenderOption]:
         pass
 
+    def output_result(self, outfd, result):
+        """Outputs the JSON data to a file in a particular format"""
+        outfd.write(json.dumps(result, indent = 2, sort_keys = True))
+
     def render(self, grid: interfaces.renderers.TreeGrid):
         outfd = sys.stdout
 
@@ -334,4 +338,14 @@ class JsonRenderer(CLIRenderer):
         else:
             grid.visit(node = None, function = visitor, initial_accumulator = final_output)
 
-        outfd.write(json.dumps(final_output[1], indent = 2, sort_keys = True))
+        self.output_result(outfd, final_output[1])
+
+
+class JsonLinesRenderer(JsonRenderer):
+    name = 'JSONL'
+
+    def output_result(self, outfd, result):
+        """Outputs the JSON results as JSON lines"""
+        for line in result:
+            outfd.write(json.dumps(line, sort_keys = True))
+            outfd.write("\n")

--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -284,15 +284,10 @@ class PrettyTextRenderer(CLIRenderer):
 
 class JsonRenderer(CLIRenderer):
     _type_renderers = {
-        format_hints.HexBytes:
-        quoted_optional(hex_bytes_as_text),
-        interfaces.renderers.Disassembly:
-        quoted_optional(display_disassembly),
-        datetime.datetime:
-        lambda x: x.strftime("%Y-%m-%d %H:%M:%S.%f %Z")
-        if not isinstance(x, interfaces.renderers.BaseAbsentValue) else None,
-        'default':
-        lambda x: x
+        format_hints.HexBytes: quoted_optional(hex_bytes_as_text),
+        interfaces.renderers.Disassembly: quoted_optional(display_disassembly),
+        datetime.datetime: lambda x: x.isoformat() if not isinstance(x, interfaces.renderers.BaseAbsentValue) else None,
+        'default': lambda x: x
     }
 
     name = 'JSON'


### PR DESCRIPTION
This renderer will output a formatted/pretty-printed JSON output file.  It contains a nested tree structure (in particular for tree output) and makes use of a special `__children` field to do so.  We don't currently have strict checking on column names not starting with `__` but it seems like a remote possibility so for now I'm not including any special casing for it.

I'll probably merge this on the 7th unless someone shouts...