### PR TITLE
Renderers: Add in very rudimentary renderer options

### DIFF
--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -167,7 +167,8 @@ class CommandLine:
         partial_args, _ = parser.parse_known_args(known_args)
 
         banner_output = sys.stdout
-        if renderers[partial_args.renderer].structured_output:
+        renderer = renderers[partial_args.renderer]
+        if renderer.structured_output:
             banner_output = sys.stderr
         banner_output.write("Volatility 3 Framework {}\n".format(constants.PACKAGE_VERSION))
 
@@ -226,6 +227,8 @@ class CommandLine:
             seen_automagics.add(amagic)
             if isinstance(amagic, interfaces.configuration.ConfigurableInterface):
                 self.populate_requirements_argparse(parser, amagic.__class__)
+
+        self.populate_requirements_renderer_options(parser, renderers)
 
         subparser = parser.add_subparsers(title = "Plugins",
                                           dest = "plugin",
@@ -311,8 +314,9 @@ class CommandLine:
 
         try:
             # Construct and run the plugin
+            options = []
             if constructed:
-                renderers[args.renderer]().render(constructed.run())
+                renderer(options).render(constructed.run())
         except (exceptions.VolatilityException) as excp:
             self.process_exceptions(excp)
 
@@ -363,7 +367,7 @@ class CommandLine:
             detail = "{}".format(excp)
             caused_by = [
                 "An invalid symbol table", "A plugin requesting a bad symbol",
-                                           "A plugin requesting a symbol from the wrong table"
+                "A plugin requesting a symbol from the wrong table"
             ]
         elif isinstance(excp, exceptions.LayerException):
             general = "Volatility experienced a layer-related issue: {}".format(excp.layer_name)
@@ -574,6 +578,24 @@ class CommandLine:
                                 dest = requirement.name,
                                 required = not requirement.optional,
                                 **additional)
+
+    def populate_requirements_renderer_options(self, parser: argparse.ArgumentParser,
+                                               renderers: Dict[str, Type[text_renderer.CLIRenderer]]):
+        renderer_parser = parser.add_argument_group('renderer', 'Renderer options')
+        for renderer_name in renderers:
+            renderer = renderers[renderer_name]
+            for option in renderer.get_render_options():
+                config_name = '-'.join([renderer.name, option.name])
+                extra_options = {
+                    'help': option.description,
+                    'type': option.option_type,
+                    'dest': config_name.replace('-', '_')
+                }
+                if option.option_type == bool:
+                    del extra_options['type']
+                    extra_options['action'] = 'store_true'
+                renderer_parser.add_argument("--" + config_name,
+                                             **extra_options)
 
 
 def main():

--- a/volatility/framework/constants/__init__.py
+++ b/volatility/framework/constants/__init__.py
@@ -39,7 +39,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 0  # Number of changes that only add to the interface
+VERSION_MINOR = 1  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = "-beta.1"
 

--- a/volatility/framework/interfaces/__init__.py
+++ b/volatility/framework/interfaces/__init__.py
@@ -12,5 +12,5 @@ components of volatility to write plugins.
 # Import the submodules we want people to be able to use without importing them themselves
 # This will also avoid namespace issues, because people can use interfaces.layers to
 # avoid clashing with the layers package
-from volatility.framework.interfaces import renderers, configuration, context, layers, objects, plugins, symbols, \
+from volatility.framework.interfaces import configuration, renderers, context, layers, objects, plugins, symbols, \
     automagic


### PR DESCRIPTION
This allows the CLI to expose options that the renderers can offer.
These options are limited (string, int, bool and bytes), so no lists
or choices, etc.

Each renderer's options are also global options, meaning they're always
present (although grouped).  There's two ways of handling this:

a) Prefix each option with the renderer's name, duplicate options are
unique
b) Deduplicate options with duplicate names and prefix 'renderer'

The current choice is a) because b) might confuse people that an option
which only applied to one renderer would be available for all, but
comes with the inconvenience that users must adapt the option name for
those that are duplicated with the same meaning.

This is at least functional and extendable in the future but still a bit
clunky.  We could have brought the entire configuration mechanism into
play, but each renderer would require a context and a config_path and
so on, meaning massive overkill and a non-addition-only API change.


This is not an urgent issue, nor one I would rush through, so I'm happy for this just to sit here and gather comments until everyone's happy with it...