### PR TITLE
Change bad copy/descriptions for Mac that say Linux

### DIFF
--- a/volatility/framework/plugins/mac/lsmod.py
+++ b/volatility/framework/plugins/mac/lsmod.py
@@ -21,7 +21,7 @@ class Lsmod(plugins.PluginInterface):
             requirements.TranslationLayerRequirement(name = 'primary',
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Linux kernel symbols")
+            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel")
         ]
 
     @classmethod

--- a/volatility/framework/plugins/mac/malfind.py
+++ b/volatility/framework/plugins/mac/malfind.py
@@ -20,7 +20,7 @@ class Malfind(interfaces.plugins.PluginInterface):
             requirements.TranslationLayerRequirement(name = 'primary',
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Linux kernel symbols"),
+            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel"),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',

--- a/volatility/framework/plugins/mac/proc_maps.py
+++ b/volatility/framework/plugins/mac/proc_maps.py
@@ -18,7 +18,7 @@ class Maps(interfaces.plugins.PluginInterface):
             requirements.TranslationLayerRequirement(name = 'primary',
                                                      description = 'Memory layer for the kernel',
                                                      architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Linux kernel symbols"),
+            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel"),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',


### PR DESCRIPTION
A quick fix to strings that didn't make sense.