### PR TITLE
Issue mac tasks

### DIFF
--- a/volatility/framework/symbols/mac/extensions/__init__.py
+++ b/volatility/framework/symbols/mac/extensions/__init__.py
@@ -390,27 +390,17 @@ class queue_entry(objects.StructType):
                   max_size: int = 4096) -> Iterable[interfaces.objects.ObjectInterface]:
         yielded = 0
 
-        try:
-            n = self.next.dereference().cast(type_name)
-            while n is not None and n.vol.offset != list_head:
-                yield n
-                yielded = yielded + 1
-                if yielded == max_size:
-                    return
-                n = n.member(attr = member_name).next.dereference().cast(type_name)
-        except exceptions.InvalidAddressException:
-            pass
-
-        try:
-            p = self.prev.dereference().cast(type_name)
-            while p is not None and p.vol.offset != list_head:
-                yield p
-                yielded = yielded + 1
-                if yielded == max_size:
-                    return
-                p = p.member(attr = member_name).prev.dereference().cast(type_name)
-        except exceptions.InvalidAddressException:
-            return
+        for attr in ['next', 'prev']:
+            try:
+                n = getattr(self, attr).dereference().cast(type_name)
+                while n is not None and n.vol.offset != list_head:
+                    yield n
+                    yielded = yielded + 1
+                    if yielded == max_size:
+                        return
+                    n = getattr(n.member(attr = member_name), attr).dereference().cast(type_name)
+            except exceptions.InvalidAddressException:
+                pass
 
 
 class ifnet(objects.StructType):

--- a/volatility/framework/symbols/mac/extensions/__init__.py
+++ b/volatility/framework/symbols/mac/extensions/__init__.py
@@ -4,7 +4,7 @@
 
 from typing import Generator, Iterable, Optional, Set, Tuple
 
-from volatility.framework import constants, objects, renderers
+from volatility.framework import constants, objects
 from volatility.framework import exceptions, interfaces
 from volatility.framework.objects import utility
 from volatility.framework.renderers import conversion
@@ -392,25 +392,25 @@ class queue_entry(objects.StructType):
 
         try:
             n = self.next.dereference().cast(type_name)
-        except exceptions.PagedInvalidAddressException:
-            return
-        while n is not None and n.vol.offset != list_head:
-            yield n
-            yielded = yielded + 1
-            if yielded == max_size:
-                return
-            n = n.member(attr = member_name).next.dereference().cast(type_name)
+            while n is not None and n.vol.offset != list_head:
+                yield n
+                yielded = yielded + 1
+                if yielded == max_size:
+                    return
+                n = n.member(attr = member_name).next.dereference().cast(type_name)
+        except exceptions.InvalidAddressException:
+            pass
 
         try:
             p = self.prev.dereference().cast(type_name)
-        except exceptions.PagedInvalidAddressException:
+            while p is not None and p.vol.offset != list_head:
+                yield p
+                yielded = yielded + 1
+                if yielded == max_size:
+                    return
+                p = p.member(attr = member_name).prev.dereference().cast(type_name)
+        except exceptions.InvalidAddressException:
             return
-        while p is not None and p.vol.offset != list_head:
-            yield p
-            yielded = yielded + 1
-            if yielded == max_size:
-                return
-            p = p.member(attr = member_name).prev.dereference().cast(type_name)
 
 
 class ifnet(objects.StructType):


### PR DESCRIPTION
As of commit `d7f5a13c467878e7927fe55c8ba7b28a3fc56e77`, buildbot broke on the mac tasks test.  Looking at the change, I thought this was because `not filter_func(proc)` could be checked if `proc` were invalid (hence adding `fda64dde958c6e236ca099b52fcce88884ad13b0`).

It turns out that due to the fix, it no longer stops as soon as it hits an error (meaning the next item in the queue is requested, which is where the break actually happened).  There was exception handling around the first item read of `next` or `prev`, but not around the later attempts to access the next item.  I've extended the exception handling around each of the loops, and then optimized it so that the loop code isn't duplicated but parameterized instead.

Please could you check that this behaves as you'd expect, and if so either directly merge it or let me know and I'll merge it.  I think it's right, so I'll merge it in 7 days if you'd don't but there might be some subtlety that I haven't spotted so better if you could review it before then please...  5:)