### PR TITLE
yarascan: Added Yara rule name to return value

### DIFF
--- a/volatility/framework/plugins/yarascan.py
+++ b/volatility/framework/plugins/yarascan.py
@@ -27,10 +27,11 @@ class YaraScanner(interfaces.layers.ScannerInterface):
         super().__init__()
         self._rules = rules
 
-    def __call__(self, data: bytes, data_offset: int) -> Iterable[Tuple[int, str, bytes]]:
+    def __call__(self, data: bytes, data_offset: int) -> Iterable[Tuple[int, str, str, bytes]]:
         for match in self._rules.match(data = data):
+            rule_name = match.rule
             for offset, name, value in match.strings:
-                yield (offset + data_offset, name, value)
+                yield (offset + data_offset, rule_name, name, value)
 
 
 class YaraScan(plugins.PluginInterface):


### PR DESCRIPTION
The return value of yarascan will contain the hit strings, but the Yara rule name is also important.

Volatility2 returned the Yara rule name.
https://github.com/botherder/volatility/blob/5eb15741a095c5f0dec9bd771f6c4a63b06137c1/volatility/plugins/malware/malfind.py#L114

Please add Yara rule name to yarascan return to maintain compatibility with Volatility2.