### PR TITLE
Mac quick pslist fix

### DIFF
--- a/volatility/framework/plugins/linux/lsmod.py
+++ b/volatility/framework/plugins/linux/lsmod.py
@@ -42,13 +42,12 @@ class Lsmod(plugins.PluginInterface):
 
         Yields:
             The modules present in the `layer_name` layer's modules list
+
+        This function will throw a SymbolError exception if kernel module support is not enabled.
         """
         linux.LinuxUtilities.aslr_mask_symbol_table(context, vmlinux_symbols, layer_name)
 
         vmlinux = contexts.Module(context, vmlinux_symbols, layer_name, 0)
-
-        # this will cause an exception if module support is not compiled into the kernel
-        vmlinux.get_type("module")
 
         modules = vmlinux.object_from_symbol(symbol_name = "modules").cast("list_head")
 

--- a/volatility/framework/plugins/mac/pslist.py
+++ b/volatility/framework/plugins/mac/pslist.py
@@ -87,7 +87,7 @@ class PsList(interfaces.plugins.PluginInterface):
             else:
                 seen[proc.vol.offset] = 1
 
-            if not filter_func(proc) and kernel_as.is_valid(proc.vol.offset, proc.vol.size):
+            if not filter_func(proc) and kernel_as.is_valid(proc.vol.offset):
                 yield proc
 
             try:

--- a/volatility/framework/symbols/linux/__init__.py
+++ b/volatility/framework/symbols/linux/__init__.py
@@ -25,7 +25,9 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class('fs_struct', extensions.fs_struct)
         self.set_type_class('files_struct', extensions.files_struct)
         self.set_type_class('vfsmount', extensions.vfsmount)
-        self.set_type_class('module', extensions.module)
+        
+        if 'module' in self.types:
+            self.set_type_class('module', extensions.module)
 
         if 'mount' in self.types:
             self.set_type_class('mount', extensions.mount)


### PR DESCRIPTION
@ikelos 

I am fine with the patch the way it is since task structures won't cross page boundaries, but that won't always be the case.

Could you please respond before merging with the proper (if any) way to get the size of an object like I thought .size used to do.