### PR TITLE
Netscan fixes

### DIFF
--- a/volatility/framework/plugins/windows/netscan.py
+++ b/volatility/framework/plugins/windows/netscan.py
@@ -153,10 +153,10 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 (10, 0, 14393): "netscan-win10-14393-x86",
                 (10, 0, 15063): "netscan-win10-15063-x86",
                 (10, 0, 16299): "netscan-win10-15063-x86",
-                (10, 0, 17134): "netscan-win10-15063-x86",
-                (10, 0, 17763): "netscan-win10-15063-x86",
-                (10, 0, 18362): "netscan-win10-15063-x86",
-                (10, 0, 18363): "netscan-win10-15063-x86"
+                (10, 0, 17134): "netscan-win10-17134-x86",
+                (10, 0, 17763): "netscan-win10-17134-x86",
+                (10, 0, 18362): "netscan-win10-17134-x86",
+                (10, 0, 18363): "netscan-win10-17134-x86"
             }
         else:
             version_dict = {
@@ -173,11 +173,12 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 (10, 0, 10586): "netscan-win10-x64",
                 (10, 0, 14393): "netscan-win10-x64",
                 (10, 0, 15063): "netscan-win10-15063-x64",
-                (10, 0, 16299): "netscan-win10-15063-x64",
-                (10, 0, 17134): "netscan-win10-15063-x64",
-                (10, 0, 17763): "netscan-win10-15063-x64",
-                (10, 0, 18362): "netscan-win10-15063-x64",
-                (10, 0, 18363): "netscan-win10-15063-x64"
+                (10, 0, 16299): "netscan-win10-16299-x64",
+                (10, 0, 17134): "netscan-win10-17134-x64",
+                (10, 0, 17763): "netscan-win10-17763-x64",
+                (10, 0, 18362): "netscan-win10-17763-x64",
+                (10, 0, 18363): "netscan-win10-17763-x64",
+                (10, 0, 19041): "netscan-win10-19041-x64"
             }
 
         # when determining the symbol file we have to consider the following cases:
@@ -187,13 +188,15 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         # windows version cannot be determined -> throw exc
         filename = version_dict.get((nt_major_version, nt_minor_version, vers_minor_version))
         if not filename:
-            if nt_major_version == 10:
-                # NtMajorVersion of 10 without a match means a newer version than listed
-                # hence try the latest supported version. If this one throws an error,
-                # support has to be added manually.
-                win_10_versions = sorted([key for key in list(version_dict.keys()) if key[0] == 10])
-                # as win10 MinorVersion counts upwards we can take the last entry
-                latest_version = win_10_versions[-1]
+            # no match on filename means that we possibly have a version newer than those listed here.
+            # try to grab the latest supported version of the current image NT version. If that symbol
+            # version does not work, support has to be added manually.
+            current_versions = [key for key in list(version_dict.keys()) if key[0] == nt_major_version and key[1] == nt_minor_version]
+            current_versions.sort()
+    
+            if current_versions:
+                latest_version = current_versions[-1]
+
                 filename = version_dict.get(latest_version)
                 vollog.debug("Unable to find exact matching symbol file, going with latest: {}".format(filename))
             else:

--- a/volatility/framework/plugins/windows/netscan.py
+++ b/volatility/framework/plugins/windows/netscan.py
@@ -177,7 +177,7 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 (10, 0, 17134): "netscan-win10-17134-x64",
                 (10, 0, 17763): "netscan-win10-17763-x64",
                 (10, 0, 18362): "netscan-win10-17763-x64",
-                (10, 0, 18363): "netscan-win10-17763-x64",
+                (10, 0, 18363): "netscan-win10-18363-x64",
                 (10, 0, 19041): "netscan-win10-19041-x64"
             }
 

--- a/volatility/framework/symbols/windows/netscan-win10-16299-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-16299-x64.json
@@ -49,75 +49,139 @@
             "endian": "little"
         }
     },
-  "symbols": {},
+  "symbols": {
+    "TcpCompartmentSet": {
+      "address": 2059400
+    },
+    "UdpCompartmentSet": {
+      "address": 2055504
+    },
+    "PartitionCount": {
+      "address": 2057284
+    },
+    "PartitionTable": {
+      "address": 2057288
+    }
+  },
   "user_types": {
-    "_TCP_SYN_ENDPOINT": {
+      "_UDP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 88,
+                "offset": 40,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_SYN_OWNER"
+                        "name": "nt_symbols!_EPROCESS"
                     }
+
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 88,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 16,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
+            "LocalAddr": {
+                "offset": 128,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
+                    }
                 }
             },
             "InetAF": {
-                "offset": 72,
+                "offset": 32,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
+
                 }
             },
