### PR TITLE
Netscan

### DIFF
--- a/volatility/framework/constants/__init__.py
+++ b/volatility/framework/constants/__init__.py
@@ -39,7 +39,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 1  # Number of releases of the library with a breaking change
-VERSION_MINOR = 1  # Number of changes that only add to the interface
+VERSION_MINOR = 2  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = "-beta.1"
 

--- a/volatility/framework/plugins/windows/netscan.py
+++ b/volatility/framework/plugins/windows/netscan.py
@@ -245,16 +245,13 @@ class NetScan(interfaces.plugins.PluginInterface):
                                                                 self.config["nt_symbols"],
                                                                 self.config_path)
 
-        tcp_states = self.context.symbol_space.get_enumeration(netscan_symbol_table + constants.BANG + "TCPStateEnum")
-
         for netw_obj in self.scan(self.context, self.config['primary'], self.config['nt_symbols'],
                                   netscan_symbol_table):
 
             vollog.debug("Found netw obj @ 0x{:2x} of assumed type {}".format(netw_obj.vol.offset, type(netw_obj)))
             # objects passed pool header constraints. check for additional constraints if strict flag is set.
-            if not show_corrupt_results:
-                if not netw_obj.is_valid():
-                    continue
+            if not show_corrupt_results and not netw_obj.is_valid():
+                continue
 
             if isinstance(netw_obj, network._UDP_ENDPOINT):
                 vollog.debug("Found UDP_ENDPOINT @ 0x{:2x}".format(netw_obj.vol.offset))
@@ -280,7 +277,7 @@ class NetScan(interfaces.plugins.PluginInterface):
                     proto = "TCPv?"
 
                 try:
-                    state = tcp_states.lookup(netw_obj.State)
+                    state = netw_obj.State.description
                 except ValueError:
                     state = renderers.UnreadableValue()
 

--- a/volatility/framework/plugins/windows/netscan.py
+++ b/volatility/framework/plugins/windows/netscan.py
@@ -4,10 +4,9 @@
 
 import logging
 import datetime
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 from volatility.framework import constants, exceptions, interfaces, renderers, symbols, layers
-from volatility.framework.automagic.pdbscan import scan
 from volatility.framework.configuration import requirements
 from volatility.framework.renderers import format_hints
 from volatility.framework.symbols import intermed
@@ -39,7 +38,7 @@ class NetScan(interfaces.plugins.PluginInterface):
         ]
 
     @staticmethod
