### PR TITLE
Objects: Simplify get_symbol_table to get_symbol_table_name.

### DIFF
--- a/volatility/framework/interfaces/objects.py
+++ b/volatility/framework/interfaces/objects.py
@@ -128,17 +128,19 @@ class ObjectInterface(metaclass = ABCMeta):
         """Writes the new value into the format at the offset the object
         currently resides at."""
 
-    def get_symbol_table(self) -> 'interfaces.symbols.SymbolTableInterface':
-        """Returns the symbol table for this particular object.
+    def get_symbol_table_name(self) -> str:
+        """Returns the symbol table name for this particular object.
 
-        Returns none if the symbol table cannot be identified.
+        Raises:
+            ValueError: If the object's symbol does not contain an explicit table
+            KeyError: If the table_name is not valid within the object's context
         """
         if constants.BANG not in self.vol.type_name:
             raise ValueError("Unable to determine table for symbol: {}".format(self.vol.type_name))
         table_name = self.vol.type_name[:self.vol.type_name.index(constants.BANG)]
         if table_name not in self._context.symbol_space:
             raise KeyError("Symbol table not found in context's symbol_space for symbol: {}".format(self.vol.type_name))
-        return self._context.symbol_space[table_name]
+        return table_name
 
     def cast(self, new_type_name: str, **additional) -> 'ObjectInterface':
         """Returns a new object at the offset and from the layer that the

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -498,7 +498,7 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
         try:
             peb = self.get_peb()
             for entry in peb.Ldr.InLoadOrderModuleList.to_list(
-                    "{}{}_LDR_DATA_TABLE_ENTRY".format(self.get_symbol_table().name, constants.BANG),
+                    "{}{}_LDR_DATA_TABLE_ENTRY".format(self.get_symbol_table_name(), constants.BANG),
                     "InLoadOrderLinks"):
                 yield entry
         except exceptions.InvalidAddressException:
@@ -510,7 +510,7 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
         try:
             peb = self.get_peb()
             for entry in peb.Ldr.InInitializationOrderModuleList.to_list(
-                    "{}{}_LDR_DATA_TABLE_ENTRY".format(self.get_symbol_table().name, constants.BANG),
+                    "{}{}_LDR_DATA_TABLE_ENTRY".format(self.get_symbol_table_name(), constants.BANG),
                     "InInitializationOrderLinks"):
                 yield entry
         except exceptions.InvalidAddressException:
@@ -522,7 +522,7 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
         try:
             peb = self.get_peb()
             for entry in peb.Ldr.InMemoryOrderModuleList.to_list(
-                    "{}{}_LDR_DATA_TABLE_ENTRY".format(self.get_symbol_table().name, constants.BANG),
+                    "{}{}_LDR_DATA_TABLE_ENTRY".format(self.get_symbol_table_name(), constants.BANG),
                     "InMemoryOrderLinks"):
                 yield entry
         except exceptions.InvalidAddressException:
@@ -546,7 +546,7 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
                 if self.Session == 0:
                     return renderers.NotApplicableValue()
 
-                symbol_table_name = self.get_symbol_table().name
+                symbol_table_name = self.get_symbol_table_name()
                 kvo = self._context.layers[self.vol.native_layer_name].config['kernel_virtual_offset']
                 ntkrnlmp = self._context.module(symbol_table_name,
                                                 layer_name = self.vol.native_layer_name,

--- a/volatility/framework/symbols/windows/extensions/kdbg.py
+++ b/volatility/framework/symbols/windows/extensions/kdbg.py
@@ -12,7 +12,7 @@ class KDDEBUGGER_DATA64(objects.StructType):
         """Returns the NT build lab string from the KDBG."""
 
         layer_name = self.vol.layer_name
-        symbol_table_name = self.get_symbol_table().name
+        symbol_table_name = self.get_symbol_table_name()
 
         return self._context.object(symbol_table_name + constants.BANG + "string",
                                     layer_name = layer_name,
@@ -24,7 +24,7 @@ class KDDEBUGGER_DATA64(objects.StructType):
         """Returns the CSDVersion as an integer (i.e. Service Pack number)"""
 
         layer_name = self.vol.layer_name
-        symbol_table_name = self.get_symbol_table().name
+        symbol_table_name = self.get_symbol_table_name()
 
         csdresult = self._context.object(symbol_table_name + constants.BANG + "unsigned long",
                                          layer_name = layer_name,

--- a/volatility/framework/symbols/windows/extensions/pe.py
+++ b/volatility/framework/symbols/windows/extensions/pe.py
@@ -23,7 +23,7 @@ class IMAGE_DOS_HEADER(objects.StructType):
             raise ValueError("e_magic {0:04X} is not a valid DOS signature.".format(self.e_magic))
 
         layer_name = self.vol.layer_name
-        symbol_table_name = self.get_symbol_table().name
+        symbol_table_name = self.get_symbol_table_name()
 
         nt_header = self._context.object(symbol_table_name + constants.BANG + "_IMAGE_NT_HEADERS",
                                          layer_name = layer_name,
@@ -89,7 +89,7 @@ class IMAGE_DOS_HEADER(objects.StructType):
         nt_header = self.get_nt_header()
 
         layer_name = self.vol.layer_name
-        symbol_table_name = self.get_symbol_table().name
+        symbol_table_name = self.get_symbol_table_name()
 
         section_alignment = nt_header.OptionalHeader.SectionAlignment
 
@@ -154,7 +154,7 @@ class IMAGE_NT_HEADERS(objects.StructType):
             <_IMAGE_SECTION_HEADER> objects
         """
         layer_name = self.vol.layer_name
-        symbol_table_name = self.get_symbol_table().name
+        symbol_table_name = self.get_symbol_table_name()
 
         sect_header_size = self._context.symbol_space.get_type(symbol_table_name + constants.BANG +
                                                                "_IMAGE_SECTION_HEADER").size


### PR DESCRIPTION
The only place we were using this was to get the table to look up its name and then use it to construct a new object (based on the previous object's table and a new type name) at a different offset.  This would cause us to do an unnecessary table lookup each time, when what we really wanted (the table name) had already been determined.  This simplifies the API a little to just return the symbol's name.

Options for the future include:
* Changing the function to construct a new object based on the table of the previous
* Removing this as an unnecessary extravagence
* Adding additional convenience functions to further split the `.vol.type_name` down
* Breaking this up at object create to ensure `type_name` is always stored separately to `symbol_table_name`, but this would be reasonably disturbing to the codebase (a lot of changes everywhere, which would need to be made carefully)

For now, this seems like a quick solution to the issue.