### PR TITLE
Quickscanning

### DIFF
--- a/volatility/framework/plugins/windows/modscan.py
+++ b/volatility/framework/plugins/windows/modscan.py
@@ -20,13 +20,18 @@ class ModScan(interfaces.plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.BooleanRequirement(name = 'quick',
+                                            description = "Scan just allocated memory",
+                                            default = False,
+                                            optional = True),
         ]
 
     @classmethod
     def scan_modules(cls,
                      context: interfaces.context.ContextInterface,
                      layer_name: str,
-                     symbol_table: str) -> \
+                     symbol_table: str,
+                     quick: bool = False) -> \
             Iterable[interfaces.objects.ObjectInterface]:
         """Scans for modules using the poolscanner module and constraints.
 
@@ -34,6 +39,7 @@ class ModScan(interfaces.plugins.PluginInterface):
             context: The context to retrieve required elements (layers, symbol tables) from
             layer_name: The name of the layer on which to operate
             symbol_table: The name of the table containing the kernel symbols
+            quick: Scan only memory that windows has allocated
 
         Returns:
             A list of Driver objects as found from the `layer_name` layer based on Driver pool signatures
@@ -41,13 +47,20 @@ class ModScan(interfaces.plugins.PluginInterface):
 
         constraints = poolscanner.PoolScanner.builtin_constraints(symbol_table, [b'MmLd'])
 
-        for result in poolscanner.PoolScanner.generate_pool_scan(context, layer_name, symbol_table, constraints):
+        for result in poolscanner.PoolScanner.generate_pool_scan(context,
+                                                                 layer_name,
+                                                                 symbol_table,
+                                                                 constraints,
+                                                                 quick = quick):
 
             _constraint, mem_object, _header = result
             yield mem_object
 
     def _generator(self):
-        for mod in self.scan_modules(self.context, self.config['primary'], self.config['nt_symbols']):
+        for mod in self.scan_modules(self.context,
+                                     self.config['primary'],
+                                     self.config['nt_symbols'],
+                                     quick = self.config['quick']):
 
             try:
                 BaseDllName = mod.BaseDllName.get_string()

--- a/volatility/framework/plugins/windows/poolscanner.py
+++ b/volatility/framework/plugins/windows/poolscanner.py
@@ -367,10 +367,11 @@ class PoolScanner(plugins.PluginInterface):
 
         sections = None
         if quick:
+            vollog.debug("Locating windows allocated sections to scan")
             scan_module = context.module(module_name = symbol_table,
                                          layer_name = scan_layer,
                                          offset = context.layers[scan_layer].config['kernel_virtual_offset'])
-            sections = virtmap.VirtMap.scannable_sections(scan_module)
+            sections = list(virtmap.VirtMap.scannable_sections(scan_module))
 
         is_windows_10 = cls.is_windows_10(context, symbol_table)
         if not is_windows_10:

--- a/volatility/framework/plugins/windows/poolscanner.py
+++ b/volatility/framework/plugins/windows/poolscanner.py
@@ -13,7 +13,7 @@ from volatility.framework.layers import scanners
 from volatility.framework.renderers import format_hints
 from volatility.framework.symbols import intermed
 from volatility.framework.symbols.windows import extensions
-from volatility.plugins.windows import handles
+from volatility.plugins.windows import handles, virtmap
 
 vollog = logging.getLogger(__name__)
 
@@ -189,7 +189,12 @@ class PoolScanner(plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.BooleanRequirement(name = 'quick',
+                                            description = "Scan just allocated memory",
+                                            default = False,
+                                            optional = True),
             requirements.PluginRequirement(name = 'handles', plugin = handles.Handles, version = (1, 0, 0)),
+            requirements.PluginRequirement(name = 'virtmap', plugin = virtmap.VirtMap, version = (1, 0, 0)),
         ]
 
     is_windows_10 = os_distinguisher(version_check = lambda x: x >= (10, 0),
@@ -206,8 +211,11 @@ class PoolScanner(plugins.PluginInterface):
         symbol_table = self.config["nt_symbols"]
         constraints = self.builtin_constraints(symbol_table)
 
-        for constraint, mem_object, header in self.generate_pool_scan(self.context, self.config["primary"],
-                                                                      symbol_table, constraints):
+        for constraint, mem_object, header in self.generate_pool_scan(self.context,
+                                                                      self.config["primary"],
+                                                                      symbol_table,
+                                                                      constraints,
+                                                                      quick = self.config["quick"]):
             # generate some type-specific info for sanity checking
             if constraint.object_type == "Process":
                 name = mem_object.ImageFileName.cast("string",
@@ -329,7 +337,8 @@ class PoolScanner(plugins.PluginInterface):
                            context: interfaces.context.ContextInterface,
                            layer_name: str,
                            symbol_table: str,
-                           constraints: List[PoolConstraint]) \
+                           constraints: List[PoolConstraint],
+                           quick: bool = False) \
             -> Generator[Tuple[
                              PoolConstraint, interfaces.objects.ObjectInterface, interfaces.objects.ObjectInterface], None, None]:
         """
