### PR TITLE
Object sizes

### DIFF
--- a/volatility/framework/contexts/__init__.py
+++ b/volatility/framework/contexts/__init__.py
@@ -111,8 +111,10 @@ class Context(interfaces.context.ContextInterface):
         object_template = object_template.clone()
         object_template.update_vol(**arguments)
         return object_template(context = self,
-                               object_info = interfaces.objects.ObjectInformation(
-                                   layer_name = layer_name, offset = offset, native_layer_name = native_layer_name))
+                               object_info = interfaces.objects.ObjectInformation(layer_name = layer_name,
+                                                                                  offset = offset,
+                                                                                  native_layer_name = native_layer_name,
+                                                                                  size = object_template.size))
 
     def module(self,
                module_name: str,

--- a/volatility/framework/interfaces/objects.py
+++ b/volatility/framework/interfaces/objects.py
@@ -63,7 +63,8 @@ class ObjectInformation(ReadOnlyMapping):
                  offset: int,
                  member_name: Optional[str] = None,
                  parent: Optional['ObjectInterface'] = None,
-                 native_layer_name: Optional[str] = None):
+                 native_layer_name: Optional[str] = None,
+                 size: Optional[int] = None):
         """Constructs a container for basic information about an object.
 
         Args:
@@ -78,7 +79,8 @@ class ObjectInformation(ReadOnlyMapping):
             'offset': offset,
             'member_name': member_name,
             'parent': parent,
-            'native_layer_name': native_layer_name or layer_name
+            'native_layer_name': native_layer_name or layer_name,
+            'size': size
         })
 
 
@@ -160,7 +162,8 @@ class ObjectInterface(metaclass = ABCMeta):
                                         offset = self.vol.offset,
                                         member_name = self.vol.member_name,
                                         parent = self.vol.parent,
-                                        native_layer_name = self.vol.native_layer_name)
+                                        native_layer_name = self.vol.native_layer_name,
+                                        size = object_template.size)
         return object_template(context = self._context, object_info = object_info)
 
     def has_member(self, member_name: str) -> bool:

--- a/volatility/framework/interfaces/objects.py
+++ b/volatility/framework/interfaces/objects.py
@@ -73,6 +73,7 @@ class ObjectInformation(ReadOnlyMapping):
             member_name: If the object was accessed as a member of a parent object, this was the name used to access it
             parent: If the object was accessed as a member of a parent object, this is the parent object
             native_layer_name: If this object references other objects (such as a pointer), what layer those objects live in
+            size: The size that the whole structure consumes in bytes
         """
         super().__init__({
             'layer_name': layer_name,

--- a/volatility/framework/objects/__init__.py
+++ b/volatility/framework/objects/__init__.py
@@ -678,14 +678,13 @@ class AggregateType(interfaces.objects.ObjectInterface):
             relative_offset, template = self.vol.members[attr]
             if isinstance(template, templates.ReferenceTemplate):
                 template = self._context.symbol_space.get_type(template.vol.type_name)
-            member = template(context = self._context,
-                              object_info = interfaces.objects.ObjectInformation(
-                                  layer_name = self.vol.layer_name,
-                                  offset = mask & (self.vol.offset + relative_offset),
-                                  member_name = attr,
-                                  parent = self,
-                                  native_layer_name = self.vol.native_layer_name,
-                                  size = template.size))
+            object_info = interfaces.objects.ObjectInformation(layer_name = self.vol.layer_name,
+                                                               offset = mask & (self.vol.offset + relative_offset),
+                                                               member_name = attr,
+                                                               parent = self,
+                                                               native_layer_name = self.vol.native_layer_name,
+                                                               size = template.size)
+            member = template(context = self._context, object_info = object_info)
             self._concrete_members[attr] = member
             return member
         # We duplicate this code to avoid polluting the methodspace

--- a/volatility/framework/objects/__init__.py
+++ b/volatility/framework/objects/__init__.py
@@ -495,6 +495,7 @@ class Array(interfaces.objects.ObjectInterface, abc.Sequence):
         super().__init__(context = context, type_name = type_name, object_info = object_info)
         self._vol['count'] = count
         self._vol['subtype'] = subtype
+        self._vol['size'] = count * subtype.size
 
     # This overrides the little known Sequence.count(val) that returns the number of items in the list that match val
     # Changing the name would be confusing (since we use count of an array everywhere else), so this is more important
@@ -507,6 +508,7 @@ class Array(interfaces.objects.ObjectInterface, abc.Sequence):
     def count(self, value: int) -> None:
         """Sets the count to a specific value."""
         self._vol['count'] = value
+        self._vol['size'] = value * self._vol['subtype'].size
 
     class VolTemplateProxy(interfaces.objects.ObjectInterface.VolTemplateProxy):
 


### PR DESCRIPTION
Ensures that `thing.vol.size` is appropriately set from the available information.

This also includes arrays (which can be dynamically sized).  The value for arrays is never taken from the Intermediate Symbol Format, but calculated based on the count and subtype and then stored.  It is updated whenever the count (that could change the size) is altered.  The subtype can only be altered by a recast, which should then recalculate the appropriate value.

This is important to get right, particularly if people are reliant on it, so it won't get pushed without a review...