### PR TITLE
Wintel: Reorder the DTB tests

### DIFF
--- a/volatility/framework/automagic/windows.py
+++ b/volatility/framework/automagic/windows.py
@@ -213,7 +213,7 @@ class PageMapScanner(interfaces.layers.ScannerInterface):
     architecture."""
     overlap = 0x4000
     thread_safe = True
-    tests = [DtbTest32bit(), DtbTest64bit(), DtbTestPae()]
+    tests = [DtbTest64bit(), DtbTest32bit(), DtbTestPae()]
     """The default tests to run when searching for DTBs"""
 
     def __init__(self, tests: List[DtbTest]) -> None:
@@ -239,7 +239,7 @@ class WintelHelper(interfaces.automagic.AutomagicInterface):
     It will scan for existing TranslationLayers that do not have a DTB  using the :class:`PageMapScanner`
     """
     priority = 20
-    tests = [DtbTest32bit(), DtbTest64bit(), DtbTestPae()]
+    tests = [DtbTest64bit(), DtbTest32bit(), DtbTestPae()]
 
     def __call__(self,
                  context: interfaces.context.ContextInterface,


### PR DESCRIPTION
Reorder the DTB tests, since 64-bits have more to match and are likely
more common these days.  We've had an instance where a 32-bit DTB was
detected because of a self-referential pointer over a 64-bit DTB leading
to an inaccessible image.

This fixes issue #193.