-    def create_netscan_constraints(context, symbol_table: str) -> List[poolscanner.PoolConstraint]:
+    def create_netscan_constraints(context: interfaces.context.ContextInterface, symbol_table: str) -> List[poolscanner.PoolConstraint]:
         """Creates a list of Pool Tag Constraints for network objects.
 
         Args:
@@ -218,7 +217,7 @@ class NetScan(interfaces.plugins.PluginInterface):
             _constraint, mem_object, _header = result
             yield mem_object
 
-    def _generator(self, show_corrupt_results = None):
+    def _generator(self, show_corrupt_results: Optional[bool] = None):
         """ Generates the network objects for use in rendering. """
 
         netscan_symbol_table = self.create_netscan_symbol_table()

--- a/volatility/framework/plugins/windows/netscan.py
+++ b/volatility/framework/plugins/windows/netscan.py
@@ -1,0 +1,306 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import datetime
+from typing import Iterable, List
+
+from volatility.framework import constants, exceptions, interfaces, renderers, symbols, layers
+from volatility.framework.automagic.pdbscan import scan
+from volatility.framework.configuration import requirements
+from volatility.framework.renderers import format_hints
+from volatility.framework.symbols import intermed
+from volatility.framework.symbols.windows.extensions import network
+from volatility.plugins import timeliner
+from volatility.plugins.windows import poolscanner
+
+vollog = logging.getLogger(__name__)
+
+class NetScan(interfaces.plugins.PluginInterface):
+    """Scans for network objects present in a particular windows memory image."""
+
+    _version = (1, 0, 0)
+    CORRUPT_DEFAULT = False
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.TranslationLayerRequirement(name = 'primary',
+                                                     description = 'Memory layer for the kernel',
+                                                     architectures = ["Intel32", "Intel64"]),
+            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.PluginRequirement(name = 'poolscanner', plugin = poolscanner.PoolScanner, version = (1, 0, 0)),
+            requirements.BooleanRequirement(name = 'include-corrupt',
+                description = "Radically eases result validation. This will show partially overwritten data. WARNING: the results are likely to include garbage and/or corrupt data. Be cautious!",
+                default = cls.CORRUPT_DEFAULT,
+                optional = True
+            ),
+        ]
+
+    @staticmethod
+    def create_netscan_constraints(context, symbol_table: str) -> List[poolscanner.PoolConstraint]:
+        """Creates a list of Pool Tag Constraints for network objects.
+
+        Args:
+            context: The context to retrieve required elements (layers, symbol tables) from
+            symbol_table: The name of an existing symbol table containing the symbols / types
+
+        Returns:
+            The list containing the built constraints.
+        """
+
+        tcpl_size = context.symbol_space.get_type(symbol_table + constants.BANG + "_TCP_LISTENER").size
+        tcpe_size = context.symbol_space.get_type(symbol_table + constants.BANG + "_TCP_ENDPOINT").size
+        udpa_size = context.symbol_space.get_type(symbol_table + constants.BANG + "_UDP_ENDPOINT").size
+
+        # ~ vollog.debug("Using pool size constraints: TcpL {}, TcpE {}, UdpA {}".format(tcpl_size, tcpe_size, udpa_size))
+
+        return [
+            # TCP listener
+            poolscanner.PoolConstraint(b'TcpL',
+                                       type_name = symbol_table + constants.BANG + "_TCP_LISTENER",
+                                       size = (tcpl_size, None),
+                                       page_type = poolscanner.PoolType.NONPAGED | poolscanner.PoolType.FREE),
+            # TCP Endpoint
+            poolscanner.PoolConstraint(b'TcpE',
+                                       type_name = symbol_table + constants.BANG + "_TCP_ENDPOINT",
+                                       size = (tcpe_size, None),
+                                       page_type = poolscanner.PoolType.NONPAGED | poolscanner.PoolType.FREE),
+            # UDP Endpoint
+            poolscanner.PoolConstraint(b'UdpA',
+                                       type_name = symbol_table + constants.BANG + "_UDP_ENDPOINT",
+                                       size = (udpa_size, None),
+                                       page_type = poolscanner.PoolType.NONPAGED | poolscanner.PoolType.FREE)
+        ]
+
+    def determine_tcpip_version(self) -> str:
+        """Tries to determine which symbol filename to use for the image's tcpip driver. The logic is partially taken from the info plugin.
+
+        Args:
+
+        Returns:
+            The filename of the symbol table to use.
+        """
+
+        # while the failsafe way to determine the version of tcpip.sys would be to
+        # extract the driver and parse its PE header containing the versionstring,
+        # unfortunately that header is not guaranteed to persist within memory.
+        # therefore we determine the version based on the kernel version as testing
+        # with several windows versions has showed this to work out correctly.
+
+        is_64bit = symbols.symbol_table_is_64bit(self.context, self.config['nt_symbols'])
+
+        if is_64bit:
+            arch = "x64"
+        else:
+            arch = "x86"
+
+        # the following code is taken from the windows.info plugin.
+
+        virtual_layer_name = self.config["primary"]
+        virtual_layer = self.context.layers[virtual_layer_name]
+        if not isinstance(virtual_layer, layers.intel.Intel):
+            raise TypeError("Virtual Layer is not an intel layer")
+
+        kvo = virtual_layer.config["kernel_virtual_offset"]
+
+        ntkrnlmp = self.context.module(self.config["nt_symbols"], layer_name = virtual_layer_name, offset = kvo)
+
+        vers_offset = ntkrnlmp.get_symbol("KdVersionBlock").address
+
+        vers = ntkrnlmp.object(object_type = "_DBGKD_GET_VERSION64",
+                               layer_name = virtual_layer_name,
+                               offset = vers_offset)
+
+        vollog.debug("Determined OS Major/Minor Version: {}.{}".format(vers.MajorVersion, vers.MinorVersion))
+
+        vers_minor_version = int(vers.MinorVersion)
+
+        # this is a hard-coded address in the Windows OS
+        if virtual_layer.bits_per_register == 32:
+            kuser_addr = 0xFFDF0000
+        else:
+            kuser_addr = 0xFFFFF78000000000
+
+        kuser = ntkrnlmp.object(object_type = "_KUSER_SHARED_DATA",
+                                layer_name = virtual_layer_name,
+                                offset = kuser_addr,
+                                absolute = True)
+
+        nt_major_version = str(kuser.NtMajorVersion)
+        nt_minor_version = str(kuser.NtMinorVersion)
+
+        # default to general class types, may be overwritten later.
+        class_types = network.class_types
+        if nt_major_version == "10":
+            if arch == "x64":
+                # win10 x64 has an additional class type we have to include.
+                class_types = network.win10_x64_class_types
+
+            if vers_minor_version < 14393:
+                # all win10 below 14393 have the same structs for our needs.
+                filename = "netscan-win10-{arch}".format(arch=arch)
+            elif vers_minor_version < 15063:
+                if arch == "x64":
+                    filename = "netscan-win10-x64"
+                else:
+                    # 14393 x86 is special.
+                    filename = "netscan-win10-14393-x86"
+            else:
+                # for now all newer windows versions share the same structs.
+                filename = "netscan-win10-15063-{arch}".format(arch=arch)
+
+        elif nt_major_version == "6":
+            # win between vista and 8.1
+            if nt_minor_version == "0":
+                # vista
+                # if vista sp 12 x64 then:
+                # filename = "netscan-vista-sp12-x64"
+                filename = "netscan-vista-{arch}".format(arch=arch)
+            elif nt_minor_version == "1":
+                # 7
+                filename = "netscan-win7-{arch}".format(arch=arch)
+            elif nt_minor_version == "2":
+                # 8
+                filename = "netscan-win8-{arch}".format(arch=arch)
+            elif nt_minor_version == "3":
+                # 8.1
+                filename = "netscan-win81-{arch}".format(arch=arch)
+        else:
+            # default to a fallback, but this *should* not happen.
+            filename = "netscan-win{vers}-{arch}".format(vers=major_version, arch=arch)
+
+        vollog.debug("Determined symbol filename: {}".format(filename))
+
+        return filename, class_types
+
+    def create_netscan_symbol_table(self) -> str:
+        """Creates a symbol table for TCP Listeners and TCP/UDP Endpoints.
+
+        Returns:
+            The name of the constructed symbol table
+        """
+        table_mapping = {"nt_symbols": self.config["nt_symbols"]}
+
+        symbol_filename, class_types = self.determine_tcpip_version()
+
+        return intermed.IntermediateSymbolTable.create(self.context,
+                                                       self.config_path,
+                                                       "windows",
+                                                       symbol_filename,
+                                                       class_types = class_types,
+                                                       table_mapping = table_mapping)
+
+    @classmethod
+    def scan(cls,
+             context: interfaces.context.ContextInterface,
+             layer_name: str,
+             nt_symbol_table: str,
+             netscan_symbol_table: str) -> \
+        Iterable[interfaces.objects.ObjectInterface]:
+        """Scans for network objects using the poolscanner module and constraints.
+
+        Args:
+            context: The context to retrieve required elements (layers, symbol tables) from
+            layer_name: The name of the layer on which to operate
+            nt_symbol_table: The name of the table containing the kernel symbols
+            netscan_symbol_table: The name of the table containing the network object symbols (_TCP_LISTENER etc.)
+
+        Returns:
+            A list of network objects found by scanning the `layer_name` layer for network pool signatures
+        """
+
+        constraints = cls.create_netscan_constraints(context, netscan_symbol_table)
+
+        for result in poolscanner.PoolScanner.generate_pool_scan(context, layer_name, nt_symbol_table, constraints):
+
+            _constraint, mem_object, _header = result
+            yield mem_object
+
+    def _generator(self, show_corrupt_results = None):
+        """ Generates the network objects for use in rendering. """
+
+        netscan_symbol_table = self.create_netscan_symbol_table()
+
+        for netw_obj in self.scan(self.context, self.config['primary'], self.config['nt_symbols'],
+                                  netscan_symbol_table):
+
+            vollog.debug("Found netw obj @ 0x{:2x} of assumed type {}".format(netw_obj.vol.offset, type(netw_obj)))
+            # objects passed pool header constraints. check for additional constraints if strict flag is set.
+            if not show_corrupt_results:
+                if not netw_obj.is_valid():
+                    continue
+
+            if isinstance(netw_obj, network._UDP_ENDPOINT):
+                vollog.debug("Found UDP_ENDPOINT @ 0x{:2x}".format(netw_obj.vol.offset))
+
+                # For UdpA, the state is always blank and the remote end is asterisks
+                for ver, laddr, _ in netw_obj.dual_stack_sockets():
+                    yield (0, (format_hints.Hex(netw_obj.vol.offset),
+                               "UDP" + ver,
+                               laddr,
+                               netw_obj.Port,
+                               "*", 0, "",
+                               netw_obj.get_owner_pid() or renderers.UnreadableValue(),
+                               netw_obj.get_owner_procname() or renderers.UnreadableValue(),
+                               netw_obj.get_create_time() or renderers.UnreadableValue()))
+
+            elif isinstance(netw_obj, network._TCP_ENDPOINT):
+                vollog.debug("Found _TCP_ENDPOINT @ 0x{:2x}".format(netw_obj.vol.offset))
+                if netw_obj.get_address_family() == network.AF_INET:
+                    proto = "TCPv4"
+                elif netw_obj.get_address_family() == network.AF_INET6:
+                    proto = "TCPv6"
+                else:
+                    proto = "TCPv?"
+
+                if netw_obj.State in network.TCP_STATE_ENUM:
+                    state = network.TCP_STATE_ENUM[netw_obj.State]
+                else:
+                    state = renderers.UnreadableValue()
+
+                yield (0, (format_hints.Hex(netw_obj.vol.offset), proto,
+                           netw_obj.get_local_address() or renderers.UnreadableValue(),
+                           netw_obj.LocalPort,
+                           netw_obj.get_remote_address() or renderers.UnreadableValue(),
+                           netw_obj.RemotePort,
+                           state,
+                           netw_obj.get_owner_pid() or renderers.UnreadableValue(),
+                           netw_obj.get_owner_procname() or renderers.UnreadableValue(),
+                           netw_obj.get_create_time() or renderers.UnreadableValue()))
+
+            # check for isinstance of tcp listener last, because all other objects are inherited from here
+            elif isinstance(netw_obj, network._TCP_LISTENER):
+                vollog.debug("Found _TCP_LISTENER @ 0x{:2x}".format(netw_obj.vol.offset))
+
+                # For TcpL, the state is always listening and the remote port is zero
+                for ver, laddr, raddr in netw_obj.dual_stack_sockets():
+                    yield (0, (format_hints.Hex(netw_obj.vol.offset), "TCP" + ver,
+                               laddr,
+                               netw_obj.Port,
+                               raddr,
+                               0,
+                               "LISTENING",
+                               netw_obj.get_owner_pid() or renderers.UnreadableValue(),
+                               netw_obj.get_owner_procname() or renderers.UnreadableValue(),
+                               netw_obj.get_create_time() or renderers.UnreadableValue()))
+            else:
+                # this should not happen therefore we log it.
+                vollog.debug("Found network object unsure of its type: {} of type {}".format(netw_obj, type(netw_obj)))
+
+    def run(self):
+        show_corrupt_results = self.config.get('include-corrupt', None)
+
+        return renderers.TreeGrid([
+            ("Offset", format_hints.Hex),
+            ("Proto", str),
+            ("LocalAddr", str),
+            ("LocalPort", int),
+            ("ForeignAddr", str),
+            ("ForeignPort", int),
+            ("State", str),
+            ("PID", int),
+            ("Owner", str),
+            ("Created", datetime.datetime),
+        ], self._generator(show_corrupt_results=show_corrupt_results))

--- a/volatility/framework/plugins/windows/netscan.py
+++ b/volatility/framework/plugins/windows/netscan.py
@@ -245,6 +245,8 @@ class NetScan(interfaces.plugins.PluginInterface):
                                                                 self.config["nt_symbols"],
                                                                 self.config_path)
 
+        tcp_states = self.context.symbol_space.get_enumeration(netscan_symbol_table + constants.BANG + "TCPStateEnum")
+
         for netw_obj in self.scan(self.context, self.config['primary'], self.config['nt_symbols'],
                                   netscan_symbol_table):
 
@@ -277,9 +279,9 @@ class NetScan(interfaces.plugins.PluginInterface):
                 else:
                     proto = "TCPv?"
 
-                if netw_obj.State in network.TCP_STATE_ENUM:
-                    state = network.TCP_STATE_ENUM[netw_obj.State]
-                else:
+                try:
+                    state = tcp_states.lookup(netw_obj.State)
+                except ValueError:
                     state = renderers.UnreadableValue()
 
                 yield (0, (format_hints.Hex(netw_obj.vol.offset), proto,

--- a/volatility/framework/plugins/windows/poolscanner.py
+++ b/volatility/framework/plugins/windows/poolscanner.py
@@ -375,7 +375,8 @@ class PoolScanner(plugins.PluginInterface):
             mem_object = header.get_object(type_name = constraint.type_name,
                                            use_top_down = is_windows_8_or_later,
                                            executive = constraint.object_type is not None,
-                                           native_layer_name = 'primary')
+                                           native_layer_name = 'primary',
+                                           kernel_symbol_table = symbol_table)
 
             if mem_object is None:
                 vollog.log(constants.LOGLEVEL_VVV, "Cannot create an instance of {}".format(constraint.type_name))

--- a/volatility/framework/plugins/windows/poolscanner.py
+++ b/volatility/framework/plugins/windows/poolscanner.py
@@ -182,6 +182,7 @@ class PoolScanner(plugins.PluginInterface):
     """A generic pool scanner plugin."""
 
     _version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility/framework/symbols/windows/extensions/network.py
+++ b/volatility/framework/symbols/windows/extensions/network.py
@@ -1,0 +1,297 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import enum
+import itertools
+import logging
+import socket
+
+from volatility.framework import objects, interfaces, exceptions
+from volatility.framework import exceptions
+from volatility.framework.objects import Array
+from volatility.framework.renderers import conversion
+from volatility.framework.symbols.wrappers import Flags
+from volatility.framework import renderers
+from typing import Dict, Tuple
+
+vollog = logging.getLogger(__name__)
+
+def inet_ntop(address_family: int, packed_ip: Array) -> str:
+
+    def inet_ntop4(packed_ip: Array) -> str:
+
+        if not (isinstance(packed_ip, list) or isinstance(packed_ip, Array)):
+            raise TypeError("must be Array, not {0}".format(type(packed_ip)))
+        if len(packed_ip) != 4:
+            raise ValueError("invalid length of packed IP address string")
+        return "{0}.{1}.{2}.{3}".format(*[x.to_bytes(1, "little")[0] for x in packed_ip])
+
+    def inet_ntop6(packed_ip) -> str:
+        if not (isinstance(packed_ip, list) or isinstance(packed_ip, Array)):
+            raise TypeError("must be Array, not {0}".format(type(packed_ip)))
+
+        if len(packed_ip) != 16:
+            raise ValueError("invalid length of packed IP address string")
+
+        words = []
+        for i in range(0, 16, 2):
+            words.append((packed_ip[i] << 8) | packed_ip[i + 1])
+
+        # Replace a run of 0x00s with None
+        numlen = [(k, len(list(g))) for k, g in itertools.groupby(words)]
+        max_zero_run = sorted(sorted(numlen, key = lambda x: x[1], reverse = True), key = lambda x: x[0])[0]
+        words = []
+        for k, l in numlen:
+            if (k == 0) and (l == max_zero_run[1]) and not (None in words):
+                words.append(None)
+            else:
+                for i in range(l):
+                    words.append(k)
+
+        # Handle encapsulated IPv4 addresses
+        encapsulated = ""
+        if (words[0] is None) and (len(words) == 3 or (len(words) == 4 and words[1] == 0xffff)):
+            words = words[:-2]
+            encapsulated = inet_ntop4(packed_ip[-4:])
+        # If we start or end with None, then add an additional :
+        if words[0] is None:
+            words = [None] + words
+        if words[-1] is None:
+            words += [None]
+        # Join up everything we've got using :s
+        return ":".join(["{0:x}".format(w) if w is not None else "" for w in words]) + encapsulated
+
+    if address_family == socket.AF_INET:
+        return inet_ntop4(packed_ip)
+    elif address_family == socket.AF_INET6:
+        return inet_ntop6(packed_ip)
+    raise socket.error("[Errno 97] Address family not supported by protocol")
+
+# Python's socket.AF_INET6 is 0x1e but Microsoft defines it
+# as a constant value of 0x17 in their source code. Thus we
+# need Microsoft's since that's what is found in memory.
+AF_INET = 2
+AF_INET6 = 0x17
+
+# String representations of INADDR_ANY and INADDR6_ANY
+inaddr_any = inet_ntop(socket.AF_INET, [0] * 4)
+inaddr6_any = inet_ntop(socket.AF_INET6, [0] * 16)
+
+# copied to here as symbol space does not appear to support custom Enums
+TCP_STATE_ENUM = {
+    0: 'CLOSED',
+    1: 'LISTENING',
+    2: 'SYN_SENT',
+    3: 'SYN_RCVD',
+    4: 'ESTABLISHED',
+    5: 'FIN_WAIT1',
+    6: 'FIN_WAIT2',
+    7: 'CLOSE_WAIT',
+    8: 'CLOSING',
+    9: 'LAST_ACK',
+    12: 'TIME_WAIT',
+    13: 'DELETE_TCB'
+}
+
+class _TCP_LISTENER(objects.StructType):
+    """Class for objects found in TcpL pools.
+
+    This class serves as a base class for all pooled network objects.
+
+    It exposes some functions which return sanity-checked members. Substructures referred to by a
+    pointer may appear valid at first glance but will throw an InvalidAddressException on access.
+
+    This is not a problem when objects are validated via their `is_valid()` method, but when
+    scanning for semi-corrupted data this check will not be performed.
+
+    Be mindful that most of those methods return `None` when they would access invalid data.
+    If you want to process the raw data access the attributes directly, e.g.
+    via `network_object.InetAF` instead of `network_object.get_address_family()`.
+
+    """
+
+    def __init__(self, context: interfaces.context.ContextInterface, type_name: str,
+                 object_info: interfaces.objects.ObjectInformation, size: int,
+                 members: Dict[str, Tuple[int, interfaces.objects.Template]]) -> None:
+
+        super().__init__(context = context,
+                         type_name = type_name,
+                         object_info = object_info,
+                         size = size,
+                         members = members)
+
+    def get_address_family(self):
+        try:
+            return self.InetAF.dereference().AddressFamily
+
+        except exceptions.InvalidAddressException:
+            return None
+
+    def get_owner(self):
+        try:
+            return self.member('Owner').dereference()
+
+        except exceptions.InvalidAddressException:
+            return None
+
+    def get_owner_pid(self):
+        try:
+            if self.get_owner().is_valid():
+                return self.get_owner().UniqueProcessId
+            else:
+                return None
+
+        except exceptions.InvalidAddressException:
+            return None
+
+    def get_owner_procname(self):
+        try:
+            if self.get_owner().is_valid():
+                return self.get_owner().ImageFileName.cast(
+                        "string", max_length = self.get_owner().ImageFileName.vol.count, errors = "replace")
+            else:
+                return None
+
+        except exceptions.InvalidAddressException:
+            return None
+
+    def get_create_time(self):
+        dt_obj = conversion.wintime_to_datetime(self.CreateTime.QuadPart)
+
+        if isinstance(dt_obj, interfaces.renderers.BaseAbsentValue):
+            return dt_obj
+
+        # return None if the timestamp seems invalid
+        if dt_obj.year < 1950 or dt_obj.year > 2200:
+            return None
+        else:
+            return dt_obj
+
+    def get_in_addr(self):
+        try:
+            local_addr = self.LocalAddr.dereference()
+
+            if local_addr.pData.dereference():
+                inaddr = local_addr.inaddr
+                return inaddr
+            else:
+                return None
+
+        except exceptions.InvalidAddressException:
+            return None
+
+    def dual_stack_sockets(self):
+        """Handle Windows dual-stack sockets"""
+
+        # If this pointer is valid, the socket is bound to
+        # a specific IP address. Otherwise, the socket is
+        # listening on all IP addresses of the address family.
+
+        # Note the remote address is always INADDR_ANY or
+        # INADDR6_ANY for sockets. The moment a client
+        # connects to the listener, a TCP_ENDPOINT is created
+        # and that structure contains the remote address.
+
+        inaddr = self.get_in_addr()
+
+        if inaddr:
+            if self.get_address_family() == AF_INET:
+                yield "v4", inet_ntop(socket.AF_INET, inaddr.addr4), inaddr_any
+            elif self.get_address_family() == AF_INET6:
+                yield "v6", inet_ntop(socket.AF_INET6, inaddr.addr6), inaddr6_any
+        else:
+            yield "v4", inaddr_any, inaddr_any
+            if self.get_address_family() == AF_INET6:
+                yield "v6", inaddr6_any, inaddr6_any
+
+    def is_valid(self):
+
+        try:
+            if not self.get_address_family() in (AF_INET, AF_INET6):
+                return False
+
+        except exceptions.InvalidAddressException:
+            return False
+        return True
+
+class _TCP_ENDPOINT(_TCP_LISTENER):
+    """Class for objects found in TcpE pools"""
+
+    def _ipv4_or_ipv6(self, inaddr):
+
+        if self.get_address_family() == AF_INET:
+            return inet_ntop(socket.AF_INET, inaddr.addr4)
+        else:
+            return inet_ntop(socket.AF_INET6, inaddr.addr6)
+
+    def get_local_address(self):
+        try:
+            inaddr = self.AddrInfo.dereference().Local.\
+                                pData.dereference().dereference()
+
+            return self._ipv4_or_ipv6(inaddr)
+
+        except exceptions.InvalidAddressException:
+            return None
+
+    def get_remote_address(self):
+        try:
+            inaddr = self.AddrInfo.dereference().\
+                                Remote.dereference()
+
+            return self._ipv4_or_ipv6(inaddr)
+
+        except exceptions.InvalidAddressException:
+            return None
+
+    def is_valid(self):
+
+        if self.State not in TCP_STATE_ENUM:
+            vollog.debug("invalid due to invalid tcp state {}".format(self.State))
+            return False
+
+        try:
+            if self.get_address_family() not in (AF_INET, AF_INET6):
+                vollog.debug("invalid due to invalid address_family {}".format(self.get_address_family()))
+                return False
+
+            if not self.get_local_address() and (not self.get_owner() or self.get_owner().UniqueProcessId == 0 or self.get_owner().UniqueProcessId > 65535):
+                vollog.debug("invalid due to invalid owner data")
+                return False
+
+        except exceptions.InvalidAddressException:
+            vollog.debug("invalid due to invalid address access")
+            return False
+
+        return True
+
+class _UDP_ENDPOINT(_TCP_LISTENER):
+    """Class for objects found in UdpA pools"""
+
+class _LOCAL_ADDRESS(objects.StructType):
+
+    @property
+    def inaddr(self):
+        return self.pData.dereference().dereference()
+
+class _LOCAL_ADDRESS_WIN10_UDP(objects.StructType):
+
+    @property
+    def inaddr(self):
+        return self.pData.dereference()
+
+win10_x64_class_types = {
+    '_TCP_ENDPOINT': _TCP_ENDPOINT,
+    '_TCP_LISTENER': _TCP_LISTENER,
+    '_UDP_ENDPOINT': _UDP_ENDPOINT,
+    '_LOCAL_ADDRESS': _LOCAL_ADDRESS,
+    '_LOCAL_ADDRESS_WIN10_UDP': _LOCAL_ADDRESS_WIN10_UDP
+}
+
+class_types = {
+    '_TCP_ENDPOINT': _TCP_ENDPOINT,
+    '_TCP_LISTENER': _TCP_LISTENER,
+    '_UDP_ENDPOINT': _UDP_ENDPOINT,
+    '_LOCAL_ADDRESS': _LOCAL_ADDRESS
+}

--- a/volatility/framework/symbols/windows/extensions/network.py
+++ b/volatility/framework/symbols/windows/extensions/network.py
@@ -78,22 +78,6 @@ AF_INET6 = 0x17
 inaddr_any = inet_ntop(socket.AF_INET, [0] * 4)
 inaddr6_any = inet_ntop(socket.AF_INET6, [0] * 16)
 
-# copied to here as symbol space does not appear to support custom Enums
-TCP_STATE_ENUM = {
-    0: 'CLOSED',
-    1: 'LISTENING',
-    2: 'SYN_SENT',
-    3: 'SYN_RCVD',
-    4: 'ESTABLISHED',
-    5: 'FIN_WAIT1',
-    6: 'FIN_WAIT2',
-    7: 'CLOSE_WAIT',
-    8: 'CLOSING',
-    9: 'LAST_ACK',
-    12: 'TIME_WAIT',
-    13: 'DELETE_TCB'
-}
-
 class _TCP_LISTENER(objects.StructType):
     """Class for objects found in TcpL pools.
 
