### PR TITLE
Stephanie's memdump & memmap plugin

### DIFF
--- a/volatility/framework/plugins/windows/memdump.py
+++ b/volatility/framework/plugins/windows/memdump.py
@@ -7,10 +7,11 @@ from typing import List
 from volatility.framework import exceptions, renderers, interfaces
 from volatility.framework.configuration import requirements
 from volatility.framework.renderers import format_hints
+from volatility.framework.objects import utility
 from volatility.plugins.windows import pslist, dlllist, ssdt, vadinfo
 
 
-class Memmap(interfaces.plugins.PluginInterface):
+class Memdump(interfaces.plugins.PluginInterface):
     """Prints the memory map"""
 
     @classmethod
@@ -27,38 +28,69 @@ class Memmap(interfaces.plugins.PluginInterface):
                                         description = "Process ID to include (all other processes are excluded)",
                                         optional = True)
         ]
+        
+    @classmethod
+    def mem_dump(cls, context: interfaces.context.ContextInterface, layer_name: str,
+                 vad: interfaces.objects.ObjectInterface) -> bytes:
+        """ Get data for each VA"""
+        temp = b""
+
+        proc_layer = context.layers[layer_name]
+        chunk_size = 1024 * 1024 * 10
+        offset = vad.get_start()
+        out_of_range = vad.get_end()
+
+        while offset < out_of_range:
+            to_read = min(chunk_size, out_of_range - offset)
+            data = proc_layer.read(offset, to_read, pad = True)
+            if not data:
+                break
+            temp += data
+            offset += to_read
+
+        return temp
+
 
     def _generator(self, procs):
-
+        #print("reading")
+        test = 0
         for proc in procs:
-            reverse_map = dict()
+            process_name = proc.ImageFileName.cast("string",
+                                                   max_length = proc.ImageFileName.vol.count,
+                                                   errors = 'replace')
             offset = 0
             pid = "Unknown"
-
             try:
                 pid = proc.UniqueProcessId
                 proc_layer_name = proc.add_process_layer()
                 proc_layer = self.context.layers[proc_layer_name]
             except exceptions.InvalidAddressException as excp:
-                vollog.debug("Process {}: invalid address {} in layer {}".format(
-                        pid, excp.invalid_address, excp.layer_name))
+                vollog.debug("Process {}: invalid address {} in layer {}".format(pid, excp.invalid_address, excp.layer_name))
                 continue
-
+            
             for mapval in proc_layer.mapping(0x0, proc_layer.maximum_address, ignore_errors = True):
-                kpage, _, vpage, page_size, maplayer = mapval
-               
-                yield(0, (
-                    format_hints.Hex(kpage), 
-                    format_hints.Hex(vpage), 
-                    format_hints.Hex(page_size), 
-                    format_hints.Hex(offset)))
+                vadd, _, vpage, page_size, maplayer = mapval
+                try:
+                    filedata = interfaces.plugins.FileInterface("{}.img".format(proc.UniqueProcessId))
+                    temp_data = data = proc_layer.read(vadd, page_size, pad = True)
+                    filedata.data.write(temp_data)
+                    #self.produce_file(filedata)
+
+                    result_text = "Writing {} [ {} ] to {}.img".format(process_name, proc.UniqueProcessId, proc.UniqueProcessId)
+                except exceptions.InvalidAddressException:
+                    result_text = "Unable to write {} [ {} ]to {}.img".format(process_name, proc.UniqueProcessId, proc.UniqueProcessId)
+
+                yield(0, (result_text,))
                 offset += page_size
+            self.produce_file(filedata)
+            
+
 
 
     def run(self):
         filter_func = pslist.PsList.create_pid_filter([self.config.get('pid', None)])
