### PR TITLE
Objects: Add a convenience function for validating enum values

### DIFF
--- a/volatility/framework/objects/__init__.py
+++ b/volatility/framework/objects/__init__.py
@@ -466,6 +466,11 @@ class Enumeration(interfaces.objects.ObjectInterface, int):
     def choices(self) -> Dict[str, int]:
         return self._vol['choices']
 
+    @property
+    def legal(self) -> bool:
+        """Returns whether the value for the object is a valid choice"""
+        return self in self.choices.values()
+
     def __getattr__(self, attr: str) -> str:
         """Returns the value for a specific name."""
         if attr in self._vol['choices']:

--- a/volatility/framework/objects/__init__.py
+++ b/volatility/framework/objects/__init__.py
@@ -467,7 +467,7 @@ class Enumeration(interfaces.objects.ObjectInterface, int):
         return self._vol['choices']
 
     @property
-    def legal(self) -> bool:
+    def is_valid_choice(self) -> bool:
         """Returns whether the value for the object is a valid choice"""
         return self in self.choices.values()
 


### PR DESCRIPTION
Very quick one, just wanting views on the name for it (and whether it should be a property or a method, whose name would then start with a verb)?

I think `is_valid` is too generic and is already used in other contexts for readability of data, so I went with legal.  Also considered `valid_choice` as a property, but again valid without context isn't ideal.  5:S

Opinions and views welcomed, otherwise this'll go in in 7 days...  5:)