@@ -247,7 +231,7 @@ class _TCP_ENDPOINT(_TCP_LISTENER):
 
     def is_valid(self):
 
-        if self.State not in TCP_STATE_ENUM:
+        if self.State not in self.State.choices.values():
             vollog.debug("invalid due to invalid tcp state {}".format(self.State))
             return False
 

--- a/volatility/framework/symbols/windows/extensions/pool.py
+++ b/volatility/framework/symbols/windows/extensions/pool.py
@@ -17,6 +17,7 @@ class POOL_HEADER(objects.StructType):
                    type_name: str,
                    use_top_down: bool,
                    executive: bool = False,
+                   kernel_symbol_table: Optional[str] = None,
                    native_layer_name: Optional[str] = None) -> Optional[interfaces.objects.ObjectInterface]:
         """Carve an object or data structure from a kernel pool allocation
 
@@ -24,6 +25,7 @@ class POOL_HEADER(objects.StructType):
             type_name: the data structure type name
             native_layer_name: the name of the layer where the data originally lived
             object_type: the object type (executive kernel objects only)
+            kernel_symbol_table: in case objects of a different symbol table are scanned for
 
         Returns:
             An object as found from a POOL_HEADER
@@ -33,7 +35,16 @@ class POOL_HEADER(objects.StructType):
         if constants.BANG in type_name:
             symbol_table_name, type_name = type_name.split(constants.BANG)[0:2]
 
-        object_header_type = self._context.symbol_space.get_type(symbol_table_name + constants.BANG + "_OBJECT_HEADER")
+        # when checking for symbols from a table other than nt_symbols grab _OBJECT_HEADER from the kernel
+        # because symbol_table_name will be different from kernel_symbol_table.
+        if kernel_symbol_table:
+            object_header_type = self._context.symbol_space.get_type(kernel_symbol_table + constants.BANG +
+                                                                 "_OBJECT_HEADER")
+        else:
+            # otherwise symbol_table_name *is* the kernel symbol table, so just use that.
+            object_header_type = self._context.symbol_space.get_type(symbol_table_name + constants.BANG +
+                                                                 "_OBJECT_HEADER")
+
         pool_header_size = self.vol.size
 
         # if there is no object type, then just instantiate a structure

--- a/volatility/framework/symbols/windows/netscan-vista-sp12-x64.json
+++ b/volatility/framework/symbols/windows/netscan-vista-sp12-x64.json
@@ -1,0 +1,536 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 16,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 48,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 100,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 102,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 80,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 104
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 48,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 50,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 72
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 88,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 128,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 130
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 88,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 106,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 108
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 528,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 40,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 84,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 86,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 80,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 536
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 20,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 22
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-06-12T14:00:00"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-vista-x64.json
+++ b/volatility/framework/symbols/windows/netscan-vista-x64.json
@@ -1,0 +1,536 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 16,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 48,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 100,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 102,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 80,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 104
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 48,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 50,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 72
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 88,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 128,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 130
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 88,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 106,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 108
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 520,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 40,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 84,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 86,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 80,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 528
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 20,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 22
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-06-12T14:00:00"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-vista-x86.json
+++ b/volatility/framework/symbols/windows/netscan-vista-x86.json
@@ -1,0 +1,537 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 8,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 28,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 28,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 30,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 36,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 352,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 16,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 44,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 46,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 40,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 356
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 12
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 12,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win10-14393-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-14393-x86.json
@@ -1,0 +1,535 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 8,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 28,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 28,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 30,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 36,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 436,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 8,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 56,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 440
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 12,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win10-15063-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-15063-x64.json
@@ -1,0 +1,388 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+      "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 88,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 128,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 120,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 132
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 48,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 64,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 116
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 624,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 616,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "AddrInfo": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 16,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 112,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 108,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 632
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 24,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 26
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win10-15063-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-15063-x86.json
@@ -1,0 +1,535 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 8,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 28,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 28,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 30,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 36,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 460,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 8,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 56,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 464
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 12,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win10-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-x64.json
@@ -1,0 +1,389 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+      "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 88,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 128,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 120,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 132
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 48,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 64,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 116
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 600,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 616,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "AddrInfo": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 16,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 112,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 108,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 624
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 24,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 26
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-06-12T11:00:00"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win10-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-x86.json
@@ -1,0 +1,535 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 8,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 28,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 28,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 30,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 36,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 432,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 8,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 56,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 436
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 12,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win7-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win7-x64.json
@@ -1,0 +1,535 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 88,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 16,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 72,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 124,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 126,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 80,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 104,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 48,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 74,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 80,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 88,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 96
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 88,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 128,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 130
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 88,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 106,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 108
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 568,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 40,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 108,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 110,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 104,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 576
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 20,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 22
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-06-12T14:00:00"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win7-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win7-x86.json
@@ -1,0 +1,536 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 44,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 8,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 36,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 74,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 52,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 76
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 40,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 42,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 44,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 48,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 52
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 372,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 16,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 56,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 58,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 52,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 376
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 12
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 12,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win8-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win8-x64.json
@@ -1,0 +1,536 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 16,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 48,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 100,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 102,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 80,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 104
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 48,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 50,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 72
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 88,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 128,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 130
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 88,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 106,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 108
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 592,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 40,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 16,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 112,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 108,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 600
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 24,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 26
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-06-12T14:00:00"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win8-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win8-x86.json
@@ -1,0 +1,537 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 8,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 28,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 28,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 30,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 36,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 372,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 8,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 56,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 376
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 12,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win81-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win81-x64.json
@@ -1,0 +1,536 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 16,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 48,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 100,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 102,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 80,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 104
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 48,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 50,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 64,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 72
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 88,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 128,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 130
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 88,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 96,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 106,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 108
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 600,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 40,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 16,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 112,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 108,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 608
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 24,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 26
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-06-12T14:00:00"
+    },
+    "format": "6.0.0"
+  }
+}

--- a/volatility/framework/symbols/windows/netscan-win81-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win81-x86.json
@@ -1,0 +1,537 @@
+{
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned be short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "big"
+        },
+        "long long": {
+          "endian": "little",
+          "kind": "int",
+          "signed": true,
+          "size": 8
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+  "symbols": {},
+  "user_types": {
+    "_TCP_SYN_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_SYN_OWNER"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 8,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 24,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 28,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 28,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 30,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 36,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 72,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 424,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 8,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "State": {
+                "offset": 56,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 428
+    },
+    "_LOCAL_ADDRESS": {
+        "fields": {
+            "pData": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_IN_ADDR"
+                        }
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_ADDRINFO": {
+        "fields": {
+            "Local": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "Remote": {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_IN_ADDR": {
+        "fields": {
+            "addr4": {
+                "offset": 0,
+                "type": {
+                    "count": 4,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            },
+            "addr6": {
+                "offset": 0,
+                "type": {
+                    "count": 16,
+                    "subtype": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "kind": "array"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6
+    },
+    "_INETAF": {
+        "fields": {
+            "AddressFamily": {
+                "offset": 12,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_SYN_OWNER": {
+        "fields": {
+            "Process": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 14
+    },
+    "_LARGE_INTEGER": {
+      "fields": {
+        "HighPart": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "long"
+          }
+        },
+        "LowPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "QuadPart": {
+          "offset": 0,
+          "type": {
+            "kind": "base",
+            "name": "long long"
+          }
+        },
+        "u": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "__unnamed_2"
+          }
+        }
+      },
+      "kind": "union",
+      "size": 8
+    }
+  },
+  "enums": {
+    "TCPStateEnum": {
+        "base": "long",
+        "constants": {
+            "CLOSED": 0,
+            "LISTENING": 1,
+            "SYN_SENT": 2,
+            "SYN_RCVD": 3,
+            "ESTABLISHED": 4,
+            "FIN_WAIT1": 5,
+            "FIN_WAIT2": 6,
+            "CLOSE_WAIT": 7,
+            "CLOSING": 8,
+            "LAST_ACK": 9,
+            "TIME_WAIT": 12,
+            "DELETE_TCB": 13
+        },
+        "size": 4
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "japhlange-by-hand",
+      "datetime": "2020-05-29T19:28:34"
+    },
+    "format": "6.0.0"
+  }
+}


### PR DESCRIPTION
Adds netscan to vol3, currently only for Win10x64_15063.

Open questions:
- is this way of adding object structures (netscan.json) OK? How best to handle different versions? With several JSONs like with https://github.com/volatilityfoundation/volatility3/blob/master/volatility/framework/symbols/windows/services-win10-16299-x64.json etc.?
- PoolType conditional check in PoolHeaderScanner.\_\_call\_\_()  checks the tag to be odd. Doesn't work for objects with Pooltag 2 (NONPAGED) as 2%2 == 0.
                        `elif (constraint.page_type & PoolType.NONPAGED) and header.PoolType % 2 == 1:`

I've also noticed two issues which appear to be independent of this plugin as they also appear e.g. in PSScan:
- the output layout appears to be broken 
- the performance (calculation time) is worse than it was in vol2