### PR TITLE
Fix find_aslr() function invocation for Linux.

### DIFF
--- a/volatility/framework/automagic/linux.py
+++ b/volatility/framework/automagic/linux.py
@@ -302,4 +302,4 @@ class LinuxSymbolFinder(symbol_finder.SymbolFinder):
     banner_config_key = "kernel_banner"
     banner_cache = LinuxBannerCache
     symbol_class = "volatility.framework.symbols.linux.LinuxKernelIntermedSymbols"
-    find_aslr = lambda *args: LinuxUtilities.find_aslr(*args)[1]
+    find_aslr = lambda cls, *args: LinuxUtilities.find_aslr(*args)[1]


### PR DESCRIPTION
The commit a6cd344e223f8f306bd3c81ddec6acf53c6d8c62 broke ASLR shift determination for Linux. Due to the new call chain that eventually invokes `LinuxUtilities.find_aslr()`, this function receives two `cls` arguments, while it only expects one. All positional arguments are shifted by one: For example, the second erroneous `cls` argument ends up at the position of the `context` argument and therefore `LinuxUtilities.find_aslr()` fails. The first three arguments (`cls`, `context` and `symbol_table`) of `LinuxUtilities.find_aslr()` are:

```
<class 'volatility.framework.automagic.linux.LinuxUtilities'>
<volatility.framework.automagic.linux.LinuxSymbolFinder object at 0x7f30c53049d0>
<volatility.framework.contexts.Context object at 0x7f30c6a1ddf0>
```

I believe the root cause is the newly created lambda function which passes all of its arguments to `LinuxUtilities.find_aslr()` (including the erroneous `cls` argument): https://github.com/volatilityfoundation/volatility3/commit/a6cd344e223f8f306bd3c81ddec6acf53c6d8c62#diff-b9e88394bdfda33e588fa2dda4a2b989R305

This PR fixes the lambda function to remove the erroneous class argument (i.e. `<volatility.framework.automagic.linux.LinuxSymbolFinder object at 0x7f30c53049d0>`).

Below is the debug output for the error I am experiencing. If you go back one commit further, everything works as expected.

