### PR TITLE
Improved strings efficiency

### DIFF
--- a/volatility/framework/plugins/windows/strings.py
+++ b/volatility/framework/plugins/windows/strings.py
@@ -5,7 +5,7 @@
 import logging
 import re
 from typing import Dict, Generator, List, Set, Tuple
-from os.path import getsize
+from os import path
 
 from volatility.framework import interfaces, renderers, exceptions
 from volatility.framework.configuration import requirements
@@ -42,7 +42,7 @@ class Strings(interfaces.plugins.PluginInterface):
 
         accessor = resources.ResourceAccessor()
         strings_fp = accessor.open(self.config['strings_file'], "rb")
-        strings_size = getsize(strings_fp.name)
+        strings_size = path.getsize(strings_fp.name)
 
         line = strings_fp.readline()
         while line != '':


### PR DESCRIPTION
Strings takes forever and there is no indication of progress.
1. Replaced readlines() with readline() to prevent loading the entire strings file to memory all at once.
2. Added process callback to indicate the progression.
3. Converted the re.compile of strings parse_line to global in order to prevent compilation for each line.
4. Changed the regex to not include the trailing newline (\n)