-            "LocalPort": {
-                "offset": 124,
+            "MaskedPrevObj": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
+            "Port": {
+                "offset": 120,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
-            },
-            "RemotePort": {
-                "offset": 126,
+            }
+        },
+        "kind": "struct",
+        "size": 132
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 48,
                 "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 64,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
                 }
             },
             "LocalAddr": {
-                "offset": 80,
+                "offset": 96,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_LOCAL_ADDRESS"
                     }
+
                 }
             },
-            "RemoteAddress": {
-                "offset": 104,
-                "type": {
+            "InetAF": {
+                "offset": 40,
+                "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_IN_ADDR"
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "MaskedPrevObj": {
+                "offset": 120,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
                     }
                 }
             }
@@ -125,204 +189,27 @@
         "kind": "struct",
         "size": 128
     },
-    "_TCP_TIMEWAIT_ENDPOINT": {
-        "fields": {
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 48,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 72,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 74,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 96
-    },
-    "_UDP_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-
-                }
-            },
-            "CreateTime": {
-                "offset": 88,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "LocalAddr": {
-                "offset": 96,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "InetAF": {
-                "offset": 32,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-
-                }
-            },
-            "Port": {
-                "offset": 128,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 130
-    },
-    "_TCP_LISTENER": {
-        "fields": {
-            "Owner": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-
-                }
-            },
-            "CreateTime": {
-                "offset": 32,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "LocalAddr": {
-                "offset": 88,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-
-                }
-            },
-            "InetAF": {
-                "offset": 96,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-
-                }
-            },
-            "Port": {
-                "offset": 106,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 108
-    },
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 568,
+                "offset": 624,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "nt_symbols!_EPROCESS"
                     }
-
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 640,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 40,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
             "AddrInfo": {
-                "offset": 32,
+                "offset": 24,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -331,41 +218,60 @@
                     }
                 }
             },
+            "HashTableEntry": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LIST_ENTRY"
+                    }
+                }
+            },
             "InetAF": {
-                "offset": 24,
+                "offset": 16,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
-
                 }
             },
             "LocalPort": {
-                "offset": 108,
+                "offset": 112,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "RemotePort": {
-                "offset": 110,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "State": {
-                "offset": 104,
+                "offset": 108,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
                 }
+            },
+            "MaskedPrevObj": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_ENDPOINT"
+                    }
+                }
             }
         },
         "kind": "struct",
-        "size": 576
+        "size": 632
     },
     "_LOCAL_ADDRESS": {
         "fields": {
@@ -384,7 +290,23 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
     },
     "_ADDRINFO": {
         "fields": {
@@ -410,7 +332,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 4
     },
     "_IN_ADDR": {
         "fields": {
@@ -443,7 +365,7 @@
     "_INETAF": {
         "fields": {
             "AddressFamily": {
-                "offset": 20,
+                "offset": 24,
                 "type": {
                     "kind": "base",
                     "name": "unsigned short"
@@ -451,89 +373,7 @@
             }
         },
         "kind": "struct",
-        "size": 22
-    },
-    "_SYN_OWNER": {
-        "fields": {
-            "Process": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 48
-    },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
+        "size": 26
     },
     "_LARGE_INTEGER": {
       "fields": {
@@ -568,6 +408,156 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "MaskedObjectPtr": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6144
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 32
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 232,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 216,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {
@@ -594,7 +584,7 @@
     "producer": {
       "version": "0.0.1",
       "name": "japhlange-by-hand",
-      "datetime": "2020-06-12T14:00:00"
+      "datetime": "2020-05-29T19:28:34"
     },
     "format": "6.0.0"
   }

--- a/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
@@ -51,145 +51,7 @@
     },
   "symbols": {},
   "user_types": {
-    "_TCP_SYN_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_SYN_OWNER"
-                    }
-                }
-            },
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 16,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 72,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 124,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 126,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 104,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
-    },
-    "_TCP_TIMEWAIT_ENDPOINT": {
-        "fields": {
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 48,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 72,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 74,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 96
-    },
-    "_UDP_ENDPOINT": {
+      "_UDP_ENDPOINT": {
         "fields": {
             "Owner": {
                 "offset": 40,
@@ -210,12 +72,12 @@
                 }
             },
             "LocalAddr": {
-                "offset": 96,
+                "offset": 128,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
                     }
                 }
             },
@@ -231,7 +93,7 @@
                 }
             },
             "Port": {
-                "offset": 128,
+                "offset": 120,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -239,12 +101,12 @@
             }
         },
         "kind": "struct",
-        "size": 130
+        "size": 132
     },
     "_TCP_LISTENER": {
         "fields": {
             "Owner": {
-                "offset": 40,
+                "offset": 48,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -255,14 +117,14 @@
                 }
             },
             "CreateTime": {
-                "offset": 32,
+                "offset": 64,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
             "LocalAddr": {
-                "offset": 88,
+                "offset": 96,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -273,7 +135,7 @@
                 }
             },
             "InetAF": {
-                "offset": 96,
+                "offset": 40,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -284,7 +146,7 @@
                 }
             },
             "Port": {
-                "offset": 106,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -292,37 +154,29 @@
             }
         },
         "kind": "struct",