@@ -339,6 +348,7 @@ class PoolScanner(plugins.PluginInterface):
             layer_name: The name of the layer on which to operate
             symbol_table: The name of the table containing the kernel symbols
             constraints: List of pool constraints used to limit the scan results
+            quick: Only scans the memory windows has allocated mapped as in-use 
 
         Returns:
             Iterable of tuples, containing the constraint that matched, the object from memory, the object header used to determine the object
@@ -355,11 +365,23 @@ class PoolScanner(plugins.PluginInterface):
         # start off with the primary virtual layer
         scan_layer = layer_name
 
-        # switch to a non-virtual layer if necessary
+        sections = None
+        if quick:
+            scan_module = context.module(module_name = symbol_table,
+                                         layer_name = scan_layer,
+                                         offset = context.layers[scan_layer].config['kernel_virtual_offset'])
+            sections = virtmap.VirtMap.scannable_sections(scan_module)
+
+        is_windows_10 = cls.is_windows_10(context, symbol_table)
         if not is_windows_10:
             scan_layer = context.layers[scan_layer].config['memory_layer']
 
-        for constraint, header in cls.pool_scan(context, scan_layer, symbol_table, constraints, alignment = 8):
+        for constraint, header in cls.pool_scan(context,
+                                                scan_layer,
+                                                symbol_table,
+                                                constraints,
+                                                alignment = 8,
+                                                sections = sections):
 
             mem_object = header.get_object(type_name = constraint.type_name,
                                            use_top_down = is_windows_8_or_later,
@@ -388,7 +410,8 @@ class PoolScanner(plugins.PluginInterface):
                   symbol_table: str,
                   pool_constraints: List[PoolConstraint],
                   alignment: int = 8,
-                  progress_callback: Optional[constants.ProgressCallback] = None) \
+                  progress_callback: Optional[constants.ProgressCallback] = None,
+                  sections: List = None) \
             -> Generator[Tuple[PoolConstraint, interfaces.objects.ObjectInterface], None, None]:
         """Returns the _POOL_HEADER object (based on the symbol_table template)
         after scanning through layer_name returning all headers that match any
@@ -418,7 +441,7 @@ class PoolScanner(plugins.PluginInterface):
         # Run the scan locating the offsets of a particular tag
         layer = context.layers[layer_name]
         scanner = PoolHeaderScanner(module, constraint_lookup, alignment)
-        yield from layer.scan(context, scanner, progress_callback)
+        yield from layer.scan(context, scanner, progress_callback, sections = sections)
 
     @classmethod
     def _get_pool_header_module(cls, context, layer_name, symbol_table):

--- a/volatility/framework/plugins/windows/poolscanner.py
+++ b/volatility/framework/plugins/windows/poolscanner.py
@@ -4,7 +4,7 @@
 
 import enum
 import logging
-from typing import Dict, Generator, List, Optional, Tuple, Callable
+from typing import Dict, Generator, List, Optional, Tuple, Callable, Iterable
 
 from volatility.framework import constants, interfaces, renderers, exceptions, symbols
 from volatility.framework.configuration import requirements
@@ -411,7 +411,7 @@ class PoolScanner(plugins.PluginInterface):
                   pool_constraints: List[PoolConstraint],
                   alignment: int = 8,
                   progress_callback: Optional[constants.ProgressCallback] = None,
-                  sections: List = None) \
+                  sections: Iterable[Tuple[int, int]] = None) \
             -> Generator[Tuple[PoolConstraint, interfaces.objects.ObjectInterface], None, None]:
         """Returns the _POOL_HEADER object (based on the symbol_table template)
         after scanning through layer_name returning all headers that match any
