### PR TITLE
issue #306 - _POOL_HEADER class based on OS

### DIFF
--- a/volatility/framework/symbols/windows/__init__.py
+++ b/volatility/framework/symbols/windows/__init__.py
@@ -36,7 +36,10 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
 
         # This doesn't exist in very specific versions of windows
         try:
-            self.set_type_class('_POOL_HEADER', pool.POOL_HEADER)
+            if self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("PoolType"):
+                self.set_type_class('_POOL_HEADER', pool.POOL_HEADER_VISTA)
+            else:
+                self.set_type_class('_POOL_HEADER', pool.POOL_HEADER)
         except ValueError:
             pass
 

--- a/volatility/framework/symbols/windows/extensions/pool.py
+++ b/volatility/framework/symbols/windows/extensions/pool.py
@@ -165,6 +165,29 @@ class POOL_HEADER(objects.StructType):
                 pass
         return headers, sizes
 
+    def is_free_pool(self):
+        return self.PoolType == 0
+
+    def is_paged_pool(self):
+        return self.PoolType % 2 == 0 and self.PoolType > 0
+
+    def is_nonpaged_pool(self):
+        return self.PoolType % 2 == 1
+
+
+class POOL_HEADER_VISTA(POOL_HEADER):
+    """A kernel pool allocation header, updated for Vista and later.
+
+    Exists at the base of the allocation and provides a tag that we can
+    scan for.
+    """
+
+    def is_paged_pool(self):
+        return self.PoolType % 2 == 1
+
+    def is_nonpaged_pool(self):
+        return self.PoolType % 2 == 0 and self.PoolType > 0
+
 
 class POOL_TRACKER_BIG_PAGES(objects.StructType):
     """A kernel big page pool tracker."""


### PR DESCRIPTION
@ikelos Let me know how this looks to fix the issue netscan #226 is waiting on.  It set the type class for _POOL_HEADER based on OS version.  Then defines some methods in the two pre and post Vista classes and uses those methods in the page_type check.