### PR TITLE
catch more exceptions traversing windows vads

### DIFF
--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -101,11 +101,17 @@ class MMVAD_SHORT(objects.StructType):
             vad_object = self.cast(target)
             yield vad_object
 
-        for vad_node in self.get_left_child().dereference().traverse(visited, depth + 1):
-            yield vad_node
+        try:
+            for vad_node in self.get_left_child().dereference().traverse(visited, depth + 1):
+                yield vad_node
+        except exceptions.InvalidAddressException as excp:
+            vollog.log(constants.LOGLEVEL_VVV, "Invalid address on LeftChild: {0:#x}".format(excp.invalid_address))
 
-        for vad_node in self.get_right_child().dereference().traverse(visited, depth + 1):
-            yield vad_node
+        try:
+            for vad_node in self.get_right_child().dereference().traverse(visited, depth + 1):
+                yield vad_node
+        except exceptions.InvalidAddressException as excp:
+            vollog.log(constants.LOGLEVEL_VVV, "Invalid address on RightChild: {0:#x}".format(excp.invalid_address))
 
     def get_right_child(self):
         """Get the right child member."""


### PR DESCRIPTION
Catch more exceptions when traversing Windows VADs. In particular, catch `InvalidAddressException` on the LeftChild and RightChild separately, so an exception on one doesn't prevent traversing the other. Log exceptions in either case. I observed this issue when trying to parse VADs for a terminated process.