### PR TITLE
add Tag to 32-bit win10 service types

### DIFF
--- a/volatility/framework/symbols/windows/services-win10-15063-x86.json
+++ b/volatility/framework/symbols/windows/services-win10-15063-x86.json
@@ -196,7 +196,18 @@
                         }
                     },
                     "offset": 44
-                }, 
+                },
+                "Tag": {
+                    "type": {
+                        "count": 4,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        },
+                        "kind": "array"
+                    },
+                    "offset": 0
+                },
                 "DriverName": {
                     "type": {
                         "kind": "pointer",

--- a/volatility/framework/symbols/windows/services-win10-16299-x86.json
+++ b/volatility/framework/symbols/windows/services-win10-16299-x86.json
@@ -196,7 +196,18 @@
                         }
                     }, 
                     "offset": 44
-                }, 
+                },
+                "Tag": {
+                    "type": {
+                        "count": 4,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        },
+                        "kind": "array"
+                    },
+                    "offset": 0
+                },
                 "DriverName": {
                     "type": {
                         "kind": "pointer",


### PR DESCRIPTION
The hand-written JSON types for 32-bit Windows 10 versions were missing the Tag member.