-        "size": 108
+        "size": 116
     },
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 568,
+                "offset": 632,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "nt_symbols!_EPROCESS"
                     }
-
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 648,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 40,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
             "AddrInfo": {
-                "offset": 32,
+                "offset": 24,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -332,32 +186,31 @@
                 }
             },
             "InetAF": {
-                "offset": 24,
+                "offset": 16,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
-
                 }
             },
             "LocalPort": {
-                "offset": 108,
+                "offset": 112,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "RemotePort": {
-                "offset": 110,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "State": {
-                "offset": 104,
+                "offset": 108,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
@@ -365,7 +218,7 @@
             }
         },
         "kind": "struct",
-        "size": 576
+        "size": 632
     },
     "_LOCAL_ADDRESS": {
         "fields": {
@@ -384,7 +237,23 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
     },
     "_ADDRINFO": {
         "fields": {
@@ -410,7 +279,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 4
     },
     "_IN_ADDR": {
         "fields": {
@@ -443,7 +312,7 @@
     "_INETAF": {
         "fields": {
             "AddressFamily": {
-                "offset": 20,
+                "offset": 24,
                 "type": {
                     "kind": "base",
                     "name": "unsigned short"
@@ -451,89 +320,7 @@
             }
         },
         "kind": "struct",
-        "size": 22
-    },
-    "_SYN_OWNER": {
-        "fields": {
-            "Process": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 48
-    },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
+        "size": 26
     },
     "_LARGE_INTEGER": {
       "fields": {
@@ -594,7 +381,7 @@
     "producer": {
       "version": "0.0.1",
       "name": "japhlange-by-hand",
-      "datetime": "2020-06-12T14:00:00"
+      "datetime": "2020-05-29T19:28:34"
     },
     "format": "6.0.0"
   }

--- a/volatility/framework/symbols/windows/netscan-win10-17134-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17134-x86.json
@@ -14,7 +14,7 @@
         },
         "pointer": {
             "kind": "int",
-            "size": 8,
+            "size": 4,
             "signed": false,
             "endian": "little"
         },
@@ -54,7 +54,7 @@
     "_TCP_SYN_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 88,
+                "offset": 32,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -71,264 +71,10 @@
                 }
             },
             "ListEntry": {
-                "offset": 16,
+                "offset": 8,
                 "type": {
                     "kind": "union",
                     "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 72,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 124,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 126,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 104,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
-    },
-    "_TCP_TIMEWAIT_ENDPOINT": {
-        "fields": {
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 48,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 72,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 74,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 96
-    },
-    "_UDP_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-
-                }
-            },
-            "CreateTime": {
-                "offset": 88,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "LocalAddr": {
-                "offset": 96,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "InetAF": {
-                "offset": 32,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-
-                }
-            },
-            "Port": {
-                "offset": 128,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 130
-    },
-    "_TCP_LISTENER": {
-        "fields": {
-            "Owner": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-
-                }
-            },
-            "CreateTime": {
-                "offset": 32,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "LocalAddr": {
-                "offset": 88,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-
-                }
-            },
-            "InetAF": {
-                "offset": 96,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-
-                }
-            },
-            "Port": {
-                "offset": 106,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 108
-    },
-    "_TCP_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 568,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-
-                }
-            },
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 40,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "AddrInfo": {
-                "offset": 32,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_ADDRINFO"
-                    }
                 }
             },
             "InetAF": {
@@ -343,21 +89,275 @@
                 }
             },
             "LocalPort": {
-                "offset": 108,
+                "offset": 60,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "RemotePort": {
-                "offset": 110,
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 28,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 40,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_TIMEWAIT_ENDPOINT": {
+        "fields": {
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "InetAF": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "LocalPort": {
+                "offset": 28,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 30,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "LocalAddr": {
+                "offset": 32,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "RemoteAddress": {
+                "offset": 36,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_UDP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 48,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 20,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 68,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 74
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 32,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "LocalAddr": {
+                "offset": 52,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS"
+                    }
+
+                }
+            },
+            "InetAF": {
+                "offset": 56,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+
+                }
+            },
+            "Port": {
+                "offset": 62,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_TCP_ENDPOINT": {
+        "fields": {
+            "Owner": {
+                "offset": 460,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+                }
+            },
+            "CreateTime": {
+                "offset": 0,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
+                }
+            },
+            "ListEntry": {
+                "offset": 20,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
+                }
+            },
+            "AddrInfo": {
+                "offset": 12,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_ADDRINFO"
+                    }
+                }
+            },
+            "InetAF": {
+                "offset": 8,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INETAF"
+                    }
+                }
+            },
+            "LocalPort": {
+                "offset": 60,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
+            },
+            "RemotePort": {
+                "offset": 62,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "State": {
-                "offset": 104,
+                "offset": 56,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
@@ -365,12 +365,12 @@
             }
         },
         "kind": "struct",
