### PR TITLE
VadDump: Fix incorrect variable out_of_range in vad_dump

### DIFF
--- a/volatility/framework/plugins/windows/vaddump.py
+++ b/volatility/framework/plugins/windows/vaddump.py
@@ -47,7 +47,7 @@ class VadDump(interfaces.plugins.PluginInterface):
         proc_layer = context.layers[layer_name]
         chunk_size = 1024 * 1024 * 10
         offset = vad.get_start()
-        out_of_range = vad.get_start() + vad.get_end()
+        out_of_range = vad.get_end()
         # print("walking from {:x} to {:x} | {:x}".format(offset, out_of_range, out_of_range-offset))
         while offset < out_of_range:
             to_read = min(chunk_size, out_of_range - offset)


### PR DESCRIPTION
This PR fixes an incorrect variable initialization in the VadDump module.

The out_of_range variable should be `vad.get_end()` instead of `vad_get_start() + vad.get_end()`. The typo must've come up when porting this module from volatility2 to volatility3 which originally was `out_of_range = vad.Start + vad.Length `.
This is causing the output files to be a lot heavier and containing extra unwanted data.
Therefore I just fixed this variable.