### PR TITLE
Refactor stacker automagic

### DIFF
--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -256,7 +256,7 @@ class CommandLine(interfaces.plugins.FileConsumerInterface):
                 # This must be specific to get us started, setup the config and run
                 ctx.config[interfaces.configuration.path_join(current_config_path, "location")] = single_location
                 physical_layer = physical.FileLayer(ctx, current_config_path, current_layer_name)
-                ctx.config['automagic.TranslationLayerStacker.initial_layer'] = physical_layer.name
+                ctx.config['automagic.LayerStacker.single_location'] = physical_layer.name
                 ctx.add_layer(physical_layer)
 
         # UI fills in the config, here we load it from the config file and do it before we process the CL parameters

--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -29,6 +29,7 @@ from volatility.framework import automagic, constants, contexts, exceptions, int
 from volatility.framework.configuration import requirements
 
 # Make sure we log everything
+from volatility.framework.layers import physical
 
 vollog = logging.getLogger()
 vollog.setLevel(1)
@@ -246,7 +247,17 @@ class CommandLine(interfaces.plugins.FileConsumerInterface):
                 vollog.log(logging.INFO, "File does not exist: {}".format(file_name))
             else:
                 single_location = "file:" + request.pathname2url(file_name)
-                ctx.config['automagic.LayerStacker.single_location'] = single_location
+
+                # Setup the local copy of the resource
+                config_path = "cli"
+                current_layer_name = ctx.layers.free_layer_name("FileLayer")
+                current_config_path = interfaces.configuration.path_join(config_path, "base_layer", current_layer_name)
+
+                # This must be specific to get us started, setup the config and run
+                ctx.config[interfaces.configuration.path_join(current_config_path, "location")] = single_location
+                physical_layer = physical.FileLayer(ctx, current_config_path, current_layer_name)
+                ctx.config['automagic.LayerStacker.single_location'] = physical_layer.name
+                ctx.add_layer(physical_layer)
 
         # UI fills in the config, here we load it from the config file and do it before we process the CL parameters
         if args.config:

--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -256,7 +256,7 @@ class CommandLine(interfaces.plugins.FileConsumerInterface):
                 # This must be specific to get us started, setup the config and run
                 ctx.config[interfaces.configuration.path_join(current_config_path, "location")] = single_location
                 physical_layer = physical.FileLayer(ctx, current_config_path, current_layer_name)
-                ctx.config['automagic.LayerStacker.single_location'] = physical_layer.name
+                ctx.config['automagic.TranslationLayerStacker.initial_layer'] = physical_layer.name
                 ctx.add_layer(physical_layer)
 
         # UI fills in the config, here we load it from the config file and do it before we process the CL parameters

--- a/volatility/framework/automagic/__init__.py
+++ b/volatility/framework/automagic/__init__.py
@@ -21,11 +21,15 @@ from volatility.framework.configuration import requirements
 
 vollog = logging.getLogger(__name__)
 
-windows_automagic = ['ConstructionMagic', 'LayerStacker', 'WintelHelper', 'KernelPDBScanner', 'WinSwapLayers']
+windows_automagic = [
+    'ConstructionMagic', 'LayerStacker', 'TranslationLayerStacker', 'WintelHelper', 'KernelPDBScanner', 'WinSwapLayers'
+]
 
-linux_automagic = ['ConstructionMagic', 'LayerStacker', 'LinuxBannerCache', 'LinuxSymbolFinder']
+linux_automagic = [
+    'ConstructionMagic', 'LayerStacker', 'TranslationLayerStacker', 'LinuxBannerCache', 'LinuxSymbolFinder'
+]
 
-mac_automagic = ['ConstructionMagic', 'LayerStacker', 'MacBannerCache', 'MacSymbolFinder']
+mac_automagic = ['ConstructionMagic', 'LayerStacker', 'TranslationLayerStacker', 'MacBannerCache', 'MacSymbolFinder']
 
 
 def available(context: interfaces.context.ContextInterface) -> List[interfaces.automagic.AutomagicInterface]:

--- a/volatility/framework/automagic/__init__.py
+++ b/volatility/framework/automagic/__init__.py
@@ -21,15 +21,11 @@ from volatility.framework.configuration import requirements
 
 vollog = logging.getLogger(__name__)
 