-        "size": 576
+        "size": 464
     },
     "_LOCAL_ADDRESS": {
         "fields": {
             "pData": {
-                "offset": 16,
+                "offset": 12,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -384,7 +384,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 16
     },
     "_ADDRINFO": {
         "fields": {
@@ -399,7 +399,7 @@
                 }
             },
             "Remote": {
-                "offset": 16,
+                "offset": 12,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -410,7 +410,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 16
     },
     "_IN_ADDR": {
         "fields": {
@@ -443,7 +443,7 @@
     "_INETAF": {
         "fields": {
             "AddressFamily": {
-                "offset": 20,
+                "offset": 12,
                 "type": {
                     "kind": "base",
                     "name": "unsigned short"
@@ -451,12 +451,12 @@
             }
         },
         "kind": "struct",
-        "size": 22
+        "size": 14
     },
     "_SYN_OWNER": {
         "fields": {
             "Process": {
-                "offset": 40,
+                "offset": 24,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -467,73 +467,7 @@
             }
         },
         "kind": "struct",
-        "size": 48
-    },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
+        "size": 14
     },
     "_LARGE_INTEGER": {
       "fields": {
@@ -594,7 +528,7 @@
     "producer": {
       "version": "0.0.1",
       "name": "japhlange-by-hand",
-      "datetime": "2020-06-12T14:00:00"
+      "datetime": "2020-05-29T19:28:34"
     },
     "format": "6.0.0"
   }

--- a/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
@@ -51,145 +51,7 @@
     },
   "symbols": {},
   "user_types": {
-    "_TCP_SYN_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_SYN_OWNER"
-                    }
-                }
-            },
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 16,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 72,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 124,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 126,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 104,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
-    },
-    "_TCP_TIMEWAIT_ENDPOINT": {
-        "fields": {
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 48,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 72,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 74,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 96
-    },
-    "_UDP_ENDPOINT": {
+      "_UDP_ENDPOINT": {
         "fields": {
             "Owner": {
                 "offset": 40,
@@ -210,12 +72,12 @@
                 }
             },
             "LocalAddr": {
-                "offset": 96,
+                "offset": 128,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
                     }
                 }
             },
@@ -231,7 +93,7 @@
                 }
             },
             "Port": {
-                "offset": 128,
+                "offset": 120,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -239,12 +101,12 @@
             }
         },
         "kind": "struct",
-        "size": 130
+        "size": 132
     },
     "_TCP_LISTENER": {
         "fields": {
             "Owner": {
-                "offset": 40,
+                "offset": 48,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -255,14 +117,14 @@
                 }
             },
             "CreateTime": {
-                "offset": 32,
+                "offset": 64,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
             "LocalAddr": {
-                "offset": 88,
+                "offset": 96,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -273,7 +135,7 @@
                 }
             },
             "InetAF": {
-                "offset": 96,
+                "offset": 40,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -284,7 +146,7 @@
                 }
             },
             "Port": {
-                "offset": 106,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -292,37 +154,29 @@
             }
         },
         "kind": "struct",
