### PR TITLE
refs #200 raise AttributeError if an object header doesn't have a nam…

### DIFF
--- a/volatility/framework/plugins/windows/mutantscan.py
+++ b/volatility/framework/plugins/windows/mutantscan.py
@@ -52,7 +52,7 @@ class MutantScan(interfaces.plugins.PluginInterface):
 
             try:
                 name = mutant.get_name()
-            except exceptions.InvalidAddressException:
+            except (AttributeError, exceptions.InvalidAddressException):
                 name = renderers.NotApplicableValue()
 
             yield (0, (format_hints.Hex(mutant.vol.offset), name))

--- a/volatility/framework/symbols/windows/extensions/pool.py
+++ b/volatility/framework/symbols/windows/extensions/pool.py
@@ -252,6 +252,11 @@ class OBJECT_HEADER(objects.StructType):
                                                  layer_name = self.vol.native_layer_name,
                                                  offset = kvo + address + calculated_index)
 
+        if header_offset == 0:
+            raise AttributeError(
+                "Could not find _OBJECT_HEADER_NAME_INFO for object at {} of layer {}".format(self.vol.offset,
+                                                                                              self.vol.layer_name))
+
         header = self._context.object(symbol_table_name + constants.BANG + "_OBJECT_HEADER_NAME_INFO",
                                       layer_name = self.vol.layer_name,
                                       offset = self.vol.offset - header_offset,


### PR DESCRIPTION
…e struct

if we stick with this approach, several other plugins that reference NameInfo.Name (directly or downstream) will need to start catching AttributeError as well