```
$ git show -s
commit a6cd344e223f8f306bd3c81ddec6acf53c6d8c62 (HEAD)
Author: Mike Auty <mike.auty@gmail.com>
Date:   Mon May 4 02:06:56 2020 +0100

    Automagic: Refactor ASLR finding for all symbol_finder using OSes
$ ./vol.py -vvvvv -f ~/[REDACTED].dump linux.lsmod.Lsmod
Volatility 3 Framework 1.0.0-beta.1
INFO     root        : Volatility plugins path: ['/home/[REDACTED]/volatility3/volatility/plugins', '/home/[REDACTED]/volatility3/volatility/framework/plugins']
INFO     root        : Volatility symbols path: ['/home/[REDACTED]/volatility3/volatility/symbols', '/home/[REDACTED]/volatility3/volatility/framework/symbols']
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.statistics
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.registry.certificates
DEBUG    volatility.framework: Importing module: volatility.plugins.yarascan
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module yarascan based on file: yarascan
DEBUG    volatility.framework: Importing module: volatility.plugins.frameworkinfo
DEBUG    volatility.framework: Importing module: volatility.plugins.layerwriter
DEBUG    volatility.framework: Importing module: volatility.plugins.configwriter
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.malfind
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.elfs
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.check_syscall
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.bash
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.proc
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.lsof
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.check_afinfo
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.lsmod
DEBUG    volatility.framework: Importing module: volatility.plugins.linux.pstree
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.proc_maps
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.malfind
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.netstat
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.check_syscall
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.bash
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.check_sysctl
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.timers
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.ifconfig
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.lsof
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.psaux
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.check_trap_table
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.pstree
DEBUG    volatility.framework: Importing module: volatility.plugins.mac.trustedbsd
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.malfind
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.mutantscan
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.info
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.svcscan
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module windows.svcscan based on file: windows/svcscan
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.psscan
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.driverirp
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.modscan
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.moddump
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.cmdline
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.strings
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.verinfo
INFO     volatility.plugins.windows.verinfo: Python pefile module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'pefile'
DEBUG    volatility.framework: Failed to import module windows.verinfo based on file: windows/verinfo
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.symlinkscan
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.virtmap
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.dlldump
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.pstree
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.filescan
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.procdump
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.dlllist
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.callbacks
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module windows.callbacks based on file: windows/callbacks
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.vaddump
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.vadyarascan
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module windows.vadyarascan based on file: windows/vadyarascan
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.registry.userassist
DEBUG    volatility.framework: Importing module: volatility.plugins.windows.registry.hivedump
INFO     root        : The following plugins could not be loaded (use -vv to see why): volatility.plugins.windows.callbacks, volatility.plugins.windows.svcscan, volatility.plugins.windows.vadyarascan, volatility.plugins.windows.verinfo, volatility.plugins.yarascan
DEBUG    volatility.framework: Importing module: volatility.framework.automagic.construct_layers
DEBUG    volatility.framework: Importing module: volatility.framework.automagic.pdbscan
DEBUG    volatility.framework: Importing module: volatility.framework.automagic.windows
DEBUG    volatility.framework: Importing module: volatility.framework.automagic.stacker
Level 7  root        : Cache directory used: /home/[REDACTED]/.cache/volatility3
INFO     volatility.framework.automagic: Detected a linux category plugin
INFO     volatility.framework.automagic: Running automagic: LinuxBannerCache
INFO     volatility.framework.automagic.symbol_cache: Building linux caches...
Level 7  volatility.framework.layers.resources: Available URL handlers: HTTPErrorProcessor, HTTPDefaultErrorHandler, HTTPRedirectHandler, ProxyHandler, HTTPBasicAuthHandler, ProxyBasicAuthHandler, HTTPDigestAuthHandler, ProxyDigestAuthHandler, AbstractHTTPHandler, HTTPHandler, HTTPSHandler, HTTPCookieProcessor, UnknownHandler, FileHandler, FTPHandler, CacheFTPHandler, DataHandler, JarHandler
INFO     volatility.framework.automagic: Running automagic: ConstructionMagic
DEBUG    volatility.framework: Importing module: volatility.framework.layers.lime
DEBUG    volatility.framework: Importing module: volatility.framework.layers.vmware
DEBUG    volatility.framework: Importing module: volatility.framework.layers.elf
DEBUG    volatility.framework: Importing module: volatility.framework.layers.crash
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.Lsmod.primary
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.Lsmod
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.Lsmod.vmlinux
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.Lsmod
INFO     volatility.framework.automagic: Running automagic: LayerStacker
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LimeStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using Elf64Stacker
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input
Level 8  volatility.framework.automagic.stacker: Stacked Elf64Layer using Elf64Stacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LimeStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WindowsCrashDump32Stacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using VmwareStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WintelStacker
DEBUG    volatility.framework.automagic.windows: Self-referential pointer not in well-known location, moving to recent windows heuristic
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LintelStacker
DEBUG    volatility.framework.automagic.linux: Identified banner: b'Linux version 4.15.0-106-generic (buildd@lcy01-amd64-016) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 (Ubuntu 4.15.0-106.107-generic 4.15.18)\n\x00'
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dma_coherent_mem
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!netns_ipvs
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mtd_info
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!s_pstats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dev_rcv_lists
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!s_stats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!nf_ct_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!nf_exp_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!xt_table
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mpls_route
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!nft_af_info
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!sctp_mib
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!ebt_table
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dn_dev
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!garp_port
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mpls_dev
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mrp_port
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!tipc_bearer
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!pcpu_dstats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!pcpu_vstats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_conn
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_cached_keys
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_cqm_config
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_internal_bss
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!phylink
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!libipw_device
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!assoc_array_ptr
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dn_route
DEBUG    volatility.framework.automagic.linux: Linux ASLR shift values determined: physical 2a200000 virtual 34800000
DEBUG    volatility.framework.automagic.linux: DTB was found at: 0x2c60a000
Level 8  volatility.framework.automagic.stacker: Stacked IntelLayer using LintelStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LimeStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WindowsCrashDump32Stacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using VmwareStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WintelStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using MacintelStacker
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary.memory_layer
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.Lsmod.primary.memory_layer.base_layer
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input
Level 9  volatility.framework.interfaces.configuration: TypeError - kernel_virtual_offset requirements only accept int type: None
Level 9  volatility.framework.interfaces.configuration: TypeError - kernel_virtual_offset requirements only accept int type: None
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.Lsmod.vmlinux
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.Lsmod
DEBUG    volatility.framework.automagic.stacker: Stacked layers: ['IntelLayer', 'Elf64Layer', 'FileLayer']
INFO     volatility.framework.automagic: Running automagic: LinuxSymbolFinder
Level 9  volatility.framework.configuration.requirements: TypeError - SymbolTableRequirement only accepts string labels: None
DEBUG    volatility.framework.automagic.symbol_finder: Identified banner: b'Linux version 4.15.0-106-generic (buildd@lcy01-amd64-016) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 (Ubuntu 4.15.0-106.107-generic 4.15.18)\n\x00'
DEBUG    volatility.framework.automagic.symbol_finder: Using symbol library: file:///home/[REDACTED]/volatility3/volatility/symbols/linux/linux-image-4.15.0-106-amd64.json.xz
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input

Offset	Name	Size
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dn_dev
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!garp_port
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mpls_dev
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mrp_port
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!tipc_bearer
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mtd_info
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dma_coherent_mem
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!pcpu_dstats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!pcpu_vstats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_conn
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_cached_keys
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_cqm_config
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_internal_bss
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!phylink
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!libipw_device
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!netns_ipvs
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!s_pstats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dev_rcv_lists
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!s_stats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!nf_ct_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!nf_exp_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!xt_table
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mpls_route
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!nft_af_info
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!sctp_mib
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!ebt_table
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!assoc_array_ptr
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dn_route


DEBUG    root        : Traceback (most recent call last):
  File "/home/[REDACTED]/volatility3/volatility/cli/__init__.py", line 292, in run
    renderers[args.renderer]().render(constructed.run())
  File "/home/[REDACTED]/volatility3/volatility/cli/text_renderer.py", line 163, in render
    grid.populate(visitor, outfd)
  File "/home/[REDACTED]/volatility3/volatility/framework/renderers/__init__.py", line 196, in populate
    for (level, item) in self._generator:
  File "/home/[REDACTED]/volatility3/volatility/framework/plugins/linux/lsmod.py", line 59, in _generator
    for module in self.list_modules(self.context, self.config['primary'], self.config['vmlinux']):
  File "/home/[REDACTED]/volatility3/volatility/framework/plugins/linux/lsmod.py", line 54, in list_modules
    for module in modules.to_list(table_name + constants.BANG + "module", "list"):
  File "/home/[REDACTED]/volatility3/volatility/framework/symbols/linux/extensions/__init__.py", line 293, in to_list
    link = getattr(self, direction).dereference()
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/__init__.py", line 707, in __getattr__
    member = template(context = self._context, object_info = object_info)
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/templates.py", line 72, in __call__
    return self.vol.object_class(context = context, object_info = object_info, **arguments)
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/__init__.py", line 120, in __new__
    value = cls._unmarshall(context, data_format, object_info)
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/__init__.py", line 304, in _unmarshall
    data = context.layers.read(object_info.layer_name, object_info.offset, length)
  File "/home/[REDACTED]/volatility3/volatility/framework/interfaces/layers.py", line 540, in read
    return self[layer].read(offset, length, pad)
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/linear.py", line 38, in read
    for (offset, _, mapped_offset, mapped_length, layer) in self.mapping(offset, length, ignore_errors = pad):
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/intel.py", line 197, in mapping
    chunk_offset, page_size, layer_name = self._translate(offset)
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/intel.py", line 99, in _translate
    entry, position = self._translate_entry(offset)
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/intel.py", line 124, in _translate_entry
    raise exceptions.PagedInvalidAddressException(self.name, offset, position + 1, entry,
volatility.framework.exceptions.PagedInvalidAddressException: Page Fault at entry 0x0 in table page table

Volatility was unable to read a requested page:
Page error 0xffff824ead30 in layer primary (Page Fault at entry 0x0 in table page table)

	* Memory smear during acquisition (try re-acquiring if possible)
	* An intentionally invalid page lookup (operating system protection)
	* A bug in the plugin/volatility (re-run with -vvv and file a bug)

No further results will be produced
```