### PR TITLE
CmdLine windows plugin: call on a single process added

### DIFF
--- a/volatility/framework/plugins/windows/cmdline.py
+++ b/volatility/framework/plugins/windows/cmdline.py
@@ -15,6 +15,8 @@ vollog = logging.getLogger(__name__)
 class CmdLine(interfaces.plugins.PluginInterface):
     """Lists process command line arguments."""
 
+    _version = (1, 0, 0)
+
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
@@ -59,9 +61,10 @@ class CmdLine(interfaces.plugins.PluginInterface):
 
         for proc in procs:
             process_name = utility.array_to_string(proc.ImageFileName)
-            proc_id = proc.UniqueProcessId
+            proc_id = "Unknown"
 
             try:
+                proc_id = proc.UniqueProcessId
                 result_text = self.get_cmdline(self.context, self.config["nt_symbols"], proc)
 
             except exceptions.SwappedInvalidAddressException as exp:

--- a/volatility/framework/plugins/windows/cmdline.py
+++ b/volatility/framework/plugins/windows/cmdline.py
@@ -31,7 +31,7 @@ class CmdLine(interfaces.plugins.PluginInterface):
         ]
 
     @classmethod
-    def get_cmdline(self, context: interfaces.context.ContextInterface, 
+    def get_cmdline(cls, context: interfaces.context.ContextInterface, 
                     kernel_table_name: str, proc):
         """Extracts the cmdline from PEB
 
@@ -43,30 +43,14 @@ class CmdLine(interfaces.plugins.PluginInterface):
         Returns:
             A string with the command line
         """
-        try:
-            proc_id = proc.UniqueProcessId
-            proc_layer_name = proc.add_process_layer()
 
-        except exceptions.InvalidAddressException as excp:
-            vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
-                                                                             excp.layer_name))
-            return "Invalid address for PID"
+        proc_id = proc.UniqueProcessId
+        proc_layer_name = proc.add_process_layer()
 
-        try:
-            peb = context.object(kernel_table_name + constants.BANG + "_PEB",
-                                       layer_name = proc_layer_name,
-                                       offset = proc.Peb)
-            result_text = peb.ProcessParameters.CommandLine.get_string()
-
-        except exceptions.SwappedInvalidAddressException as exp:
-            result_text = "Required memory at {0:#x} is inaccessible (swapped)".format(exp.invalid_address)
-
-        except exceptions.PagedInvalidAddressException as exp:
-            result_text = "Required memory at {0:#x} is not valid (process exited?)".format(exp.invalid_address)
-
-        except exceptions.InvalidAddressException as exp:
-            result_text = "Required memory at {0:#x} is not valid (incomplete layer {1}?)".format(
-                exp.invalid_address, exp.layer_name)
+        peb = context.object(kernel_table_name + constants.BANG + "_PEB",
+                             layer_name = proc_layer_name,
+                             offset = proc.Peb)
+        result_text = peb.ProcessParameters.CommandLine.get_string()
 
         return result_text
 
@@ -75,12 +59,24 @@ class CmdLine(interfaces.plugins.PluginInterface):
 
         for proc in procs:
             process_name = utility.array_to_string(proc.ImageFileName)
-            proc_id = "Unknown"
+            proc_id = proc.UniqueProcessId
 
-            result_text = self.get_cmdline(self.context, self.config["nt_symbols"], proc)
+            try:
+                result_text = self.get_cmdline(self.context, self.config["nt_symbols"], proc)
 
+            except exceptions.SwappedInvalidAddressException as exp:
+                result_text = "Required memory at {0:#x} is inaccessible (swapped)".format(exp.invalid_address)
+
+            except exceptions.PagedInvalidAddressException as exp:
+                result_text = "Required memory at {0:#x} is not valid (process exited?)".format(exp.invalid_address)
+
+            except exceptions.InvalidAddressException as exp:
+                result_text = "Process {}: Required memory at {:#x} is not valid (incomplete layer {}?)".format(
+                               proc_id, exp.invalid_address, exp.layer)
+    
+ 
             yield (0, (proc.UniqueProcessId, process_name, result_text))
-
+    
     def run(self):
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
 


### PR DESCRIPTION
Added method "get_cmdline" to be able to call the plugin on a single process.

The general plugin behavior is exactly the same, just moved the "query" part in a
single method, callable from outside