### PR TITLE
BUGFIX: C strings can be zero length. 

### DIFF
--- a/volatility/framework/objects/utility.py
+++ b/volatility/framework/objects/utility.py
@@ -24,8 +24,8 @@ def pointer_to_string(pointer: 'objects.Pointer', count: int, errors: str = 'rep
     """Takes a volatility Pointer to characters and returns a string."""
     if not isinstance(pointer, objects.Pointer):
         raise TypeError("pointer_to_string takes a Pointer")
-    if count < 1:
-        raise ValueError("pointer_to_string requires a positive count")
+    if count < 0:
+        raise ValueError("pointer_to_string requires a positive or zero count")
     char = pointer.dereference()
     return char.cast("string", max_length = count, errors = errors)
 


### PR DESCRIPTION
We should be able to read zero length strings without raising an exception. We can still check if the string is empty as we do for instance [here](https://github.com/volatilityfoundation/volatility3/blob/fe2b2ccaeb075d2c83d7f1bc8ae9fa0bb870ed68/volatility/framework/symbols/linux/__init__.py#L53)
