### PR TITLE
Configurable stacker list

### DIFF
--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -271,7 +271,7 @@ class CommandLine(interfaces.plugins.FileConsumerInterface):
 
         # It should be up to the UI to determine which automagics to run, so this is before BACK TO THE FRAMEWORK
         automagics = automagic.choose_automagic(automagics, plugin)
-        ctx.config['automagic.LayerStacker.stackers'] = stacker.choose_stackers(plugin)
+        ctx.config['automagic.LayerStacker.stackers'] = stacker.choose_os_stackers(plugin)
         self.output_dir = args.output_dir
 
         ###

--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -26,6 +26,7 @@ import volatility.symbols
 from volatility import framework
 from volatility.cli import text_renderer, volargparse
 from volatility.framework import automagic, constants, contexts, exceptions, interfaces, plugins, configuration
+from volatility.framework.automagic import stacker
 from volatility.framework.configuration import requirements
 
 # Make sure we log everything
@@ -270,6 +271,7 @@ class CommandLine(interfaces.plugins.FileConsumerInterface):
 
         # It should be up to the UI to determine which automagics to run, so this is before BACK TO THE FRAMEWORK
         automagics = automagic.choose_automagic(automagics, plugin)
+        ctx.config['automagic.LayerStacker.stackers'] = stacker.choose_stackers(plugin)
         self.output_dir = args.output_dir
 
         ###

--- a/volatility/framework/automagic/linux.py
+++ b/volatility/framework/automagic/linux.py
@@ -14,7 +14,7 @@ from volatility.framework.symbols import linux
 vollog = logging.getLogger(__name__)
 
 
-class LintelStacker(interfaces.automagic.StackerLayerInterface):
+class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 45
 
     @classmethod

--- a/volatility/framework/automagic/linux.py
+++ b/volatility/framework/automagic/linux.py
@@ -16,6 +16,7 @@ vollog = logging.getLogger(__name__)
 
 class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 45
+    exclusion_list = ['mac', 'windows']
 
     @classmethod
     def stack(cls,

--- a/volatility/framework/automagic/mac.py
+++ b/volatility/framework/automagic/mac.py
@@ -14,7 +14,7 @@ from volatility.framework.symbols import mac
 vollog = logging.getLogger(__name__)
 
 
-class MacintelStacker(interfaces.automagic.StackerLayerInterface):
+class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 45
 
     @classmethod

--- a/volatility/framework/automagic/mac.py
+++ b/volatility/framework/automagic/mac.py
@@ -16,6 +16,7 @@ vollog = logging.getLogger(__name__)
 
 class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 45
+    exclusion_list = ['windows', 'linux']
 
     @classmethod
     def stack(cls,

--- a/volatility/framework/automagic/stacker.py
+++ b/volatility/framework/automagic/stacker.py
@@ -247,7 +247,10 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
 
 def choose_os_stackers(plugin):
     """Identifies the stackers that should be run, based on the plugin (and thus os) provided"""
-    plugin_first_level = plugin.__module__.split('.')[0]
+    plugin_first_level = plugin.__module__.split('.')[2]
+
+    # Ensure all stackers are loaded
+    framework.import_files(sys.modules['volatility.framework.layers'])
 
     result = []
     for stacker in sorted(framework.class_subclasses(interfaces.automagic.StackerLayerInterface),

--- a/volatility/framework/automagic/stacker.py
+++ b/volatility/framework/automagic/stacker.py
@@ -245,32 +245,14 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
         ]
 
 
-def choose_stackers(plugin):
-    """Chooses the available stackers based on the plugin"""
-    plugin_module_components = plugin.__module__.split('.')
-    oses = ['windows', 'linux', 'mac']
-
-    operating_system = 'unknown'
-    lowest_index = len(plugin_module_components)
-
-    for os in oses:
-        try:
-            if plugin_module_components.index(os) < lowest_index:
-                lowest_index = plugin_module_components.index(os)
-                operating_system = os
-        except ValueError:
-            # The value wasn't found, try the next one
-            pass
+def choose_os_stackers(plugin):
+    """Identifies the stackers that should be run, based on the plugin (and thus os) provided"""
+    plugin_first_level = plugin.__module__.split('.')[0]
 
     result = []
     for stacker in sorted(framework.class_subclasses(interfaces.automagic.StackerLayerInterface),
                           key = lambda x: x.stack_order):
-        stacker_name = stacker.__name__.lower()
-        append = True
-        if 'intel' in stacker_name:
-            if operating_system in oses:
-                if not stacker_name.startswith(operating_system):
-                    append = False
-        if append:
-            result.append(stacker.__name__)
+        if plugin_first_level in stacker.exclusion_list:
+            continue
+        result.append(stacker.__name__)
     return result

--- a/volatility/framework/automagic/stacker.py
+++ b/volatility/framework/automagic/stacker.py
@@ -45,7 +45,7 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
     def __call__(self,
                  context: interfaces.context.ContextInterface,
                  config_path: str,
-                 requirement: interfaces.configuration.RequirementInterface = None,
+                 requirement: interfaces.configuration.RequirementInterface,
                  progress_callback: constants.ProgressCallback = None) -> Optional[List[str]]:
         """Runs the automagic over the configurable."""
 

--- a/volatility/framework/automagic/windows.py
+++ b/volatility/framework/automagic/windows.py
@@ -286,7 +286,7 @@ class WintelHelper(interfaces.automagic.AutomagicInterface):
                 self(context, sub_config_path, subreq)
 
 
-class WintelStacker(interfaces.automagic.StackerLayerInterface):
+class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 40
 
     @classmethod

--- a/volatility/framework/automagic/windows.py
+++ b/volatility/framework/automagic/windows.py
@@ -288,6 +288,7 @@ class WintelHelper(interfaces.automagic.AutomagicInterface):
 
 class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 40
+    exclusion_list = ['mac', 'linux']
 
     @classmethod
     def stack(cls,

--- a/volatility/framework/interfaces/automagic.py
+++ b/volatility/framework/interfaces/automagic.py
@@ -104,6 +104,9 @@ class StackerLayerInterface(metaclass = ABCMeta):
     """
 
     stack_order = 0
+    """The order in which to attempt stacking, the lower the earlier"""
+    exclusion_list = []
+    """The list operating systems/first-level plugin hierarchy that should exclude this stacker"""
 
     @classmethod
     def stack(self,


### PR DESCRIPTION
This will significantly speed up mac and linux plugins by not running the Wintel stacker uselessly against such plugins.  It also allows CLI users to choose which stackers to use, should they so desire, and allows generic plugins to still try all the stacking options.

This is built on top of #244, which should be reviewed/get committed first...