-        "size": 108
+        "size": 116
     },
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 568,
+                "offset": 656,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "nt_symbols!_EPROCESS"
                     }
-
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 672,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 40,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
             "AddrInfo": {
-                "offset": 32,
+                "offset": 24,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -332,32 +186,31 @@
                 }
             },
             "InetAF": {
-                "offset": 24,
+                "offset": 16,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
-
                 }
             },
             "LocalPort": {
-                "offset": 108,
+                "offset": 112,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "RemotePort": {
-                "offset": 110,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "State": {
-                "offset": 104,
+                "offset": 108,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
@@ -365,7 +218,7 @@
             }
         },
         "kind": "struct",
-        "size": 576
+        "size": 632
     },
     "_LOCAL_ADDRESS": {
         "fields": {
@@ -384,7 +237,23 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
     },
     "_ADDRINFO": {
         "fields": {
@@ -410,7 +279,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 4
     },
     "_IN_ADDR": {
         "fields": {
@@ -443,7 +312,7 @@
     "_INETAF": {
         "fields": {
             "AddressFamily": {
-                "offset": 20,
+                "offset": 24,
                 "type": {
                     "kind": "base",
                     "name": "unsigned short"
@@ -451,89 +320,7 @@
             }
         },
         "kind": "struct",
-        "size": 22
-    },
-    "_SYN_OWNER": {
-        "fields": {
-            "Process": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 48
-    },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
+        "size": 26
     },
     "_LARGE_INTEGER": {
       "fields": {
@@ -594,7 +381,7 @@
     "producer": {
       "version": "0.0.1",
       "name": "japhlange-by-hand",
-      "datetime": "2020-06-12T14:00:00"
+      "datetime": "2020-05-29T19:28:34"
     },
     "format": "6.0.0"
   }

--- a/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
@@ -51,145 +51,7 @@
     },
   "symbols": {},
   "user_types": {
-    "_TCP_SYN_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_SYN_OWNER"
-                    }
-                }
-            },
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 16,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 72,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 124,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 126,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 104,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
-    },
-    "_TCP_TIMEWAIT_ENDPOINT": {
-        "fields": {
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 48,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 72,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 74,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 96
-    },
-    "_UDP_ENDPOINT": {
+      "_UDP_ENDPOINT": {
         "fields": {
             "Owner": {
                 "offset": 40,
@@ -210,12 +72,12 @@
                 }
             },
             "LocalAddr": {
-                "offset": 96,
+                "offset": 128,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
                     }
                 }
             },
@@ -231,7 +93,7 @@
                 }
             },
             "Port": {
-                "offset": 128,
+                "offset": 120,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -239,12 +101,12 @@
             }
         },
         "kind": "struct",
-        "size": 130
+        "size": 132
     },
     "_TCP_LISTENER": {
         "fields": {
             "Owner": {
-                "offset": 40,
+                "offset": 48,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -255,14 +117,14 @@
                 }
             },
             "CreateTime": {
-                "offset": 32,
+                "offset": 64,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
             "LocalAddr": {
-                "offset": 88,
+                "offset": 96,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -273,7 +135,7 @@
                 }
             },
             "InetAF": {
-                "offset": 96,
+                "offset": 40,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -284,7 +146,7 @@
                 }
             },
             "Port": {
-                "offset": 106,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -292,37 +154,29 @@
             }
         },
         "kind": "struct",
-        "size": 108
+        "size": 116
     },
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 568,
+                "offset": 656,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "nt_symbols!_EPROCESS"
                     }
