### PR TITLE
Registry stringlike data

### DIFF
--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -58,7 +58,11 @@ def strlike_as_text(value: format_hints.StrLike) -> str:
 
     This attempts to convert the string based on its encoding and if no data's been lost due to the split on the null character, then it displays it as is
     """
+    if value.show_hex:
+        return hex_bytes_as_text(value)
     string_representation = str(value, encoding = value.encoding, errors = 'replace')
+    if value.split_nulls and ((len(value) / 2 - 1) <= len(string_representation) <= (len(value) / 2)):
+        return "\n".join(string_representation.split("\x00"))
     if len(string_representation) - 1 <= len(string_representation.split("\x00")[0]) <= len(string_representation):
         return string_representation.split("\x00")[0]
     return hex_bytes_as_text(value)
@@ -85,6 +89,8 @@ def quoted_optional(func):
         result = optional(func)(x)
         if result == "-" or result == "N/A":
             return ""
+        if isinstance(x, format_hints.StrLike) and x.converted_int:
+            return "{}".format(result)
         if isinstance(x, int) and not isinstance(x, (format_hints.Hex, format_hints.Bin)):
             return "{}".format(result)
         return "\"{}\"".format(result)

--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -53,6 +53,17 @@ def hex_bytes_as_text(value: bytes) -> str:
     return output
 
 
+def strlike_as_text(value: format_hints.StrLike) -> str:
+    """Renders the bytes as a string where possible, otherwise it displays hex data
+
+    This attempts to convert the string based on its encoding and if no data's been lost due to the split on the null character, then it displays it as is
+    """
+    string_representation = str(value, encoding = value.encoding, errors = 'replace')
+    if len(string_representation) - 1 <= len(string_representation.split("\x00")[0]) <= len(string_representation):
+        return string_representation.split("\x00")[0]
+    return hex_bytes_as_text(value)
+
+
 def optional(func):
 
     @wraps(func)
@@ -117,6 +128,7 @@ class QuickTextRenderer(CLIRenderer):
         format_hints.Bin: optional(lambda x: "0b{:b}".format(x)),
         format_hints.Hex: optional(lambda x: "0x{:x}".format(x)),
         format_hints.HexBytes: optional(hex_bytes_as_text),
+        format_hints.StrLike: quoted_optional(strlike_as_text),
         interfaces.renderers.Disassembly: optional(display_disassembly),
         bytes: optional(lambda x: " ".join(["{0:2x}".format(b) for b in x])),
         datetime.datetime: optional(lambda x: x.strftime("%Y-%m-%d %H:%M:%S.%f %Z")),
@@ -172,6 +184,7 @@ class CSVRenderer(CLIRenderer):
         format_hints.Bin: quoted_optional(lambda x: "0b{:b}".format(x)),
         format_hints.Hex: quoted_optional(lambda x: "0x{:x}".format(x)),
         format_hints.HexBytes: quoted_optional(hex_bytes_as_text),
+        format_hints.StrLike: quoted_optional(strlike_as_text),
         interfaces.renderers.Disassembly: quoted_optional(display_disassembly),
         bytes: quoted_optional(lambda x: " ".join(["{0:2x}".format(b) for b in x])),
         datetime.datetime: quoted_optional(lambda x: x.strftime("%Y-%m-%d %H:%M:%S.%f %Z")),

--- a/volatility/cli/text_renderer.py
+++ b/volatility/cli/text_renderer.py
@@ -53,7 +53,7 @@ def hex_bytes_as_text(value: bytes) -> str:
     return output
 
 
-def strlike_as_text(value: format_hints.StrLike) -> str:
+def multitypedata_as_text(value: format_hints.MultiTypeData) -> str:
     """Renders the bytes as a string where possible, otherwise it displays hex data
 
     This attempts to convert the string based on its encoding and if no data's been lost due to the split on the null character, then it displays it as is
@@ -89,7 +89,7 @@ def quoted_optional(func):
         result = optional(func)(x)
         if result == "-" or result == "N/A":
             return ""
-        if isinstance(x, format_hints.StrLike) and x.converted_int:
+        if isinstance(x, format_hints.MultiTypeData) and x.converted_int:
             return "{}".format(result)
         if isinstance(x, int) and not isinstance(x, (format_hints.Hex, format_hints.Bin)):
             return "{}".format(result)
@@ -134,7 +134,7 @@ class QuickTextRenderer(CLIRenderer):
         format_hints.Bin: optional(lambda x: "0b{:b}".format(x)),
         format_hints.Hex: optional(lambda x: "0x{:x}".format(x)),
         format_hints.HexBytes: optional(hex_bytes_as_text),