-windows_automagic = [
-    'ConstructionMagic', 'LayerStacker', 'TranslationLayerStacker', 'WintelHelper', 'KernelPDBScanner', 'WinSwapLayers'
-]
+windows_automagic = ['ConstructionMagic', 'LayerStacker', 'WintelHelper', 'KernelPDBScanner', 'WinSwapLayers']
 
-linux_automagic = [
-    'ConstructionMagic', 'LayerStacker', 'TranslationLayerStacker', 'LinuxBannerCache', 'LinuxSymbolFinder'
-]
+linux_automagic = ['ConstructionMagic', 'LayerStacker', 'LinuxBannerCache', 'LinuxSymbolFinder']
 
-mac_automagic = ['ConstructionMagic', 'LayerStacker', 'TranslationLayerStacker', 'MacBannerCache', 'MacSymbolFinder']
+mac_automagic = ['ConstructionMagic', 'LayerStacker', 'MacBannerCache', 'MacSymbolFinder']
 
 
 def available(context: interfaces.context.ContextInterface) -> List[interfaces.automagic.AutomagicInterface]:

--- a/volatility/framework/automagic/stacker.py
+++ b/volatility/framework/automagic/stacker.py
@@ -16,10 +16,9 @@ import traceback
 from typing import List, Optional, Tuple
 
 from volatility import framework
-from volatility.framework import interfaces, constants, import_files
+from volatility.framework import interfaces, constants
 from volatility.framework.automagic import construct_layers
 from volatility.framework.configuration import requirements
-from volatility.framework.layers import physical
 
 vollog = logging.getLogger(__name__)
 
@@ -61,7 +60,7 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
             vollog.info("Unable to run LayerStacker, unsatisfied requirement: {}".format(unsatisfied))
             return list(unsatisfied)
         if not self.config or not self.config.get('single_location', None):
-            raise ValueError("Unable to run LayerStacker, single_location parameter not provided")
+            return list(unsatisfied)
 
         # Search for suitable requirements
         self.stack(context, config_path, requirement, progress_callback)
@@ -92,16 +91,7 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
             self._cached = None
 
         new_context = context.clone()
-        location = self.config.get('single_location', None)
-
-        # Setup the local copy of the resource
-        current_layer_name = context.layers.free_layer_name("FileLayer")
-        current_config_path = interfaces.configuration.path_join(config_path, "stack", current_layer_name)
-
-        # This must be specific to get us started, setup the config and run
-        new_context.config[interfaces.configuration.path_join(current_config_path, "location")] = location
-        physical_layer = physical.FileLayer(new_context, current_config_path, current_layer_name)
-        new_context.add_layer(physical_layer)
+        current_layer_name = self.config.get('single_location', None)
 
         # Repeatedly apply "determine what this is" code and build as much up as possible
         stacked = True

--- a/volatility/framework/automagic/stacker.py
+++ b/volatility/framework/automagic/stacker.py
@@ -19,11 +19,69 @@ from volatility import framework
 from volatility.framework import interfaces, constants
 from volatility.framework.automagic import construct_layers
 from volatility.framework.configuration import requirements
+from volatility.framework.layers import physical
 
 vollog = logging.getLogger(__name__)
 
 
 class LayerStacker(interfaces.automagic.AutomagicInterface):
