### PR TITLE
refs #333 catch InvalidAddressException instead of AttributeError when accessing DLL timestamps

### DIFF
--- a/volatility/framework/plugins/windows/dlllist.py
+++ b/volatility/framework/plugins/windows/dlllist.py
@@ -101,7 +101,7 @@ class DllList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
             for entry in proc.load_order_modules():
 
-                BaseDllName = FullDllName = DllLoadTime = renderers.UnreadableValue()
+                BaseDllName = FullDllName = renderers.UnreadableValue()
                 try:
                     BaseDllName = entry.BaseDllName.get_string()
                     # We assume that if the BaseDllName points to an invalid buffer, so will FullDllName
@@ -114,8 +114,10 @@ class DllList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                     # and 32bit version shouldn't have the Quadpart according to MSDN
                     try:
                         DllLoadTime = conversion.wintime_to_datetime(entry.LoadTime.QuadPart)
-                    except AttributeError:
-                        pass
+                    except exceptions.InvalidAddressException:
+                        DllLoadTime = renderers.UnreadableValue()
+                else:
+                    DllLoadTime = renderers.NotApplicableValue()
 
                 dumped = False
                 if self.config['dump']:


### PR DESCRIPTION
This should address #333. In particular, there's no need to catch `AttributeError` if we're already using `dll_load_time_field` which limits accesses to only the Windows versions that have the member. 