### PR TITLE
adds dynamic length of pool header alignments

### DIFF
--- a/volatility/framework/plugins/windows/poolscanner.py
+++ b/volatility/framework/plugins/windows/poolscanner.py
@@ -361,7 +361,12 @@ class PoolScanner(plugins.PluginInterface):
         if not is_windows_10:
             scan_layer = context.layers[scan_layer].config['memory_layer']
 
-        for constraint, header in cls.pool_scan(context, scan_layer, symbol_table, constraints, alignment = 8):
+        if symbols.symbol_table_is_64bit(context, symbol_table):
+            alignment = 0x10
+        else:
+            alignment = 8
+
+        for constraint, header in cls.pool_scan(context, scan_layer, symbol_table, constraints, alignment = alignment):
 
             mem_object = header.get_object(type_name = constraint.type_name,
                                            use_top_down = is_windows_8_or_later,


### PR DESCRIPTION
Pool alignments appear dependent on system architecture. This update checks for the current apparent system architecture and changes the alignment.
```
$ vol2.py -f win8x64_vm.dd --profile=Win8SP0x64 volshell
To get help, type 'hh()'
>>> addr_space = utils.load_as(self._config)
>>> obj.VolMagic(addr_space).PoolAlignment.v()
16
$ vol2.py -f win8x86_vm.dd --profile=Win8SP0x86 volshell
>>> addr_space = utils.load_as(self._config)
>>> obj.VolMagic(addr_space).PoolAlignment.v()
8
```