-
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 672,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 40,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
             "AddrInfo": {
-                "offset": 32,
+                "offset": 24,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -332,32 +186,31 @@
                 }
             },
             "InetAF": {
-                "offset": 24,
+                "offset": 16,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
-
                 }
             },
             "LocalPort": {
-                "offset": 108,
+                "offset": 112,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "RemotePort": {
-                "offset": 110,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "State": {
-                "offset": 104,
+                "offset": 108,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
@@ -365,7 +218,7 @@
             }
         },
         "kind": "struct",
-        "size": 576
+        "size": 632
     },
     "_LOCAL_ADDRESS": {
         "fields": {
@@ -384,7 +237,23 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
     },
     "_ADDRINFO": {
         "fields": {
@@ -410,7 +279,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 4
     },
     "_IN_ADDR": {
         "fields": {
@@ -443,7 +312,7 @@
     "_INETAF": {
         "fields": {
             "AddressFamily": {
-                "offset": 20,
+                "offset": 24,
                 "type": {
                     "kind": "base",
                     "name": "unsigned short"
@@ -451,89 +320,7 @@
             }
         },
         "kind": "struct",
-        "size": 22
-    },
-    "_SYN_OWNER": {
-        "fields": {
-            "Process": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 48
-    },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
+        "size": 26
     },
     "_LARGE_INTEGER": {
       "fields": {
@@ -594,7 +381,7 @@
     "producer": {
       "version": "0.0.1",
       "name": "japhlange-by-hand",
-      "datetime": "2020-06-12T14:00:00"
+      "datetime": "2020-05-29T19:28:34"
     },
     "format": "6.0.0"
   }

--- a/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
@@ -72,7 +72,7 @@
                 }
             },
             "LocalAddr": {
-                "offset": 128,
+                "offset": 136,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -93,7 +93,7 @@
                 }
             },
             "Port": {
-                "offset": 120,
+                "offset": 128,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"

--- a/volatility/framework/symbols/windows/netscan-win10-19041-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-19041-x64.json
@@ -51,278 +51,152 @@
     },
   "symbols": {},
   "user_types": {
-    "_TCP_SYN_ENDPOINT": {
+      "_UDP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 88,
+                "offset": 40,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_SYN_OWNER"
+                        "name": "nt_symbols!_EPROCESS"
                     }
+
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 88,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 16,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
+            "LocalAddr": {
+                "offset": 168,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
+                    }
                 }
             },
             "InetAF": {
-                "offset": 72,
+                "offset": 32,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
+
                 }
             },
-            "LocalPort": {
-                "offset": 124,
+            "MaskedPrevObj": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
+            "Port": {
+                "offset": 160,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
-            },
-            "RemotePort": {
-                "offset": 126,
+            }
+        },
+        "kind": "struct",
+        "size": 132
+    },
+    "_TCP_LISTENER": {
+        "fields": {
+            "Owner": {
+                "offset": 48,
                 "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_EPROCESS"
+                    }
+
+                }
+            },
+            "CreateTime": {
+                "offset": 64,
+                "type": {
+                    "kind": "union",
+                    "name": "_LARGE_INTEGER"
                 }
             },
             "LocalAddr": {
-                "offset": 80,
+                "offset": 96,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_LOCAL_ADDRESS"
                     }
+
                 }
             },
-            "RemoteAddress": {
-                "offset": 104,
-                "type": {
+            "InetAF": {
+                "offset": 40,
+                "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_IN_ADDR"
+                        "name": "_INETAF"
                     }
+
+                }
+            },
+            "MaskedPrevObj": {
+                "offset": 120,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
+                }
+            },
+            "Port": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
                 }
             }
         },
         "kind": "struct",
         "size": 128
     },
-    "_TCP_TIMEWAIT_ENDPOINT": {
-        "fields": {
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 48,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 72,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 74,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 96
-    },
-    "_UDP_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-
-                }
-            },
-            "CreateTime": {
-                "offset": 88,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "LocalAddr": {
-                "offset": 96,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "InetAF": {
-                "offset": 32,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-
-                }
-            },
-            "Port": {
-                "offset": 128,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 130
-    },
-    "_TCP_LISTENER": {
-        "fields": {
-            "Owner": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-
-                }
-            },
-            "CreateTime": {
-                "offset": 32,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "LocalAddr": {
-                "offset": 88,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-
-                }
-            },
-            "InetAF": {
-                "offset": 96,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-
-                }
-            },
-            "Port": {
-                "offset": 106,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 108
-    },
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 568,
+                "offset": 728,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "nt_symbols!_EPROCESS"
                     }