-        format_hints.StrLike: quoted_optional(strlike_as_text),
+        format_hints.MultiTypeData: quoted_optional(multitypedata_as_text),
         interfaces.renderers.Disassembly: optional(display_disassembly),
         bytes: optional(lambda x: " ".join(["{0:2x}".format(b) for b in x])),
         datetime.datetime: optional(lambda x: x.strftime("%Y-%m-%d %H:%M:%S.%f %Z")),
@@ -190,7 +190,7 @@ class CSVRenderer(CLIRenderer):
         format_hints.Bin: quoted_optional(lambda x: "0b{:b}".format(x)),
         format_hints.Hex: quoted_optional(lambda x: "0x{:x}".format(x)),
         format_hints.HexBytes: quoted_optional(hex_bytes_as_text),
-        format_hints.StrLike: quoted_optional(strlike_as_text),
+        format_hints.MultiTypeData: quoted_optional(multitypedata_as_text),
         interfaces.renderers.Disassembly: quoted_optional(display_disassembly),
         bytes: quoted_optional(lambda x: " ".join(["{0:2x}".format(b) for b in x])),
         datetime.datetime: quoted_optional(lambda x: x.strftime("%Y-%m-%d %H:%M:%S.%f %Z")),

--- a/volatility/framework/plugins/windows/registry/printkey.py
+++ b/volatility/framework/plugins/windows/registry/printkey.py
@@ -121,7 +121,7 @@ class PrintKey(interfaces.plugins.PluginInterface):
                     value_node_name = renderers.UnreadableValue()
 
                 try:
-                    value_data = str(node.decode_data())  # type: Union[interfaces.renderers.BaseAbsentValue, str]
+                    value_data = node.decode_data()  # type: Union[interfaces.renderers.BaseAbsentValue, bytes]
                 except (ValueError, exceptions.InvalidAddressException, RegistryFormatException) as excp:
                     vollog.debug(excp)
                     value_data = renderers.UnreadableValue()
