### PR TITLE
ResourceAccessor: fix unverified retrieval for ssl.SSLError

### DIFF
--- a/volatility/framework/layers/resources.py
+++ b/volatility/framework/layers/resources.py
@@ -70,7 +70,11 @@ class ResourceAccessor(object):
             fp = urllib.request.urlopen(url, context = self._context)
         except error.URLError as excp:
             if excp.args:
-                if isinstance(excp.args[0], ssl.SSLCertVerificationError):
+                unverified_retrieval = (hasattr(ssl, "SSLCertVerificationError") and isinstance(excp.args[0],
+                                                                                                ssl.SSLCertVerificationError)) or (
+                                               isinstance(excp.args[0], ssl.SSLError) and excp.args[
+                                           0].reason == "CERTIFICATE_VERIFY_FAILED")
+                if unverified_retrieval:
                     vollog.warning("SSL certificate verification failed: attempting UNVERIFIED retrieval")
                     non_verifying_ctx = ssl.SSLContext()
                     non_verifying_ctx.check_hostname = False


### PR DESCRIPTION
On my Mac, I'm running Python 3.6.3 from python.org. The commit 2d3cceda only solved the problem halfway for me. This PR fixes the rest. In particular, the ssl shipped with my Python version doesn't have `ssl.SSLCertVerificationError`. Instead, it raises `ssl.SSLError` with a reason of `CERTIFICATE_VERIFY_FAILED`. 