-
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 744,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 40,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
             "AddrInfo": {
-                "offset": 32,
+                "offset": 24,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -332,32 +206,31 @@
                 }
             },
             "InetAF": {
-                "offset": 24,
+                "offset": 16,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
-
                 }
             },
             "LocalPort": {
-                "offset": 108,
+                "offset": 112,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "RemotePort": {
-                "offset": 110,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "State": {
-                "offset": 104,
+                "offset": 108,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
@@ -365,7 +238,7 @@
             }
         },
         "kind": "struct",
-        "size": 576
+        "size": 632
     },
     "_LOCAL_ADDRESS": {
         "fields": {
@@ -384,7 +257,23 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
     },
     "_ADDRINFO": {
         "fields": {
@@ -410,7 +299,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 4
     },
     "_IN_ADDR": {
         "fields": {
@@ -443,7 +332,7 @@
     "_INETAF": {
         "fields": {
             "AddressFamily": {
-                "offset": 20,
+                "offset": 24,
                 "type": {
                     "kind": "base",
                     "name": "unsigned short"
@@ -451,89 +340,7 @@
             }
         },
         "kind": "struct",
-        "size": 22
-    },
-    "_SYN_OWNER": {
-        "fields": {
-            "Process": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 48
-    },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
+        "size": 26
     },
     "_LARGE_INTEGER": {
       "fields": {
@@ -594,7 +401,7 @@
     "producer": {
       "version": "0.0.1",
       "name": "japhlange-by-hand",
-      "datetime": "2020-06-12T14:00:00"
+      "datetime": "2020-05-29T19:28:34"
     },
     "format": "6.0.0"
   }

--- a/volatility/framework/symbols/windows/netscan-win10-19041-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-19041-x86.json
@@ -14,7 +14,7 @@
         },
         "pointer": {
             "kind": "int",
-            "size": 8,
+            "size": 4,
             "signed": false,
             "endian": "little"
         },
@@ -51,145 +51,7 @@
     },
   "symbols": {},
   "user_types": {
-    "_TCP_SYN_ENDPOINT": {
-        "fields": {
-            "Owner": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_SYN_OWNER"
-                    }
-                }
-            },
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 16,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 72,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 124,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 126,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 104,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
-    },
-    "_TCP_TIMEWAIT_ENDPOINT": {
-        "fields": {
-            "CreateTime": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "_LARGE_INTEGER"
-                }
-            },
-            "ListEntry": {
-                "offset": 0,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
-            "InetAF": {
-                "offset": 48,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_INETAF"
-                    }
-                }
-            },
-            "LocalPort": {
-                "offset": 72,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "RemotePort": {
-                "offset": 74,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
-            "LocalAddr": {
-                "offset": 80,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
-                    }
-                }
-            },
-            "RemoteAddress": {
-                "offset": 88,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_IN_ADDR"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 96
-    },
-    "_UDP_ENDPOINT": {
+      "_UDP_ENDPOINT": {
         "fields": {
             "Owner": {
                 "offset": 40,
@@ -210,12 +72,12 @@
                 }
             },
             "LocalAddr": {
-                "offset": 96,
+                "offset": 160,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
-                        "name": "_LOCAL_ADDRESS"
+                        "name": "_LOCAL_ADDRESS_WIN10_UDP"
                     }
                 }
             },
@@ -231,7 +93,7 @@
                 }
             },
             "Port": {
-                "offset": 128,
+                "offset": 152,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -239,12 +101,12 @@
             }
         },
         "kind": "struct",
-        "size": 130
+        "size": 132
     },
     "_TCP_LISTENER": {
         "fields": {
             "Owner": {
-                "offset": 40,
+                "offset": 48,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -255,14 +117,14 @@
                 }
             },
             "CreateTime": {
-                "offset": 32,
+                "offset": 64,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
             "LocalAddr": {
-                "offset": 88,
+                "offset": 96,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -273,7 +135,7 @@
                 }
             },
             "InetAF": {
-                "offset": 96,
+                "offset": 40,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -284,7 +146,7 @@
                 }
             },
             "Port": {
-                "offset": 106,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -292,37 +154,29 @@
             }
         },
         "kind": "struct",
-        "size": 108
+        "size": 116
     },
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 568,
+                "offset": 624,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "nt_symbols!_EPROCESS"
                     }
-
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 616,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
-            "ListEntry": {
-                "offset": 40,
-                "type": {
-                    "kind": "union",
-                    "name": "nt_symbols!_LIST_ENTRY"
-                }
-            },
             "AddrInfo": {
-                "offset": 32,
+                "offset": 24,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -332,32 +186,31 @@
                 }
             },
             "InetAF": {
-                "offset": 24,
+                "offset": 16,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
                         "kind": "struct",
                         "name": "_INETAF"
                     }
-
                 }
             },
             "LocalPort": {
-                "offset": 108,
+                "offset": 112,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "RemotePort": {
-                "offset": 110,
+                "offset": 114,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
                 }
             },
             "State": {
-                "offset": 104,
+                "offset": 108,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
@@ -365,7 +218,7 @@
             }
         },
         "kind": "struct",
