### PR TITLE
Plugins: Version Mac/LinuxUtilities classes

### DIFF
--- a/volatility/framework/plugins/linux/check_idt.py
+++ b/volatility/framework/plugins/linux/check_idt.py
@@ -5,7 +5,7 @@
 import logging
 from typing import List
 
-from volatility.framework import interfaces, renderers, constants, contexts, exceptions, symbols
+from volatility.framework import interfaces, renderers, contexts, symbols
 from volatility.framework.configuration import requirements
 from volatility.framework.renderers import format_hints
 from volatility.framework.symbols import linux
@@ -25,7 +25,7 @@ class Check_idt(interfaces.plugins.PluginInterface):
                                                      architectures = ["Intel32", "Intel64"]),
 
             requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            
+            requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
         ]
 
@@ -34,8 +34,8 @@ class Check_idt(interfaces.plugins.PluginInterface):
 
         modules = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['vmlinux'])
 
-        handlers = linux.LinuxUtilities.generate_kernel_handler_info(self.context, self.config['primary'], self.config['vmlinux'], modules)
-
+        handlers = linux.LinuxUtilities.generate_kernel_handler_info(self.context, self.config['primary'],
+                                                                     self.config['vmlinux'], modules)
 
         is_32bit = not symbols.symbol_table_is_64bit(self.context, self.config["vmlinux"])
 
@@ -61,7 +61,8 @@ class Check_idt(interfaces.plugins.PluginInterface):
 
         addrs = vmlinux.object_from_symbol("idt_table")
 
-        table = vmlinux.object(object_type = 'array', offset = addrs.vol.offset, subtype = vmlinux.get_type(idt_type), count = idt_table_size)
+        table = vmlinux.object(object_type = 'array', offset = addrs.vol.offset, subtype = vmlinux.get_type(idt_type),
+                               count = idt_table_size)
 
         for i in check_idxs:
             ent = table[i]
@@ -86,8 +87,9 @@ class Check_idt(interfaces.plugins.PluginInterface):
 
             module_name, symbol_name = linux.LinuxUtilities.lookup_module_address(self.context, handlers, idt_addr)
 
-            yield(0, [format_hints.Hex(i), format_hints.Hex(idt_addr), module_name, symbol_name])
-        
+            yield (0, [format_hints.Hex(i), format_hints.Hex(idt_addr), module_name, symbol_name])
 
     def run(self):
-        return renderers.TreeGrid([("Index", format_hints.Hex), ("Address", format_hints.Hex), ("Module", str), ("Symbol", str)], self._generator())
+        return renderers.TreeGrid(
+            [("Index", format_hints.Hex), ("Address", format_hints.Hex), ("Module", str), ("Symbol", str)],
+            self._generator())

--- a/volatility/framework/plugins/linux/keyboard_notifiers.py
+++ b/volatility/framework/plugins/linux/keyboard_notifiers.py
@@ -4,10 +4,10 @@
 
 import logging
 
-from volatility.framework import interfaces, renderers, constants, contexts, exceptions
-from volatility.framework.symbols import linux
+from volatility.framework import interfaces, renderers, contexts, exceptions
 from volatility.framework.configuration import requirements
 from volatility.framework.renderers import format_hints
+from volatility.framework.symbols import linux
 from volatility.plugins.linux import lsmod
 
 vollog = logging.getLogger(__name__)
@@ -23,7 +23,8 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0)),
+            requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (1, 0, 0))
         ]
 
     def _generator(self):

--- a/volatility/framework/plugins/linux/lsof.py
+++ b/volatility/framework/plugins/linux/lsof.py
@@ -27,6 +27,7 @@ class Lsof(plugins.PluginInterface):
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (1, 0, 0)),
+            requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (1, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,

--- a/volatility/framework/plugins/linux/tty_check.py
+++ b/volatility/framework/plugins/linux/tty_check.py
@@ -6,12 +6,12 @@ import logging
 from typing import List
 
 from volatility.framework import interfaces, renderers, exceptions, constants, contexts
-from volatility.framework.symbols import linux
 from volatility.framework.configuration import requirements
 from volatility.framework.interfaces import plugins
 from volatility.framework.objects import utility
-from volatility.plugins.linux import lsmod
 from volatility.framework.renderers import format_hints
+from volatility.framework.symbols import linux
+from volatility.plugins.linux import lsmod
 
 vollog = logging.getLogger(__name__)
 
@@ -26,7 +26,8 @@ class tty_check(plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0)),
+            requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (1, 0, 0))
         ]
 
     def _generator(self):

--- a/volatility/framework/plugins/mac/check_syscall.py
+++ b/volatility/framework/plugins/mac/check_syscall.py
@@ -25,6 +25,7 @@ class Check_syscall(plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
         ]
 

--- a/volatility/framework/plugins/mac/check_sysctl.py
+++ b/volatility/framework/plugins/mac/check_sysctl.py
@@ -27,6 +27,7 @@ class Check_sysctl(plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
         ]
 

