### PR TITLE
Has valid member

### DIFF
--- a/volatility/framework/constants/__init__.py
+++ b/volatility/framework/constants/__init__.py
@@ -36,7 +36,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 1  # Number of releases of the library with a breaking change
-VERSION_MINOR = 0  # Number of changes that only add to the interface
+VERSION_MINOR = 1  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = "-beta.1"
 

--- a/volatility/framework/interfaces/objects.py
+++ b/volatility/framework/interfaces/objects.py
@@ -176,6 +176,32 @@ class ObjectInterface(metaclass = ABCMeta):
         """
         return False
 
+    def has_valid_member(self, member_name: str) -> bool:
+        """Returns whether the dereferenced type has a valid member."""
+        if self.has_member(member_name):
+            try:
+                _ = getattr(self, member_name)
+                return True
+            finally:
+                return False
+        return False
+
+    def has_valid_members(self, member_names: List[str]) -> bool:
+        """Returns whether the object has all of the members listed in member_names
+
+        Args:
+            member_names: List of names to test as to members with those names validity
+        """
+        # Use only a single try/except for efficiency
+        try:
+            for member_name in member_names:
+                if not self.has_member(member_name):
+                    return False
+                _ = getattr(self, member_name)
+            return True
+        finally:
+            return False
+
     class VolTemplateProxy(metaclass = abc.ABCMeta):
         """A container for proxied methods that the ObjectTemplate of this
         object will call.  This is primarily to keep methods together for easy

--- a/volatility/framework/interfaces/objects.py
+++ b/volatility/framework/interfaces/objects.py
@@ -6,7 +6,6 @@ interpreted values of data from a layer."""
 import abc
 import collections
 import collections.abc
-import contextlib
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Mapping, Optional
@@ -184,9 +183,12 @@ class ObjectInterface(metaclass = ABCMeta):
             member_name: Name of the member to test access to determine if the member is valid or not
         """
         if self.has_member(member_name):
-            with contextlib.suppress(Exception):
+            # noinspection PyBroadException
+            try:
                 _ = getattr(self, member_name)
                 return True
+            except Exception:
+                pass
         return False
 
     def has_valid_members(self, member_names: List[str]) -> bool:

--- a/volatility/framework/interfaces/objects.py
+++ b/volatility/framework/interfaces/objects.py
@@ -178,7 +178,11 @@ class ObjectInterface(metaclass = ABCMeta):
         return False
 
     def has_valid_member(self, member_name: str) -> bool:
-        """Returns whether the dereferenced type has a valid member."""
+        """Returns whether the dereferenced type has a valid member.
+
+        Args:
+            member_name: Name of the member to test access to determine if the member is valid or not
+        """
         if self.has_member(member_name):
             with contextlib.suppress(Exception):
                 _ = getattr(self, member_name)
@@ -191,14 +195,7 @@ class ObjectInterface(metaclass = ABCMeta):
         Args:
             member_names: List of names to test as to members with those names validity
         """
-        # Use catch a single error to short circuit failures quickly
-        with contextlib.suppress(Exception):
-            for member_name in member_names:
-                if not self.has_member(member_name):
-                    return False
-                _ = getattr(self, member_name)
-            return True
-        return False
+        return all([self.has_valid_member(member_name) for member_name in member_names])
 
     class VolTemplateProxy(metaclass = abc.ABCMeta):
         """A container for proxied methods that the ObjectTemplate of this

--- a/volatility/framework/interfaces/objects.py
+++ b/volatility/framework/interfaces/objects.py
@@ -6,6 +6,7 @@ interpreted values of data from a layer."""
 import abc
 import collections
 import collections.abc
+import contextlib
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Mapping, Optional
@@ -179,11 +180,9 @@ class ObjectInterface(metaclass = ABCMeta):
     def has_valid_member(self, member_name: str) -> bool:
         """Returns whether the dereferenced type has a valid member."""
         if self.has_member(member_name):
-            try:
+            with contextlib.suppress(Exception):
                 _ = getattr(self, member_name)
                 return True
-            finally:
-                return False
         return False
 
     def has_valid_members(self, member_names: List[str]) -> bool:
@@ -192,15 +191,14 @@ class ObjectInterface(metaclass = ABCMeta):
         Args:
             member_names: List of names to test as to members with those names validity
         """
-        # Use only a single try/except for efficiency
-        try:
+        # Use catch a single error to short circuit failures quickly
+        with contextlib.suppress(Exception):
             for member_name in member_names:
                 if not self.has_member(member_name):
                     return False
                 _ = getattr(self, member_name)
             return True
-        finally:
-            return False
+        return False
 
     class VolTemplateProxy(metaclass = abc.ABCMeta):
         """A container for proxied methods that the ObjectTemplate of this


### PR DESCRIPTION
Adds in the new `has_valid_member` capability, bumping the API for plugins that might use it.  All plugins should now have the `_required_framework_version` member, which should be set to a tuple of (1,1,0) for those that need to use this feature.