-        "size": 576
+        "size": 632
     },
     "_LOCAL_ADDRESS": {
         "fields": {
@@ -384,7 +237,23 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 20
+    },
+    "_LOCAL_ADDRESS_WIN10_UDP": {
+        "fields": {
+            "pData": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_IN_ADDR"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4
     },
     "_ADDRINFO": {
         "fields": {
@@ -410,7 +279,7 @@
             }
         },
         "kind": "struct",
-        "size": 24
+        "size": 4
     },
     "_IN_ADDR": {
         "fields": {
@@ -443,7 +312,7 @@
     "_INETAF": {
         "fields": {
             "AddressFamily": {
-                "offset": 20,
+                "offset": 24,
                 "type": {
                     "kind": "base",
                     "name": "unsigned short"
@@ -451,89 +320,7 @@
             }
         },
         "kind": "struct",
-        "size": 22
-    },
-    "_SYN_OWNER": {
-        "fields": {
-            "Process": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "nt_symbols!_EPROCESS"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 48
-    },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
+        "size": 26
     },
     "_LARGE_INTEGER": {
       "fields": {
@@ -594,7 +381,7 @@
     "producer": {
       "version": "0.0.1",
       "name": "japhlange-by-hand",
-      "datetime": "2020-06-12T14:00:00"
+      "datetime": "2020-08-20T17:00:00"
     },
     "format": "6.0.0"
   }

--- a/volatility/framework/symbols/windows/netscan-win10-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-x86.json
@@ -246,7 +246,7 @@
     "_TCP_LISTENER": {
         "fields": {
             "Owner": {
-                "offset": 24,
+                "offset": 28,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -257,14 +257,14 @@
                 }
             },
             "CreateTime": {
-                "offset": 32,
+                "offset": 40,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
                 }
             },
             "LocalAddr": {
-                "offset": 52,
+                "offset": 60,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -275,7 +275,7 @@
                 }
             },
             "InetAF": {
-                "offset": 56,
+                "offset": 64,
                 "type":{
                     "kind": "pointer",
                     "subtype": {
@@ -286,7 +286,7 @@
                 }
             },
             "Port": {
-                "offset": 62,
+                "offset": 70,
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
@@ -294,7 +294,7 @@
             }
         },
         "kind": "struct",
-        "size": 64
+        "size": 72
     },
     "_TCP_ENDPOINT": {
         "fields": {
@@ -309,7 +309,7 @@
                 }
             },
             "CreateTime": {
-                "offset": 0,
+                "offset": 440,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
@@ -365,7 +365,7 @@
             }
         },
         "kind": "struct",
-        "size": 436
+        "size": 448
     },
     "_LOCAL_ADDRESS": {
         "fields": {

--- a/volatility/framework/symbols/windows/versions.py
+++ b/volatility/framework/symbols/windows/versions.py
@@ -107,6 +107,9 @@ is_win10_16299_or_later = OsDistinguisher(version_check = lambda x: x >= (10, 0,
                                                              ("_EPROCESS", "KeepAliveCounter", False),
                                                              ("_EPROCESS", "ControlFlowGuardEnabled", False)])
 
+is_win10_18363_or_later = OsDistinguisher(version_check = lambda x: x >= (10, 0, 18363),
+                                          fallback_checks = [("_KQOS_GROUPING_SETS", None, True)])
+
 is_windows_10 = OsDistinguisher(version_check = lambda x: x >= (10, 0),
                                 fallback_checks = [("ObHeaderCookie", None, True)])
 


### PR DESCRIPTION
Fixes a few things for `netscan`.

- the symbol table is chosen based on the newest one available for the given Windows version not just for Win10, but for older versions as well (>= Vista)
- fixes bug which can occur when trying to dereference a nullpointer actually works because the image has a valid virtual memory address of `0`, which happened to me in exactly one memory image of 30. Honestly no idea how often this will happen...
- adds a bunch of new symbol tables for different Windows versions, including the change for Win10x64_18363 found by @mikevsunny in https://github.com/volatilityfoundation/volatility/issues/763. This obviously does not fix the issue that 18363 is not properly detected, but one step after the other :)

Note: https://github.com/volatilityfoundation/volatility3/pull/392/files#diff-4f922f46a5f105772c8f988caf36079c512c87a01949d0639a991ff080024187 contains a bunch of symbols which are needed for parsing the "official" kernel network address lists. I have only documented those for Win10x64_16299 for now, but they will (most likely) be added for the other Windows versions later on. I hope it's okay that they are already contained here, but if necessary I can remove them for this PR.