--- a/volatility/framework/plugins/mac/check_trap_table.py
+++ b/volatility/framework/plugins/mac/check_trap_table.py
@@ -26,7 +26,8 @@ class Check_trap_table(plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0)),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
         ]
 
     def _generator(self):

--- a/volatility/framework/plugins/mac/ifconfig.py
+++ b/volatility/framework/plugins/mac/ifconfig.py
@@ -17,7 +17,8 @@ class Ifconfig(plugins.PluginInterface):
             requirements.TranslationLayerRequirement(name = 'primary',
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Linux kernel symbols")
+            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0))
         ]
 
     def _generator(self):

--- a/volatility/framework/plugins/mac/lsof.py
+++ b/volatility/framework/plugins/mac/lsof.py
@@ -23,6 +23,7 @@ class Lsof(plugins.PluginInterface):
                                                      description = 'Kernel Address Space',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac Kernel"),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',

--- a/volatility/framework/plugins/mac/mount.py
+++ b/volatility/framework/plugins/mac/mount.py
@@ -10,6 +10,7 @@ from volatility.framework.objects import utility
 from volatility.framework.renderers import format_hints
 from volatility.framework.symbols import mac
 
+
 class Mount(plugins.PluginInterface):
     """A module containing a collection of plugins that produce data typically
     foundin Mac's mount command"""
@@ -22,6 +23,7 @@ class Mount(plugins.PluginInterface):
             requirements.TranslationLayerRequirement(name = 'primary',
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols")
         ]
 
@@ -43,13 +45,13 @@ class Mount(plugins.PluginInterface):
 
         for mount in mac.MacUtilities.walk_tailq(list_head, "mnt_list"):
             yield mount
-        
+
     def _generator(self):
         for mount in self.list_mounts(self.context, self.config['primary'], self.config['darwin']):
             vfs = mount.mnt_vfsstat
             device_name = utility.array_to_string(vfs.f_mntonname)
             mount_point = utility.array_to_string(vfs.f_mntfromname)
-            mount_type  = utility.array_to_string(vfs.f_fstypename)
+            mount_type = utility.array_to_string(vfs.f_fstypename)
 
             yield 0, (device_name, mount_point, mount_type)
 

--- a/volatility/framework/plugins/mac/netstat.py
+++ b/volatility/framework/plugins/mac/netstat.py
@@ -27,6 +27,7 @@ class Netstat(plugins.PluginInterface):
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac Kernel"),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,

--- a/volatility/framework/plugins/mac/timers.py
+++ b/volatility/framework/plugins/mac/timers.py
@@ -25,6 +25,7 @@ class Timers(plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
         ]
 

--- a/volatility/framework/plugins/mac/trustedbsd.py
+++ b/volatility/framework/plugins/mac/trustedbsd.py
@@ -27,6 +27,7 @@ class Trustedbsd(plugins.PluginInterface):
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
             requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
         ]
 

--- a/volatility/framework/symbols/linux/__init__.py
+++ b/volatility/framework/symbols/linux/__init__.py
@@ -36,8 +36,10 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
             self.set_type_class('mount', extensions.mount)
 
 
-class LinuxUtilities(object):
+class LinuxUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful linux functions."""
+
+    _verison = (1, 0, 0)
 
     # based on __d_path from the Linux kernel
     @classmethod
@@ -221,13 +223,13 @@ class LinuxUtilities(object):
         end_addr = end_addr.vol.offset & mask
 
         return [(constants.linux.KERNEL_NAME, start_addr, end_addr)] + \
-            LinuxUtilities.mask_mods_list(context, layer_name, mods_list)
+               LinuxUtilities.mask_mods_list(context, layer_name, mods_list)
 
     @classmethod
     def lookup_module_address(cls, context: interfaces.context.ContextInterface, handlers: Tuple[str, str],
                               target_address):
         """
-        Searches between the start and end address of the kernel module using target_address.  
+        Searches between the start and end address of the kernel module using target_address.
         Returns the module and symbol name of the address provided.
         """
 

--- a/volatility/framework/symbols/mac/__init__.py
+++ b/volatility/framework/symbols/mac/__init__.py
@@ -28,8 +28,10 @@ class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class('sysctl_oid', extensions.sysctl_oid)
 
 
-class MacUtilities(object):
+class MacUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful mac functions."""
+
+    _version = (1, 0, 0)
 
     @classmethod
     def mask_mods_list(cls, context: interfaces.context.ContextInterface, layer_name: str,


### PR DESCRIPTION
This is designed to allow our utility classes to change without breaking plugins that depend on them (or at least, gracefully inform the user they've broken).  Since these are core plugins, we can generally keep these in check (and there is a question about whether these are parts of the framework and therefore could be lumped into part of the `_required_framework_version`, but that number would skyrocket, and this allows us a little more granularity.

Asking for reviews by @atcuno because it touches mac/linux and from @npetroni to make sure the idea/level of granularity seems appropriate (some overcatch, but not so much as a different version of the framework for each change).

This isn't overly contentious though, so I'll commit it in 4 days unless someone shouts...  5:)