@@ -425,6 +425,7 @@ class PoolScanner(plugins.PluginInterface):
             pool_constraints: List of pool constraints used to limit the scan results
             alignment: An optional value that all pool headers will be aligned to
             progress_callback: An optional function to provide progress feedback whilst scanning
+            sections: Specific memory sections to scan through
 
         Returns:
             An Iterable of pool constraints and the pool headers associated with them

--- a/volatility/framework/plugins/windows/registry/hivescan.py
+++ b/volatility/framework/plugins/windows/registry/hivescan.py
@@ -22,13 +22,18 @@ class HiveScan(interfaces.plugins.PluginInterface):
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
             requirements.PluginRequirement(name = 'poolscanner', plugin = poolscanner.PoolScanner, version = (1, 0, 0)),
+            requirements.BooleanRequirement(name = 'quick',
+                                            description = "Scan just allocated memory",
+                                            default = False,
+                                            optional = True),
         ]
 
     @classmethod
     def scan_hives(cls,
                    context: interfaces.context.ContextInterface,
                    layer_name: str,
-                   symbol_table: str) -> \
+                   symbol_table: str,
+                   quick: bool = False) -> \
             Iterable[interfaces.objects.ObjectInterface]:
         """Scans for hives using the poolscanner module and constraints.
 
@@ -36,6 +41,7 @@ class HiveScan(interfaces.plugins.PluginInterface):
             context: The context to retrieve required elements (layers, symbol tables) from
             layer_name: The name of the layer on which to operate
             symbol_table: The name of the table containing the kernel symbols
+            quick: Scan only memory that windows has allocated
 
         Returns:
             A list of Hive objects as found from the `layer_name` layer based on Hive pool signatures
@@ -43,13 +49,20 @@ class HiveScan(interfaces.plugins.PluginInterface):
 
         constraints = poolscanner.PoolScanner.builtin_constraints(symbol_table, [b'CM10'])
 
-        for result in poolscanner.PoolScanner.generate_pool_scan(context, layer_name, symbol_table, constraints):
+        for result in poolscanner.PoolScanner.generate_pool_scan(context,
+                                                                 layer_name,
+                                                                 symbol_table,
+                                                                 constraints,
+                                                                 quick = quick):
 
             _constraint, mem_object, _header = result
             yield mem_object
 
     def _generator(self):
-        for hive in self.scan_hives(self.context, self.config['primary'], self.config['nt_symbols']):
+        for hive in self.scan_hives(self.context,
+                                    self.config['primary'],
+                                    self.config['nt_symbols'],
+                                    quick = self.config['quick']):
 
             yield (0, (format_hints.Hex(hive.vol.offset), ))
 

--- a/volatility/framework/plugins/windows/virtmap.py
+++ b/volatility/framework/plugins/windows/virtmap.py
@@ -16,6 +16,8 @@ vollog = logging.getLogger(__name__)
 class VirtMap(interfaces.plugins.PluginInterface):
     """Lists virtual mapped sections."""
 
+    _version = (1, 0, 0)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Ok, so this mostly just pulls segments from the virtmap plugin, but it's given reasonable speed ups (around 50%).

One this this does change is not to exclude the "Unused" section, since I've found kernels that had valuable data in areas that were marked that way.  I don't know whether our marking was wrong, or whether the kernel was just doing weird things, but using `--quick` will definitely restrict findings that come from outside the allocated memory ranges.

@iMHLv2 if you can shed any light on what's going on with the Unused stuff, and/or why our virtmap code doesn't work for certain windows versions (from around 2016) that would be much appreciated!  5:)