+    """Builds up layers in a single stack.
+
+    This class mimics the volatility 2 style of stacking address spaces.  It builds up various layers based on
+    separate :class:`~volatility.framework.interfaces.automagic.StackerLayerInterface` classes.  These classes are
+    built up based on a `stack_order` class variable each has.
+
+    This has a high priority to provide other automagic modules as complete a context/configuration tree as possible.
+    Upon completion it will re-call the :class:`~volatility.framework.automagic.construct_layers.ConstructionMagic`,
+    so that any stacked layers are actually constructed and added to the context.
+    """
+    priority = 9
+
+    def __call__(self,
+                 context: interfaces.context.ContextInterface,
+                 config_path: str,
+                 requirement: interfaces.configuration.RequirementInterface,
+                 progress_callback: constants.ProgressCallback = None) -> Optional[List[str]]:
+        """Runs the automagic over the configurable."""
+        if not self.config or not self.config.get('single_location'):
+            # "Successful" but no results
+            return []
+
+        vollog.warning("Outdated Interface: The LayerStacker interface has been deprecated for TranslationLayerStacker")
+        # raise DeprecationWarning("The LayerStacker has been updated as TranslationLayerStacker")
+
+        unsatisfied = self.unsatisfied(self.context, self.config_path)
+        if unsatisfied:
+            vollog.info("Unable to run LayerStacker, unsatisfied requirement: {}".format(unsatisfied))
+            return list(unsatisfied)
+
+        # Setup the local copy of the resource
+        base_config_path = config_path.split(interfaces.configuration.CONFIG_SEPARATOR)
+        tls_config_path = interfaces.configuration.path_join(*base_config_path, 'TranslationLayerStacker')
+        single_location = self.config['single_location']
+        current_layer_name = context.layers.free_layer_name("FileLayer")
+        current_config_path = interfaces.configuration.path_join(config_path, "base_layer", current_layer_name)
+
+        # This must be specific to get us started, setup the config and run
+        context.config[interfaces.configuration.path_join(current_config_path, "location")] = single_location
+        physical_layer = physical.FileLayer(context, current_config_path, current_layer_name)
+        context.add_layer(physical_layer)
+
+        # Setup and call the TranslationLayerStacker
+        context.config[interfaces.configuration.path_join(tls_config_path, 'initial_layer')] = physical_layer.name
+        stacker = TranslationLayerStacker(context, tls_config_path)
+        stacker(context, config_path, requirement, progress_callback)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.URIRequirement("single_location",
+                                        description = "Specifies the URI of an initial physical file on which to stack",
+                                        optional = True)
+        ]
+
+
+class TranslationLayerStacker(interfaces.automagic.AutomagicInterface):
     """Builds up layers in a single stack.
 
     This class mimics the volatility 2 style of stacking address spaces.  It builds up various layers based on
@@ -57,9 +115,7 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
         # Bow out quickly if the UI hasn't provided a single_location
         unsatisfied = self.unsatisfied(self.context, self.config_path)
         if unsatisfied:
-            vollog.info("Unable to run LayerStacker, unsatisfied requirement: {}".format(unsatisfied))
-            return list(unsatisfied)
-        if not self.config or not self.config.get('single_location', None):
+            vollog.info("Unable to run TranslationLayerStacker, unsatisfied requirement: {}".format(unsatisfied))
             return list(unsatisfied)
 
         # Search for suitable requirements
@@ -91,7 +147,7 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
             self._cached = None
 
         new_context = context.clone()
-        current_layer_name = self.config.get('single_location', None)
+        current_layer_name = self.config.get('initial_layer', None)
 
         # Repeatedly apply "determine what this is" code and build as much up as possible
         stacked = True
@@ -178,9 +234,8 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
-        # This is not optional for the stacker to run, so optional must be marked as False
         return [
-            requirements.URIRequirement("single_location",
-                                        description = "Specifies a base location on which to stack",
-                                        optional = True)
+            requirements.StringRequirement("initial_layer",
+                                           description = "Specifies the name of a layer on which to stack",
+                                           optional = True)
         ]


### PR DESCRIPTION
Ok,

So it occurred to me that the LayerStacker automagic was a little non-generic and not really reusable.  Previous it look a single_location parameter that was a URI and attempted to stack as high as possible on top of, and then attach it to the configuration at a TranslationRequirement that wasn't yet satisified.

It seemed as though the "construct layers" code could be applied to any starting layer, rather than taking an explicit URI and always starting from a physical layer.  It also occurs to me that people may want to apply it without a requirement/config tree beside it.  That's surprisingly hard to arrange with the existing system, since it all gets built in a temporary context which is thrown away if it's not attached to a requirement in the original context, so I think I'm gonna leave the output bit as it (otherwise it may well clutter a config with random layers that might've stacked). 

This has been reworked, the first commit was the most basic implementation but wasn't backwards compatible.  The second commit changes names to allow for backwards compatibility of old clients (for whatever reason).

@npetroni I've asked for a review because I'm interested in your perspective on whether the change is worthwhile, and whether we being cautious about backwards compatibility (a good thing) is worth the cost of the extra code to get it going (and the use of the longer class name to not stomp on the old one)?