### PR TITLE
Clear symbol cache after ASLR computation on Linux.

### DIFF
--- a/volatility/framework/automagic/symbol_finder.py
+++ b/volatility/framework/automagic/symbol_finder.py
@@ -127,6 +127,7 @@ class SymbolFinder(interfaces.automagic.AutomagicInterface):
                         raise TypeError("Layer name {} is not an intel space")
                     aslr_shift = self.find_aslr(context, unmasked_symbol_table_name, layer.config['memory_layer'])
                     context.config[path_join(config_path, requirement.name, "symbol_shift")] = aslr_shift
+                    context.symbol_space.clear_symbol_cache(unmasked_symbol_table_name)
 
                 break
             else:

--- a/volatility/framework/interfaces/symbols.py
+++ b/volatility/framework/interfaces/symbols.py
@@ -220,6 +220,11 @@ class SymbolSpaceInterface(collections.abc.Mapping):
         inserting a symbol table."""
 
     @abstractmethod
+    def clear_symbol_cache(self, table_name: str) -> None:
+        """Clears the symbol cache for the specified table name. If no table
+        name is specified, the caches of all symbol tables are cleared."""
+
+    @abstractmethod
     def get_symbols_by_type(self, type_name: str) -> Iterable[str]:
         """Returns all symbols based on the type of the symbol."""
 

--- a/volatility/framework/symbols/__init__.py
+++ b/volatility/framework/symbols/__init__.py
@@ -37,6 +37,17 @@ class SymbolSpace(interfaces.symbols.SymbolSpaceInterface):
         self._resolved = {}  # type: Dict[str, interfaces.objects.Template]
         self._resolved_symbols = {}  # type: Dict[str, interfaces.objects.Template]
 
+    def clear_symbol_cache(self, table_name: str = None) -> None:
+        """Clears the symbol cache for the specified table name. If no table
+        name is specified, the caches of all symbol tables are cleared."""
+        table_list = list()
+        if table_name is None:
+            table_list = self._dict.values()
+        else:
+            table_list.append(self._dict[table_name])
+        for table in table_list:
+            table.clear_symbol_cache()
+
     def free_table_name(self, prefix: str = "layer") -> str:
         """Returns an unused table name to ensure no collision occurs when
         inserting a symbol table."""

--- a/volatility/framework/symbols/intermed.py
+++ b/volatility/framework/symbols/intermed.py
@@ -157,6 +157,7 @@ class IntermediateSymbolTable(interfaces.symbols.SymbolTableInterface):
     types = _construct_delegate_function('types', True)
     enumerations = _construct_delegate_function('enumerations', True)
     metadata = _construct_delegate_function('metadata', True)
+    clear_symbol_cache = _construct_delegate_function('clear_symbol_cache')
     get_type = _construct_delegate_function('get_type')
     get_symbol = _construct_delegate_function('get_symbol')
     get_enumeration = _construct_delegate_function('get_enumeration')
@@ -313,6 +314,10 @@ class ISFormatTable(interfaces.symbols.SymbolTableInterface, metaclass = ABCMeta
         """Returns a metadata object containing information about the symbol
         table."""
         return None
+
+    def clear_symbol_cache(self) -> None:
+        """Clears the symbol cache of the symbol table."""
+        self._symbol_cache.clear()
 
 
 class Version1Format(ISFormatTable):


### PR DESCRIPTION
With 573590878afde184df443e581110a84a4ee4583f, the computed ASLR shift is now applied in the `get_symbol()` function of the respective `ISFormatTable` subclass. Furthermore, symbols that are looked up via `get_symbol()` are cached. This leads to a problem if symbols get resolved (and cached) at a point in time where ASLR shift computation was not executed yet. For me, this happens when I try to run the command listed below (after applying #235).

This leads to `init_task` and `files_task` already being resolved and cached with the default ASLR shift of 0, when ASLR shift is computed. Subsequently, the memory accesses required for `linux.pslist.PsList` fail, as they involve the symbol `init_task`. If you want to showcase this caching issue, you can inspect the cache at this position:  https://github.com/volatilityfoundation/volatility3/blob/abb1f3d71cb18390440ba9717ca94431a838a75c/volatility/framework/symbols/intermed.py#L584

If you disable the cache lookups at this point, the problem does not arise.

One way to solve this issue is clearing the symbol cache after ASLR is computed. This is implemented in this PR.

```
$ ./vol.py -vvvvv -f ~/[REDACTED].dump linux.pslist.PsList
Volatility 3 Framework 1.0.0-beta.1
INFO     root        : Volatility plugins path: ['/home/[REDACTED]/volatility3/volatility/plugins', '/home/[REDACTED]/volatility3/volatility/framework/plugins']
INFO     root        : Volatility symbols path: ['/home/[REDACTED]/volatility3/volatility/symbols', '/home/[REDACTED]/volatility3/volatility/framework/symbols']
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module volatility.plugins.yarascan based on file: yarascan
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module volatility.plugins.windows.svcscan based on file: windows/svcscan
INFO     volatility.plugins.windows.verinfo: Python pefile module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'pefile'
DEBUG    volatility.framework: Failed to import module volatility.plugins.windows.verinfo based on file: windows/verinfo
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module volatility.plugins.windows.callbacks based on file: windows/callbacks
INFO     volatility.plugins.yarascan: Python Yara module not found, plugin (and dependent plugins) not available
DEBUG    volatility.framework: No module named 'yara'
DEBUG    volatility.framework: Failed to import module volatility.plugins.windows.vadyarascan based on file: windows/vadyarascan
INFO     root        : The following plugins could not be loaded (use -vv to see why): volatility.plugins.windows.callbacks, volatility.plugins.windows.svcscan, volatility.plugins.windows.vadyarascan, volatility.plugins.windows.verinfo, volatility.plugins.yarascan
Level 7  root        : Cache directory used: /home/[REDACTED]/.cache/volatility3
INFO     volatility.framework.automagic: Detected a linux category plugin
INFO     volatility.framework.automagic: Running automagic: LinuxBannerCache
INFO     volatility.framework.automagic.symbol_cache: Building linux caches...
Level 7  volatility.framework.layers.resources: Available URL handlers: HTTPErrorProcessor, HTTPDefaultErrorHandler, HTTPRedirectHandler, ProxyHandler, HTTPBasicAuthHandler, ProxyBasicAuthHandler, HTTPDigestAuthHandler, ProxyDigestAuthHandler, AbstractHTTPHandler, HTTPHandler, HTTPSHandler, HTTPCookieProcessor, UnknownHandler, FileHandler, FTPHandler, CacheFTPHandler, DataHandler, JarHandler
INFO     volatility.framework.automagic: Running automagic: ConstructionMagic
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.PsList.primary
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.PsList
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.PsList.vmlinux
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.PsList
INFO     volatility.framework.automagic: Running automagic: LayerStacker
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LimeStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using Elf64Stacker
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input
Level 8  volatility.framework.automagic.stacker: Stacked Elf64Layer using Elf64Stacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LimeStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using QemuStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WindowsCrashDump32Stacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using VmwareStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WintelStacker
DEBUG    volatility.framework.automagic.windows: Self-referential pointer not in well-known location, moving to recent windows heuristic
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LintelStacker
DEBUG    volatility.framework.automagic.linux: Identified banner: b'Linux version 4.15.0-106-generic (buildd@lcy01-amd64-016) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 (Ubuntu 4.15.0-106.107-generic 4.15.18)\n\x00'
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dma_coherent_mem
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!netns_ipvs
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mtd_info
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!s_pstats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dev_rcv_lists
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!s_stats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!nf_ct_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!nf_exp_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!xt_table
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mpls_route
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!nft_af_info
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!sctp_mib
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!ebt_table
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dn_dev
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!garp_port
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mpls_dev
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!mrp_port
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!tipc_bearer
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!pcpu_dstats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!pcpu_vstats
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_conn
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_cached_keys
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_cqm_config
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!cfg80211_internal_bss
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!phylink
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!libipw_device
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!assoc_array_ptr
DEBUG    volatility.framework.symbols: Unresolved reference: LintelStacker1!dn_route
DEBUG    volatility.framework.automagic.linux: Linux ASLR shift values determined: physical 2a200000 virtual 34800000
DEBUG    volatility.framework.automagic.linux: DTB was found at: 0x2c60a000
Level 8  volatility.framework.automagic.stacker: Stacked IntelLayer using LintelStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using LimeStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using QemuStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WindowsCrashDump32Stacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using VmwareStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using WintelStacker
Level 8  volatility.framework.automagic.stacker: Attempting to stack using MacintelStacker
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary.memory_layer
Level 9  volatility.framework.configuration.requirements: IndexError - No configuration provided: plugins.PsList.primary.memory_layer.base_layer
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input
Level 9  volatility.framework.interfaces.configuration: TypeError - kernel_virtual_offset requirements only accept int type: None
Level 9  volatility.framework.interfaces.configuration: TypeError - kernel_virtual_offset requirements only accept int type: None
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.PsList.vmlinux
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
Level 9  volatility.framework.automagic.construct_layers: Failed on requirement: plugins.PsList
DEBUG    volatility.framework.automagic.stacker: Stacked layers: ['IntelLayer', 'Elf64Layer', 'FileLayer']
INFO     volatility.framework.automagic: Running automagic: LinuxSymbolFinder
Level 9  volatility.framework.configuration.requirements: Symbol table requirement not yet fulfilled: plugins.PsList.vmlinux
DEBUG    volatility.framework.automagic.symbol_finder: Identified banner: b'Linux version 4.15.0-106-generic (buildd@lcy01-amd64-016) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 (Ubuntu 4.15.0-106.107-generic 4.15.18)\n\x00'
DEBUG    volatility.framework.automagic.symbol_finder: Using symbol library: file:///home/[REDACTED]/volatility3/volatility/symbols/linux/linux-image-4.15.0-106-amd64.json.xz
INFO     volatility.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility.schemas: All validations will report success, even with malformed input
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dma_coherent_mem
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!netns_ipvs
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mtd_info
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!s_pstats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dev_rcv_lists
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!s_stats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!nf_ct_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!nf_exp_event_notifier
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!xt_table
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mpls_route
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!nft_af_info
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!sctp_mib
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!ebt_table
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dn_dev
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!garp_port
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mpls_dev
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!mrp_port
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!tipc_bearer
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!pcpu_dstats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!pcpu_vstats
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_conn
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_cached_keys
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_cqm_config
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!cfg80211_internal_bss
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!phylink
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!libipw_device
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!assoc_array_ptr
DEBUG    volatility.framework.symbols: Unresolved reference: vmlinux1!dn_route
DEBUG    volatility.framework.automagic.linux: Linux ASLR shift values determined: physical -fffe95e00000 virtual ffff000034800000

PID	PPID	COMM


DEBUG    root        : Traceback (most recent call last):
  File "/home/[REDACTED]/volatility3/volatility/cli/__init__.py", line 292, in run
    renderers[args.renderer]().render(constructed.run())
  File "/home/[REDACTED]/volatility3/volatility/cli/text_renderer.py", line 163, in render
    grid.populate(visitor, outfd)
  File "/home/[REDACTED]/volatility3/volatility/framework/renderers/__init__.py", line 208, in populate
    for (level, item) in self._generator:
  File "/home/[REDACTED]/volatility3/volatility/framework/plugins/linux/pslist.py", line 50, in _generator
    for task in self.list_tasks(self.context,
  File "/home/[REDACTED]/volatility3/volatility/framework/plugins/linux/pslist.py", line 82, in list_tasks
    for task in init_task.tasks:
  File "/home/[REDACTED]/volatility3/volatility/framework/symbols/linux/extensions/__init__.py", line 293, in to_list
    link = getattr(self, direction).dereference()
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/__init__.py", line 710, in __getattr__
    member = template(context = self._context, object_info = object_info)
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/templates.py", line 72, in __call__
    return self.vol.object_class(context = context, object_info = object_info, **arguments)
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/__init__.py", line 120, in __new__
    value = cls._unmarshall(context, data_format, object_info)
  File "/home/[REDACTED]/volatility3/volatility/framework/objects/__init__.py", line 307, in _unmarshall
    data = context.layers.read(object_info.layer_name, object_info.offset, length)
  File "/home/[REDACTED]/volatility3/volatility/framework/interfaces/layers.py", line 540, in read
    return self[layer].read(offset, length, pad)
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/linear.py", line 38, in read
    for (offset, _, mapped_offset, mapped_length, layer) in self.mapping(offset, length, ignore_errors = pad):
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/intel.py", line 197, in mapping
    chunk_offset, page_size, layer_name = self._translate(offset)
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/intel.py", line 99, in _translate
    entry, position = self._translate_entry(offset)
  File "/home/[REDACTED]/volatility3/volatility/framework/layers/intel.py", line 124, in _translate_entry
    raise exceptions.PagedInvalidAddressException(self.name, offset, position + 1, entry,
volatility.framework.exceptions.PagedInvalidAddressException: Page Fault at entry 0x0 in table page table

Volatility was unable to read a requested page:
Page error 0xffff82413c28 in layer primary (Page Fault at entry 0x0 in table page table)

	* Memory smear during acquisition (try re-acquiring if possible)
	* An intentionally invalid page lookup (operating system protection)
	* A bug in the plugin/volatility (re-run with -vvv and file a bug)

No further results will be produced
```