### PR TITLE
Removal of UnicodeDecodeError from psaux.py

### DIFF
--- a/volatility/framework/plugins/mac/psaux.py
+++ b/volatility/framework/plugins/mac/psaux.py
@@ -80,8 +80,11 @@ class Psaux(plugins.PluginInterface):
                     args.append(arg)
 
                 argc = argc - 1
-
-            args_str = " ".join([s.decode("utf-8") for s in args])
+                
+            try:
+                args_str = " ".join([s.decode("utf-8") for s in args])
+            except:
+                pass
 
             yield (0, (task.p_pid, task_name, task.p_argc, args_str))
 


### PR DESCRIPTION
During testing my sample, I came across UnicodeDecodeError and the processing of next PID'S in my sample halted(as error handling was not present here), thus I propose a small patch that'll allow processing of next PID's even if UnicodeDecodeError is seen. This will ensure complete output to the end user.