### PR TITLE
Fix is_valid call to remove size

### DIFF
--- a/volatility/framework/plugins/mac/pslist.py
+++ b/volatility/framework/plugins/mac/pslist.py
@@ -87,7 +87,7 @@ class PsList(interfaces.plugins.PluginInterface):
             else:
                 seen[proc.vol.offset] = 1
 
-            if not filter_func(proc) and kernel_as.is_valid(proc.vol.offset, proc.vol.size):
+            if not filter_func(proc) and kernel_as.is_valid(proc.vol.offset):
                 yield proc
 
             try:


### PR DESCRIPTION
@ikelos 

I am fine with the patch the way it is since task structures won't cross page boundaries, but that won't always be the case.

Could you please respond before merging with the proper (if any) way to get the size of an object like I thought .size used to do
