### PR TITLE
Plugins: Allow None types in the configuration tree as values

### DIFF
--- a/volatility/framework/interfaces/configuration.py
+++ b/volatility/framework/interfaces/configuration.py
@@ -35,7 +35,7 @@ vollog = logging.getLogger(__name__)
 
 BasicTypes = (int, bool, bytes, str)
 SimpleTypes = Union[int, bool, bytes, str]
-ConfigSimpleType = Union[SimpleTypes, List[SimpleTypes]]
+ConfigSimpleType = Optional[Union[SimpleTypes, List[SimpleTypes]]]
 
 
 def path_join(*args) -> str:
@@ -184,6 +184,8 @@ class HierarchicalDict(collections.abc.Mapping):
                     raise TypeError("Configuration list types cannot contain list types")
                 new_list.append(element_value)
             return new_list
+        elif value is None:
+            return None
         else:
             raise TypeError("Invalid type stored in configuration")
 
@@ -296,7 +298,7 @@ class RequirementInterface(metaclass = ABCMeta):
     def __init__(self,
                  name: str,
                  description: str = None,
-                 default: Optional[ConfigSimpleType] = None,
+                 default: ConfigSimpleType = None,
                  optional: bool = False) -> None:
         """
 
@@ -334,7 +336,7 @@ class RequirementInterface(metaclass = ABCMeta):
         return self._description
 
     @property
-    def default(self) -> Optional[ConfigSimpleType]:
+    def default(self) -> ConfigSimpleType:
         """Returns the default value if one is set."""
         return self._default
 

--- a/volatility/framework/interfaces/plugins.py
+++ b/volatility/framework/interfaces/plugins.py
@@ -102,7 +102,7 @@ class PluginInterface(interfaces.configuration.ConfigurableInterface,
             raise exceptions.PluginRequirementException("The plugin configuration failed to validate")
         # Populate any optional defaults
         for requirement in self.get_requirements():
-            if requirement.name not in self.config and requirement.default is not None:
+            if requirement.name not in self.config:
                 self.config[requirement.name] = requirement.default
 
         self._file_consumer = None  # type: Optional[FileConsumerInterface]


### PR DESCRIPTION
This feels like the right direction.   Since we're essentially using dictionaries, I think supporting None values rather than an entry not existing makes sense, both will need checking when attempting to access something from the config, but None is much easier to check.  I can only imagine this impacting code that a) assumes value in the config means it must always be a valid value or b) that in some way uses None to indicate information.  If we run into any such circumstances, I figure we'll correct them then rather than worrying over the possibilities now.  This has been around for a while, and should be easy to roll back if necessary, so I'll merge this as is.

Closes #324 