@@ -133,7 +133,7 @@ class PrintKey(interfaces.plugins.PluginInterface):
                     value_type = renderers.UnreadableValue()
 
                 result = (depth, (last_write_time, renderers.format_hints.Hex(hive.hive_offset), value_type, key_path,
-                                  value_node_name, value_data, volatile))
+                                  value_node_name, format_hints.StrLike(value_data), volatile))
                 yield result
 
     def _registry_walker(self,
@@ -173,7 +173,8 @@ class PrintKey(interfaces.plugins.PluginInterface):
         offset = self.config.get('offset', None)
 
         return TreeGrid(columns = [('Last Write Time', datetime.datetime), ('Hive Offset', format_hints.Hex),
-                                   ('Type', str), ('Key', str), ('Name', str), ('Data', str), ('Volatile', bool)],
+                                   ('Type', str), ('Key', str), ('Name', str), ('Data', format_hints.StrLike),
+                                   ('Volatile', bool)],
                         generator = self._registry_walker(self.config['primary'],
                                                           self.config['nt_symbols'],
                                                           hive_offsets = None if offset is None else [offset],

--- a/volatility/framework/plugins/windows/registry/printkey.py
+++ b/volatility/framework/plugins/windows/registry/printkey.py
@@ -133,7 +133,7 @@ class PrintKey(interfaces.plugins.PluginInterface):
                     value_type = renderers.UnreadableValue()
 
                 result = (depth, (last_write_time, renderers.format_hints.Hex(hive.hive_offset), value_type, key_path,
-                                  value_node_name, format_hints.StrLike(value_data), volatile))
+                                  value_node_name, format_hints.StrLike(value_data, encoding = 'utf-16-le'), volatile))
                 yield result
 
     def _registry_walker(self,

--- a/volatility/framework/plugins/windows/registry/printkey.py
+++ b/volatility/framework/plugins/windows/registry/printkey.py
@@ -136,13 +136,15 @@ class PrintKey(interfaces.plugins.PluginInterface):
                         value_data = node.decode_data()  # type: Union[interfaces.renderers.BaseAbsentValue, bytes]
 
                         if isinstance(value_data, int):
-                            value_data = format_hints.StrLike(value_data, encoding='utf-8')
+                            value_data = format_hints.MultiTypeData(value_data, encoding = 'utf-8')
                         elif RegValueTypes.get(node.Type) == RegValueTypes.REG_BINARY:
-                            value_data = format_hints.StrLike(value_data, show_hex=True)
+                            value_data = format_hints.MultiTypeData(value_data, show_hex = True)
                         elif RegValueTypes.get(node.Type) == RegValueTypes.REG_MULTI_SZ:
-                            value_data = format_hints.StrLike(value_data, encoding='utf-16-le', split_nulls=True)
+                            value_data = format_hints.MultiTypeData(value_data,
+                                                                    encoding = 'utf-16-le',
+                                                                    split_nulls = True)
                         else:
-                            value_data = format_hints.StrLike(value_data, encoding='utf-16-le')
+                            value_data = format_hints.MultiTypeData(value_data, encoding = 'utf-16-le')
                     except (ValueError, exceptions.InvalidAddressException, RegistryFormatException) as excp:
                         vollog.debug(excp)
                         value_data = renderers.UnreadableValue()
@@ -188,7 +190,7 @@ class PrintKey(interfaces.plugins.PluginInterface):
         offset = self.config.get('offset', None)
 
         return TreeGrid(columns = [('Last Write Time', datetime.datetime), ('Hive Offset', format_hints.Hex),
-                                   ('Type', str), ('Key', str), ('Name', str), ('Data', format_hints.StrLike),
+                                   ('Type', str), ('Key', str), ('Name', str), ('Data', format_hints.MultiTypeData),
                                    ('Volatile', bool)],
                         generator = self._registry_walker(self.config['primary'],
                                                           self.config['nt_symbols'],

--- a/volatility/framework/plugins/windows/registry/printkey.py
+++ b/volatility/framework/plugins/windows/registry/printkey.py
@@ -20,6 +20,7 @@ class PrintKey(interfaces.plugins.PluginInterface):
     """Lists the registry keys under a hive or specific key value."""
 
     _version = (1, 0, 0)
+    _required_framework_version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility/framework/renderers/conversion.py
+++ b/volatility/framework/renderers/conversion.py
@@ -109,3 +109,15 @@ def convert_network_four_tuple(family, four_tuple):
         ret = None
 
     return ret
+
+
+class StringlikeData(str):
+    """Container for data that's supposed to be a string but could in fact be binary data"""
+
+    def __init__(self, original: bytes, encoding: str = 'utf-16-le'):
+        self.original = original
+        self._encoding = encoding
+        str.__init__(self)
+
+    def __str__(self):
+        return str(self.original, encoding = self._encoding, errors = 'replace').split("\x00")[0]

--- a/volatility/framework/renderers/conversion.py
+++ b/volatility/framework/renderers/conversion.py
@@ -109,15 +109,3 @@ def convert_network_four_tuple(family, four_tuple):
         ret = None
 
     return ret
-
-
-class StringlikeData(str):
-    """Container for data that's supposed to be a string but could in fact be binary data"""
-
-    def __init__(self, original: bytes, encoding: str = 'utf-16-le'):
-        self.original = original
-        self._encoding = encoding
-        str.__init__(self)
-
-    def __str__(self):
-        return str(self.original, encoding = self._encoding, errors = 'replace').split("\x00")[0]

--- a/volatility/framework/renderers/format_hints.py
+++ b/volatility/framework/renderers/format_hints.py
@@ -28,9 +28,17 @@ class HexBytes(bytes):
 class StrLike(bytes):
     """The contents are supposed to be a string, but may contain binary data."""
 
-    def __new__(cls, original, encoding: str = 'utf-16-le'):
+    def __new__(cls, original, encoding: str = 'utf-16-le', split_nulls: bool = False, show_hex: bool = False):
+        if isinstance(original, int):
+            original = str(original).encode(encoding)
         return super().__new__(cls, original)
 
-    def __init__(self, original: bytes, encoding: str = 'utf-16-le'):
+    def __init__(self, original: bytes, encoding: str = 'utf-16-le', split_nulls: bool = False, show_hex: bool = False):
+        if isinstance(original, int):
+            self.converted_int = True
+        else:
+            self.converted_int = False
         self.encoding = encoding
+        self.split_nulls = split_nulls
+        self.show_hex = show_hex
         bytes.__init__(original)

--- a/volatility/framework/renderers/format_hints.py
+++ b/volatility/framework/renderers/format_hints.py
@@ -25,7 +25,7 @@ class HexBytes(bytes):
     format showing hexadecimal and ascii printable display."""
 
 
-class StrLike(bytes):
+class MultiTypeData(bytes):
     """The contents are supposed to be a string, but may contain binary data."""
 
     def __new__(cls, original, encoding: str = 'utf-16-le', split_nulls: bool = False, show_hex: bool = False):

--- a/volatility/framework/renderers/format_hints.py
+++ b/volatility/framework/renderers/format_hints.py
@@ -32,5 +32,9 @@ class StrLike(bytes):
         return super().__new__(cls, original)
 
     def __init__(self, original: bytes, encoding: str = 'utf-16-le'):
-        self.encoding = encoding
+        self.original = original
+        self._encoding = encoding
         bytes.__init__(original)
+
+    def __str__(self):
+        return str(self.original, encoding = self._encoding, errors = 'replace').split("\x00")[0]

--- a/volatility/framework/renderers/format_hints.py
+++ b/volatility/framework/renderers/format_hints.py
@@ -32,9 +32,5 @@ class StrLike(bytes):
         return super().__new__(cls, original)
 
     def __init__(self, original: bytes, encoding: str = 'utf-16-le'):
-        self.original = original
-        self._encoding = encoding
+        self.encoding = encoding
         bytes.__init__(original)
-
-    def __str__(self):
-        return str(self.original, encoding = self._encoding, errors = 'replace').split("\x00")[0]

--- a/volatility/framework/renderers/format_hints.py
+++ b/volatility/framework/renderers/format_hints.py
@@ -23,3 +23,18 @@ class Hex(int):
 class HexBytes(bytes):
     """A class to indicate that the bytes should be display in an extended
     format showing hexadecimal and ascii printable display."""
+
+
+class StrLike(bytes):
+    """The contents are supposed to be a string, but may contain binary data."""
+
+    def __new__(cls, original, encoding: str = 'utf-16-le'):
+        return super().__new__(cls, original)
+
+    def __init__(self, original: bytes, encoding: str = 'utf-16-le'):
+        self.original = original
+        self._encoding = encoding
+        bytes.__init__(original)
+
+    def __str__(self):
+        return str(self.original, encoding = self._encoding, errors = 'replace').split("\x00")[0]

--- a/volatility/framework/symbols/windows/extensions/registry.py
+++ b/volatility/framework/symbols/windows/extensions/registry.py
@@ -5,7 +5,7 @@
 import enum
 import logging
 import struct
-from typing import Optional, Iterable
+from typing import Optional, Iterable, Union
 
 from volatility.framework import constants, exceptions, objects, interfaces
 from volatility.framework.layers.registry import RegistryHive, RegistryInvalidIndex, RegistryFormatException
@@ -239,7 +239,7 @@ class CM_KEY_VALUE(objects.StructType):
         self.Name.count = namelength
         return self.Name.cast("string", max_length = namelength, encoding = "latin-1")
 
-    def decode_data(self) -> bytes:
+    def decode_data(self) -> Union[int, bytes]:
         """Properly decodes the data associated with the value node"""
         # Determine if the data is stored inline
         datalen = self.DataLength
@@ -298,4 +298,4 @@ class CM_KEY_VALUE(objects.StructType):
 
         # Fall back if it's something weird
         vollog.debug("Unknown registry value type encountered: {}".format(self.Type))
-        return data.hex()
+        return data

--- a/volatility/framework/symbols/windows/extensions/registry.py
+++ b/volatility/framework/symbols/windows/extensions/registry.py
@@ -5,11 +5,10 @@
 import enum
 import logging
 import struct
-from typing import Optional, Iterable, Union
+from typing import Optional, Iterable
 
 from volatility.framework import constants, exceptions, objects, interfaces
 from volatility.framework.layers.registry import RegistryHive, RegistryInvalidIndex, RegistryFormatException
-from volatility.framework.renderers import conversion
 
 vollog = logging.getLogger(__name__)
 
@@ -240,7 +239,7 @@ class CM_KEY_VALUE(objects.StructType):
         self.Name.count = namelength
         return self.Name.cast("string", max_length = namelength, encoding = "latin-1")
 
-    def decode_data(self) -> Union[str, bytes]:
+    def decode_data(self) -> bytes:
         """Properly decodes the data associated with the value node"""
         # Determine if the data is stored inline
         datalen = self.DataLength
@@ -289,16 +288,13 @@ class CM_KEY_VALUE(objects.StructType):
                 raise ValueError("Size of data does not match the type of registry value {}".format(self.get_name()))
             return struct.unpack("<Q", data)[0]
         if self_type in [
-                RegValueTypes.REG_SZ, RegValueTypes.REG_EXPAND_SZ, RegValueTypes.REG_LINK, RegValueTypes.REG_MULTI_SZ
-        ]:
-            return conversion.StringlikeData(data, encoding = 'utf-16-le')
-        if self_type in [
+                RegValueTypes.REG_SZ, RegValueTypes.REG_EXPAND_SZ, RegValueTypes.REG_LINK, RegValueTypes.REG_MULTI_SZ,
                 RegValueTypes.REG_BINARY, RegValueTypes.REG_FULL_RESOURCE_DESCRIPTOR, RegValueTypes.REG_RESOURCE_LIST,
                 RegValueTypes.REG_RESOURCE_REQUIREMENTS_LIST
         ]:
             return data
         if self_type == RegValueTypes.REG_NONE:
-            return ''
+            return b''
 
         # Fall back if it's something weird
         vollog.debug("Unknown registry value type encountered: {}".format(self.Type))


### PR DESCRIPTION
Here's a partial resolution to ensuring the registry API returns all data, but hints that it's likely to be a string (and leaves it to the renderer to determine how to render it).  Any renderer that does not support the StrLike hint will display the bytes instead.