-
-        return renderers.TreeGrid([ ("Virtual", format_hints.Hex),("Physical", format_hints.Hex), ("Size", format_hints.Hex), ("Offset", format_hints.Hex)],
+        #print("here run")
+        return renderers.TreeGrid([ ("Result", str)],
                                   self._generator(
                                       pslist.PsList.list_processes(context = self.context,
                                                                    layer_name = self.config['primary'],

--- a/volatility/framework/plugins/windows/memdump.py
+++ b/volatility/framework/plugins/windows/memdump.py
@@ -12,7 +12,7 @@ from volatility.plugins.windows import pslist, dlllist, ssdt, vadinfo
 
 
 class Memdump(interfaces.plugins.PluginInterface):
-    """Prints the memory map"""
+    """Dump the addressable memory for a process"""
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -55,7 +55,6 @@ class Memdump(interfaces.plugins.PluginInterface):
                 except exceptions.InvalidAddressException:
                     vollog.debug("Unable to write {}'s address {} [ {} ]to {}.dmp".format(process_name, vadd, proc.UniqueProcessId, proc.UniqueProcessId))
                     continue
-
 
             try:
                 result_text = "Writing {} [ {} ] to {}.dmp".format(process_name, proc.UniqueProcessId, proc.UniqueProcessId)

--- a/volatility/framework/plugins/windows/memmap.py
+++ b/volatility/framework/plugins/windows/memmap.py
@@ -1,0 +1,69 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+from typing import List
+
+from volatility.framework import exceptions, renderers, interfaces
+from volatility.framework.configuration import requirements
+from volatility.framework.renderers import format_hints
+from volatility.plugins.windows import pslist, dlllist, ssdt, vadinfo
+
+
+class Memmap(interfaces.plugins.PluginInterface):
+    """Prints the memory map"""
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.TranslationLayerRequirement(name = 'primary',
+                                                     description = 'Memory layer for the kernel',
+                                                     architectures = ["Intel32", "Intel64"]),
+            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (1, 0, 0)),
+            requirements.PluginRequirement(name = 'vadinfo', plugin = vadinfo.VadInfo, version = (1, 0, 0)),
+            requirements.IntRequirement(name = 'pid',
+                                        description = "Process ID to include (all other processes are excluded)",
+                                        optional = True)
+        ]
+
+    def _generator(self, procs):
+
+        for proc in procs:
+            reverse_map = dict()
+            offset = 0
+            pid = "Unknown"
+
+            try:
+                pid = proc.UniqueProcessId
+                proc_layer_name = proc.add_process_layer()
+                proc_layer = self.context.layers[proc_layer_name]
+            except exceptions.InvalidAddressException as excp:
+                vollog.debug("Process {}: invalid address {} in layer {}".format(
+                        pid, excp.invalid_address, excp.layer_name))
+                continue
+
+            for mapval in proc_layer.mapping(0x0, proc_layer.maximum_address, ignore_errors = True):
+                kpage, _, vpage, page_size, maplayer = mapval
+                cur_set = reverse_map.get(kpage >> 12, set())
+                cur_set.add(("kernel", vpage))
+                reverse_map[kpage >> 12] = cur_set
+                yield(0, (proc.ImageFileName.cast("string", max_length = proc.ImageFileName.vol.count),
+                    proc.UniqueProcessId,
+                    format_hints.Hex(kpage), 
+                    format_hints.Hex(vpage), 
+                    format_hints.Hex(page_size), 
+                    format_hints.Hex(offset)))
+                offset += page_size
+
+
+    def run(self):
+        filter_func = pslist.PsList.create_pid_filter([self.config.get('pid', None)])
+
+        return renderers.TreeGrid([ ("Process", str), ("PID", int),("Virtual", format_hints.Hex),("Physical", format_hints.Hex), ("Size", format_hints.Hex), ("Offset", format_hints.Hex)],
+                                  self._generator(
+                                      pslist.PsList.list_processes(context = self.context,
+                                                                   layer_name = self.config['primary'],
+                                                                   symbol_table = self.config['nt_symbols'],
+                                                                   filter_func = filter_func)))

--- a/volatility/framework/plugins/windows/memmap.py
+++ b/volatility/framework/plugins/windows/memmap.py
@@ -29,7 +29,6 @@ class Memmap(interfaces.plugins.PluginInterface):
         ]
 
     def _generator(self, procs):
-
         for proc in procs:
             reverse_map = dict()
             offset = 0


### PR DESCRIPTION
Memmap: tested with grrcon-0a7030d.img and win10-x64-2016-05-16-10586.lime
--output with grrcon 100% matches vol2's output
--with the win10 file, it prints out more valid addresses than vol2 at the end, possibly because vol3 is reporting what's valid based on PTE entries 
--found an edge case for 64-bit .lime files, need to use patch when comparing data with vol2

Memdump: tested with grrcon-0a7030d.img and win10-x64-2016-05-16-10586.lime
--output with grrcon 100% matches vol2's output (compared with md5 hash)
--same discrepancies with the .lime file
--needs further testing with 64-bit file after patch is applied