### PR TITLE
refs #139 use _EPROCESS.ControlFlowGuardEnabled to distinguish betwee…

### DIFF
--- a/volatility/framework/plugins/windows/svcscan.py
+++ b/volatility/framework/plugins/windows/svcscan.py
@@ -35,7 +35,8 @@ class SvcScan(interfaces.plugins.PluginInterface):
     is_win10_up_to_15063 = poolscanner.os_distinguisher(version_check = lambda x: (10, 0) <= x < (10, 0, 16299),
                                                         fallback_checks = [("ObHeaderCookie", None, True),
                                                                            ("_HANDLE_TABLE", "HandleCount", False),
-                                                                           ("ObHeaderCookie", None, True)])
+                                                                           ("ObHeaderCookie", None, True),
+                                                                           ("_EPROCESS", "ControlFlowGuardEnabled", True)])
 
     is_win10_16299_or_later = poolscanner.os_distinguisher(version_check = lambda x: x >= (10, 0, 16299),
                                                            fallback_checks = [("ObHeaderCookie", None, True),


### PR DESCRIPTION
…n windows 10 <= 15063 versus >= 16299

To determine this, I wrote a little tool that compares the `_EPROCESS` structure between 15063 and 16299. It provided a couple of options. I chose one (`ControlFlowGuardEnabled`) and wrote a similar tool to scan all json files that were Windows 10. Of those, I gathered a unique set of versions that contained `ControlFlowGuardEnabled`:

```
Versions with member:
(10, 0, 14300)
(10, 0, 15002)
(10, 0, 10586)
(10, 0, 15048)
(10, 0, 15063)
(10, 0, 15058)
(10, 0, 10240)
(10, 0, 14393)
(10, 0, 14986)
```

So, it looks like the latest version that included the member was 15063. 