### PR TITLE
print correct db/.. offset: increment offset after printing, not before

### DIFF
--- a/volatility/cli/volshell/generic.py
+++ b/volatility/cli/volshell/generic.py
@@ -128,7 +128,6 @@ class Volshell(interfaces.plugins.PluginInterface):
 
         while remaining_data:
             current_line, remaining_data = remaining_data[:16], remaining_data[16:]
-            offset += 16
 
             data_blocks = [current_line[chunk_size * i:chunk_size * (i + 1)] for i in range(16 // chunk_size)]
             data_blocks = [x for x in data_blocks if x != b'']
@@ -145,6 +144,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                 ascii_data = connector.join([self._ascii_bytes(x) for x in valid_data])
 
             print(hex(offset), "  ", hex_data, "  ", ascii_data)
+            offset += 16
 
     @staticmethod
     def _ascii_bytes(bytes):


### PR DESCRIPTION
Currently, the db(..) commands in volshell will print a wrong offset:

(primary) >>> db(0xffff81a000e0)
0xffff81a000f0    4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 34 2e    Linux.version.4.
0xffff81a00100    34 2e 30 2d 31 32 34 2d 67 65 6e 65 72 69 63 20    4.0-124-generic.
(the data is actually from offset ...e0, but the offset shown in the left column is off by 0x10)

This pull request fixed this issue by incrementing offset only after it was printed, not before.