### PR TITLE
New file interface

### DIFF
--- a/doc/source/complex-plugin.rst
+++ b/doc/source/complex-plugin.rst
@@ -29,7 +29,7 @@ available plugins that feature a Timeliner interface).  This can be achieved wit
 
     automagics = automagic.choose_automagic(automagic.available(self._context), plugin_class)
     plugin = plugins.construct_plugin(self.context, automagics, plugin_class, self.config_path,
-                                self._progress_callback, self._file_consumer)
+                                self._progress_callback, self._file_consumer, self.FileHandler)
 
 This code will first generate suitable automagics for running against the context.  Unfortunately this must be re-run for
 each plugin in order to populate the context's configuration correctly based on the plugin's requirements (which may vary
@@ -41,10 +41,29 @@ between plugins).  Once the automagics have been constructed, the plugin can be 
  * the configuration path within the context for the plugin
  * any callback to determine progress in lengthy operations
  * any file consumers for files created during running of the plugin
+ * a file handler class for files created during the running of the plugin
 
 With the constructed plugin, it can either be run by calling its
 :py:meth:`~volatility.framework.interfaces.plugins.PluginInterface.run` method, or any other known method can
 be invoked on it.
+
+Writing out files
+-----------------
+The :py:class:`~volatility.framework.interfaces.plugins.PluginInterface` contains a FileHandler attribute, that should be
+used as a means of writing out files by passing them to the `consume_file` method.  When producing a file, construct an object
+handler using the :py:obj:`~volatility.framework.interfaces.plugins.PluginInterface.FileHandler` class.
+
+..code-block:: python
+
+    output = self.FileHandler(filename = 'newfile.out')
+    output.data.write(data_for_file)
+
+    self.consume_file(output)
+
+The filename is the preferred filename to be output, but there is no guarantee the UI will want to or be able to produce
+that exact filename.  This layer of abstraction allows different UIs (such as a Web-based UI or a Command Line Interface)
+to be able to handle and work with the file data produced by a plugin.  The data attribute is an io-based object
+that adheres to the BytesIO class.  The backing store is unspecified and may be decided by the UI.
 
 Writing Scanners
 ----------------

--- a/volatility/framework/constants/__init__.py
+++ b/volatility/framework/constants/__init__.py
@@ -36,7 +36,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 1  # Number of releases of the library with a breaking change
-VERSION_MINOR = 1  # Number of changes that only add to the interface
+VERSION_MINOR = 2  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = "-beta.1"
 

