### PR TITLE
ISF: Improve handling of anonymous members (inspired by gcmoreira)

### DIFF
--- a/volatility/framework/symbols/intermed.py
+++ b/volatility/framework/symbols/intermed.py
@@ -657,7 +657,7 @@ class Version8Format(Version7Format):
                     replacement_fields = self._process_fields(replacement.get('fields', {}))
                     # Whatever was there is now in our fields list, with a modified offset
                     for replacement_field in replacement_fields:
-                        # These will already have been converted into (offset, template) pairs by
+                        # These will already have been converted into (offset, template) pairs by the recursed call
                         replacement_offset, replacement_object = replacement_fields[replacement_field]
                         result[replacement_field] = (replacement_offset + child_offset,
                                                      replacement_object)


### PR DESCRIPTION
Hopefully this improves the previously buggy version of anonymous flattening.

In the previous version we would never flatten the top level's anonymous types properly and didn't recurse down (it passed across `type` rather than `fields`).

Closes #291 