--- a/volatility/framework/interfaces/plugins.py
+++ b/volatility/framework/interfaces/plugins.py
@@ -101,6 +101,7 @@ class PluginInterface(interfaces.configuration.ConfigurableInterface,
             vollog.warning("Plugin failed validation")
             raise exceptions.PluginRequirementException("The plugin configuration failed to validate")
         self._file_consumer = None  # type: Optional[FileConsumerInterface]
+        self._file_handler = interfaces.plugins.FileInterface
 
         framework.require_interface_version(*self._required_framework_verison)
 
@@ -130,3 +131,13 @@ class PluginInterface(interfaces.configuration.ConfigurableInterface,
         Returns:
             A TreeGrid object that can then be passed to a Renderer.
         """
+
+    @property
+    def FileHandler(self):
+        """Returns a FileHandler which implements interfaces.plugins.FileInterface"""
+        return self._file_handler
+
+    def set_file_handler_class(self, value):
+        """Sets the file handler class to be used by plugins"""
+        if isinstance(value, interfaces.plugins.FileInterface):
+            self._file_handler = value

--- a/volatility/framework/plugins/__init__.py
+++ b/volatility/framework/plugins/__init__.py
@@ -15,11 +15,14 @@ from volatility.framework import interfaces, automagic, exceptions, constants
 vollog = logging.getLogger(__name__)
 
 
-def construct_plugin(context: interfaces.context.ContextInterface,
-                     automagics: List[interfaces.automagic.AutomagicInterface],
-                     plugin: Type[interfaces.plugins.PluginInterface], base_config_path: str,
-                     progress_callback: constants.ProgressCallback,
-                     file_consumer: interfaces.plugins.FileConsumerInterface) -> interfaces.plugins.PluginInterface:
+def construct_plugin(
+        context: interfaces.context.ContextInterface,
+        automagics: List[interfaces.automagic.AutomagicInterface],
+        plugin: Type[interfaces.plugins.PluginInterface],
+        base_config_path: str,
+        progress_callback: constants.ProgressCallback,
+        file_consumer: interfaces.plugins.FileConsumerInterface,
+        file_handler_class: Type[interfaces.plugins.FileInterface] = None) -> interfaces.plugins.PluginInterface:
     """Constructs a plugin object based on the parameters.
 
     Clever magic figures out how to fulfill each requirement that might not be fulfilled
@@ -31,6 +34,7 @@ def construct_plugin(context: interfaces.context.ContextInterface,
         base_config_path: The path within the context's config containing the plugin's configuration
         progress_callback: Callback function to provide feedback for ongoing processes
         file_consumer: Object to pass any generated files to
+        file_handler_class: Class for new constructed files to be passed to the consumer
 
     Returns:
         The constructed plugin object
@@ -51,4 +55,6 @@ def construct_plugin(context: interfaces.context.ContextInterface,
     constructed = plugin(context, plugin_config_path, progress_callback = progress_callback)
     if file_consumer:
         constructed.set_file_consumer(file_consumer)
+    if file_handler_class:
+        constructed.set_file_handler_class(file_handler_class)
     return constructed

--- a/volatility/framework/plugins/timeliner.py
+++ b/volatility/framework/plugins/timeliner.py
@@ -107,7 +107,6 @@ class Timeliner(interfaces.plugins.PluginInterface):
         """Takes a timeline, sorts it and output the data from each relevant
         row from each plugin."""
         # Generate the results for each plugin
-        data = []
         for plugin in runable_plugins:
             plugin_name = plugin.__class__.__name__
             self._progress_callback((runable_plugins.index(plugin) * 100) // len(runable_plugins),
@@ -136,7 +135,7 @@ class Timeliner(interfaces.plugins.PluginInterface):
 
         # Write out a body file if necessary
         if self.config.get('create-bodyfile', True):
-            filedata = interfaces.plugins.FileInterface("volatility.body")
+            filedata = self.FileHandler("volatility.body")
             with io.TextIOWrapper(filedata.data, write_through = True) as fp:
                 for (plugin_name, item) in self.timeline:
                     times = self.timeline[(plugin_name, item)]
@@ -202,7 +201,7 @@ class Timeliner(interfaces.plugins.PluginInterface):
                 for entry in old_dict:
                     total_config[interfaces.configuration.path_join(plugin.__class__.__name__, entry)] = old_dict[entry]
 
-            filedata = interfaces.plugins.FileInterface("config.json")
+            filedata = self.FileHandler("config.json")
             with io.TextIOWrapper(filedata.data, write_through = True) as fp:
                 json.dump(total_config, fp, sort_keys = True, indent = 2)
                 self.produce_file(filedata)

--- a/volatility/framework/plugins/windows/dlldump.py
+++ b/volatility/framework/plugins/windows/dlldump.py
@@ -86,8 +86,9 @@ class DllDump(interfaces.plugins.PluginInterface):
                         continue
 
                 try:
-                    filedata = interfaces.plugins.FileInterface("pid.{0}.{1}.{2:#x}.dmp".format(
-                        proc.UniqueProcessId, ntpath.basename(vad.get_file_name()), vad.get_start()))
+                    filedata = self.FileHandler("pid.{0}.{1}.{2:#x}.dmp".format(proc.UniqueProcessId,
+                                                                                ntpath.basename(vad.get_file_name()),
+                                                                                vad.get_start()))
 
                     dos_header = self.context.object(pe_table_name + constants.BANG + "_IMAGE_DOS_HEADER",
                                                      offset = vad.get_start(),

--- a/volatility/framework/plugins/windows/moddump.py
+++ b/volatility/framework/plugins/windows/moddump.py
@@ -131,7 +131,7 @@ class ModDump(interfaces.plugins.PluginInterface):
                                                      offset = mod.DllBase,
                                                      layer_name = session_layer_name)
 
-                    filedata = interfaces.plugins.FileInterface("module.{0:#x}.dmp".format(mod.DllBase))
+                    filedata = self.FileHandler("module.{0:#x}.dmp".format(mod.DllBase))
 
                     for offset, data in dos_header.reconstruct():
                         filedata.data.seek(offset)

--- a/volatility/framework/plugins/windows/registry/hivedump.py
+++ b/volatility/framework/plugins/windows/registry/hivedump.py
@@ -7,7 +7,6 @@ from typing import List
 
 from volatility.framework import interfaces
 from volatility.framework.configuration import requirements
-from volatility.framework.interfaces import plugins
 from volatility.framework.renderers import TreeGrid, format_hints
 from volatility.plugins.windows.registry import hivelist
 
@@ -42,7 +41,7 @@ class HiveDump(interfaces.plugins.PluginInterface):
             maxaddr = hive.hive.Storage[0].Length
             hive_name = self._sanitize_hive_name(hive.get_name())
 
-            filedata = plugins.FileInterface('registry.{}.{}.hive'.format(hive_name, hex(hive.hive_offset)))
+            filedata = self.FileHandler('registry.{}.{}.hive'.format(hive_name, hex(hive.hive_offset)))
             if hive._base_block:
                 hive_data = self.context.layers[hive.dependencies[0]].read(hive.hive.BaseBlock, 1 << 12)
             else:

--- a/volatility/framework/plugins/windows/vaddump.py
+++ b/volatility/framework/plugins/windows/vaddump.py
@@ -81,7 +81,7 @@ class VadDump(interfaces.plugins.PluginInterface):
 
             for vad in vadinfo.VadInfo.list_vads(proc, filter_func = filter_func):
                 try:
-                    filedata = interfaces.plugins.FileInterface("pid.{0}.vad.{1:#x}-{2:#x}.dmp".format(
+                    filedata = self.FileHandler("pid.{0}.vad.{1:#x}-{2:#x}.dmp".format(
                         proc.UniqueProcessId, vad.get_start(), vad.get_end()))
 
                     data = self.vad_dump(self.context, proc_layer_name, vad)


### PR DESCRIPTION
Ok, so this is a fairly deep-rooted change, but hopefully all works smoothly...

The concept is that when a plugin wants to create a file, it'll construct a `self.FileHandler` rather than a `interfaces.plugins.FileInterface`.  If it's a previously written plugin, it'll still use the old BytesIO interface.

The UI can then specify what a FileHandler should be (this is on a per-plugin basis, rather than a per-context basis, because plugins that run sub-plugins may find it very useful to choose to act as the file handler and/or consumer themselves).

The CLI has been updated to provide a file-backed handler (and all existing core plugins have been updated, the non-core plugins haven't, but that can easily be done).  Since plugins should be inheritting from the interface, they'll get the new `set_file_handler` method for free, and thus don't depend on a later version of the framework.  The CLI does make calls to this method though, and so requires that the framework be the increased version.

So @iMHLv2 could you please check this works ok and solves your memory issues and @npetroni could you please check it's nt too ugly and/or I haven't done something stupid?