### PR TITLE
Netstat for x64 Windows

### DIFF
--- a/volatility/framework/plugins/windows/netlist.py
+++ b/volatility/framework/plugins/windows/netlist.py
@@ -1,0 +1,363 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import datetime
+from typing import Iterable, List, Optional, Callable
+
+from volatility.framework import constants, exceptions, interfaces, renderers, symbols, layers
+from volatility.framework.configuration import requirements
+from volatility.framework.renderers import format_hints
+from volatility.framework.symbols import intermed
+from volatility.framework.symbols.windows.extensions import network
+from volatility.framework.symbols.windows.pdbutil import PDBUtility
+from volatility.plugins import timeliner
+from volatility.plugins.windows import info, poolscanner, netscan, modules
+
+vollog = logging.getLogger(__name__)
+
+
+class NetList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
+    """Scans for network objects present in a particular windows memory image."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.TranslationLayerRequirement(name = 'primary',
+                                                     description = 'Memory layer for the kernel',
+                                                     architectures = ["Intel32", "Intel64"]),
+            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.VersionRequirement(name = 'netscan', component = netscan.NetScan, version = (1, 0, 0)),
+            requirements.BooleanRequirement(
+                name = 'include-corrupt',
+                description =
+                "Radically eases result validation. This will show partially overwritten data. WARNING: the results are likely to include garbage and/or corrupt data. Be cautious!",
+                default = False,
+                optional = True),
+        ]
+
+    @classmethod
+    def _decode_pointer(self, value):
+        """Windows encodes pointers to objects and decodes them on the fly
+        before using them.
+
+        This function mimics the decoding routine so we can generate the
+        proper pointer values as well.
+        """
+
+        value = value & 0xFFFFFFFFFFFFFFFC
+
+        return value
+
+    @classmethod
+    def read_pointer(cls,
+                     context: interfaces.context.ContextInterface,
+                     layer_name: str,
+                     offset: int,
+                     length: int) -> int:
+
+        return int.from_bytes(context.layers[layer_name].read(offset, length), "little")
+
+    @classmethod
+    def parse_bitmap(cls,
+                     context: interfaces.context.ContextInterface,
+                     layer_name: str,
+                     bitmap_offset: int,
+                     bitmap_size_in_byte: int) -> list:
+        ret = []
+        for idx in range(bitmap_size_in_byte-1):
+            current_byte = context.layers[layer_name].read(bitmap_offset + idx, 1)[0]
+            current_offs = idx*8
+            if current_byte&1 != 0:
+                ret.append(0 + current_offs)
+            if current_byte&2 != 0:
+                ret.append(1 + current_offs)
+            if current_byte&4 != 0:
+                ret.append(2 + current_offs)
+            if current_byte&8 != 0:
+                ret.append(3 + current_offs)
+            if current_byte&16 != 0:
+                ret.append(4 + current_offs)
+            if current_byte&32 != 0:
+                ret.append(5 + current_offs)
+            if current_byte&64 != 0:
+                ret.append(6 + current_offs)
+            if current_byte&128 != 0:
+                ret.append(7 + current_offs)
+        return ret
+
+    @classmethod
+    def enumerate_structures_by_port(cls,
+                       context: interfaces.context.ContextInterface,
+                       layer_name: str,
+                       net_symbol_table: str,
+                       port: int,
+                       ppobj,
+                       proto="tcp"):
+        if proto == "tcp":
+            obj_name = net_symbol_table + constants.BANG + "_TCP_LISTENER"
+            ptr_offset = context.symbol_space.get_type(obj_name).relative_child_offset("Next")
+        elif proto == "udp":
+            obj_name = net_symbol_table + constants.BANG + "_UDP_ENDPOINT"
+            ptr_offset = context.symbol_space.get_type(obj_name).relative_child_offset("Next")
+        else:
+            yield
+        list_index = port >> 8
+        truncated_port = port & 0xff
+        inpa = ppobj.PortAssignments[list_index].dereference()
+        assignment = inpa.InPaBigPoolBase.dereference().Assignments[truncated_port]
+        if not assignment:
+            yield
+        netw_inside = cls._decode_pointer(assignment.Entry)
+        if netw_inside:
+            curr_obj = context.object(obj_name, layer_name = layer_name, offset = netw_inside - ptr_offset)
+            vollog.debug("Found object @ 0x{:2x}, yielding...".format(curr_obj.vol.offset))
+            yield curr_obj
+
+            vollog.debug("PrevPointer val: {}".format(curr_obj.Next))
+            while curr_obj.Next:
+                curr_obj = context.object(obj_name, layer_name = layer_name, offset = cls._decode_pointer(curr_obj.Next) - ptr_offset)
+                yield curr_obj
+                vollog.debug("Checking if PrevPointer is valid (val: {})".format(curr_obj.Next))
+
+    @classmethod
+    def get_tcpip_module(cls, context, layer_name, nt_symbols):
+        for mod in modules.Modules.list_modules(context, layer_name, nt_symbols):
+            # ~ print(mod.BaseDllName.get_string())
+            if mod.BaseDllName.get_string() == "tcpip.sys":
+                vollog.debug("Found tcpip.sys offset @ 0x{:x}".format(mod.DllBase))
+                return mod
+
+    @classmethod
+    def get_tcpip_guid(cls, context, layer_name, tcpip_module):
+        return list(
+            PDBUtility.pdbname_scan(
+                context,
+                layer_name,
+                context.layers[layer_name].page_size,
+                [b"tcpip.pdb"],
+                start=tcpip_module.DllBase,
+                end=tcpip_module.DllBase + tcpip_module.SizeOfImage
+            )
+        )
+
+    @classmethod
+    def parse_hashtable(cls, context, layer_name, ht_offset, ht_length, pointer_length) -> list:
+        # ~ ret = []
+        for idx in range(ht_length):
+            current_qword = (0xffff000000000000 | cls.read_pointer(context, layer_name, ht_offset + idx * 16, pointer_length))
+            if current_qword == (0xffff000000000000 | (ht_offset + idx * 16)):
+                continue
+            yield current_qword
+
+    @classmethod
+    def parse_partitions(cls, context, layer_name, net_symbol_table, tcpip_symbol_table, tcpip_module_offset, pointer_length):
+        # ~ endpoints = []
+        obj_name = net_symbol_table + constants.BANG + "_TCP_ENDPOINT"
+        pto = context.symbol_space.get_symbol(tcpip_symbol_table + constants.BANG + "PartitionTable").address
+        pco = context.symbol_space.get_symbol(tcpip_symbol_table + constants.BANG + "PartitionCount").address
+        part_table = cls.read_pointer(context, layer_name, tcpip_module_offset + pto, pointer_length)
+        part_count = int.from_bytes(context.layers[layer_name].read(tcpip_module_offset + pco, 1), "little")
+        partitions = []
+        for part_idx in range(part_count):
+            current_partition = context.object(net_symbol_table + "!_PARTITION", layer_name = layer_name, offset = part_table + 128 * part_idx)
+            partitions.append(current_partition)
+        for partition in partitions:
+            if partition.Endpoints.NumEntries > 0:
+                for endpoint_entry in cls.parse_hashtable(context, layer_name, partition.Endpoints.Directory, 128, pointer_length):
+                    # ~ yield endpoint
+                    entry_offset = context.symbol_space.get_type(obj_name).relative_child_offset("HashTableEntry")
+                    endpoint = context.object(obj_name, layer_name = layer_name, offset = endpoint_entry - entry_offset)
+                    yield endpoint
+                # ~ endpoints.extend(parse_hashtable(partition.Endpoints.Directory, 128))
+        # ~ return endpoints
+
+    @classmethod
+    def create_tcpip_symbol_table(cls,
+                                    context: interfaces.context.ContextInterface,
+                                    config_path: str,
+                                    layer_name: str,
+                                    tcpip_module):
+
+        guids = cls.get_tcpip_guid(context, layer_name, tcpip_module)
+
+        if not guids:
+            print("no pdb found!")
+            raise
+
+        guid = guids[0]
+
+        vollog.debug("Found {}: {}-{}".format(guid["pdb_name"], guid["GUID"], guid["age"]))
+
+        return PDBUtility.load_windows_symbol_table(context,
+                                                    guid["GUID"],
+                                                    guid["age"],
+                                                    guid["pdb_name"],
+                                                    "volatility.framework.symbols.intermed.IntermediateSymbolTable",
+                                                    config_path="tcpip")
+
+    @classmethod
+    def list_sockets(cls,
+                       context: interfaces.context.ContextInterface,
+                       layer_name: str,
+                       nt_symbols,
+                       net_symbol_table: str,
+                       tcpip_module,
+                       tcpip_symbol_table: str) -> \
+            Iterable[interfaces.objects.ObjectInterface]:
+        """Lists all the processes in the primary layer that are in the pid
+        config option.
+
+        Args:
+            context: The context to retrieve required elements (layers, symbol tables) from
+            layer_name: The name of the layer on which to operate
+            nt_symbols: The name of the table containing the kernel symbols
+            net_symbol_table: The name of the table containing the tcpip symbols
+
+        Returns:
+            The list of network objects from the `layer_name` layer's `PartitionTable` and `PortPools`
+        """
+
+        tcpip_vo = tcpip_module.DllBase
+
+        pointer_length = context.symbol_space.get_type(net_symbol_table + constants.BANG + "pointer").size
+
+        # tcpe
+
+        for endpoint in cls.parse_partitions(context, layer_name, net_symbol_table, tcpip_symbol_table, tcpip_vo, pointer_length):
+            yield endpoint
+
+        # listeners
+
+        ucs = context.symbol_space.get_symbol(tcpip_symbol_table + constants.BANG + "UdpCompartmentSet").address
+        tcs = context.symbol_space.get_symbol(tcpip_symbol_table + constants.BANG + "TcpCompartmentSet").address
+
+        ucs_offset = cls.read_pointer(context, layer_name, tcpip_vo + ucs, pointer_length)
+        tcs_offset = cls.read_pointer(context, layer_name, tcpip_vo + tcs, pointer_length)
+
+        ucs_obj = context.object(net_symbol_table + constants.BANG + "_INET_COMPARTMENT_SET", layer_name = layer_name, offset = ucs_offset)
+        upp_addr = ucs_obj.InetCompartment.dereference().ProtocolCompartment.dereference().PortPool
+
+        upp_obj = context.object(net_symbol_table + constants.BANG + "_INET_PORT_POOL", layer_name = layer_name, offset = upp_addr)
+        udpa_ports = cls.parse_bitmap(context, layer_name, upp_obj.PortBitMap.Buffer, upp_obj.PortBitMap.SizeOfBitMap // 8)
+
+        tcs_obj = context.object(net_symbol_table + constants.BANG + "_INET_COMPARTMENT_SET", layer_name = layer_name, offset = tcs_offset)
+        tpp_addr = tcs_obj.InetCompartment.dereference().ProtocolCompartment.dereference().PortPool
+
+        tpp_obj = context.object(net_symbol_table + constants.BANG + "_INET_PORT_POOL", layer_name = layer_name, offset = tpp_addr)
+        tcpl_ports = cls.parse_bitmap(context, layer_name, tpp_obj.PortBitMap.Buffer, tpp_obj.PortBitMap.SizeOfBitMap // 8)
+
+        for port in tcpl_ports:
+            if port == 0:
+                continue
+            for obj in cls.enumerate_structures_by_port(context, layer_name, net_symbol_table, port, tpp_obj, "tcp"):
+                yield obj
+
+        for port in udpa_ports:
+            if port == 0:
+                continue
+            for obj in cls.enumerate_structures_by_port(context, layer_name, net_symbol_table, port, upp_obj, "udp"):
+                yield obj
+
+    def _generator(self, show_corrupt_results: Optional[bool] = None):
+        """ Generates the network objects for use in rendering. """
+
+        netscan_symbol_table = netscan.NetScan.create_netscan_symbol_table(self.context, self.config["primary"],
+                                                                self.config["nt_symbols"], self.config_path)
+
+        tcpip_module = self.get_tcpip_module(self.context, self.config["primary"], self.config["nt_symbols"])
+
+        tcpip_symbol_table = self.create_tcpip_symbol_table(self.context, self.config_path, self.config["primary"], tcpip_module)
+
+        for netw_obj in self.list_sockets(self.context,
+                                            self.config['primary'],
+                                            self.config['nt_symbols'],
+                                            netscan_symbol_table,
+                                            tcpip_module,
+                                            tcpip_symbol_table):
+
+            vollog.debug("Found netw obj @ 0x{:2x} of assumed type {}".format(netw_obj.vol.offset, type(netw_obj)))
+            # objects passed pool header constraints. check for additional constraints if strict flag is set.
+            if not show_corrupt_results and not netw_obj.is_valid():
+                continue
+
+            if isinstance(netw_obj, network._UDP_ENDPOINT):
+                vollog.debug("Found UDP_ENDPOINT @ 0x{:2x}".format(netw_obj.vol.offset))
+
+                # For UdpA, the state is always blank and the remote end is asterisks
+                for ver, laddr, _ in netw_obj.dual_stack_sockets():
+                    yield (0, (format_hints.Hex(netw_obj.vol.offset), "UDP" + ver, laddr, netw_obj.Port, "*", 0, "",
+                               netw_obj.get_owner_pid() or renderers.UnreadableValue(), netw_obj.get_owner_procname()
+                               or renderers.UnreadableValue(), netw_obj.get_create_time()
+                               or renderers.UnreadableValue()))
+
+            elif isinstance(netw_obj, network._TCP_ENDPOINT):
+                vollog.debug("Found _TCP_ENDPOINT @ 0x{:2x}".format(netw_obj.vol.offset))
+                if netw_obj.get_address_family() == network.AF_INET:
+                    proto = "TCPv4"
+                elif netw_obj.get_address_family() == network.AF_INET6:
+                    proto = "TCPv6"
+                else:
+                    proto = "TCPv?"
+
+                try:
+                    state = netw_obj.State.description
+                except ValueError:
+                    state = renderers.UnreadableValue()
+
+                yield (0, (format_hints.Hex(netw_obj.vol.offset), proto, netw_obj.get_local_address()
+                           or renderers.UnreadableValue(), netw_obj.LocalPort, netw_obj.get_remote_address()
+                           or renderers.UnreadableValue(), netw_obj.RemotePort, state, netw_obj.get_owner_pid()
+                           or renderers.UnreadableValue(), netw_obj.get_owner_procname() or renderers.UnreadableValue(),
+                           netw_obj.get_create_time() or renderers.UnreadableValue()))
+
+            # check for isinstance of tcp listener last, because all other objects are inherited from here
+            elif isinstance(netw_obj, network._TCP_LISTENER):
+                vollog.debug("Found _TCP_LISTENER @ 0x{:2x}".format(netw_obj.vol.offset))
+
+                # For TcpL, the state is always listening and the remote port is zero
+                for ver, laddr, raddr in netw_obj.dual_stack_sockets():
+                    yield (0, (format_hints.Hex(netw_obj.vol.offset), "TCP" + ver, laddr, netw_obj.Port, raddr, 0,
+                               "LISTENING", netw_obj.get_owner_pid() or renderers.UnreadableValue(),
+                               netw_obj.get_owner_procname() or renderers.UnreadableValue(), netw_obj.get_create_time()
+                               or renderers.UnreadableValue()))
+            else:
+                # this should not happen therefore we log it.
+                vollog.debug("Found network object unsure of its type: {} of type {}".format(netw_obj, type(netw_obj)))
+
+    def generate_timeline(self):
+        for row in self._generator():
+            _depth, row_data = row
+            # Skip network connections without creation time
+            if not isinstance(row_data[9], datetime.datetime):
+                continue
+            row_data = [
+                "N/A" if isinstance(i, renderers.UnreadableValue) or isinstance(i, renderers.UnparsableValue) else i
+                for i in row_data
+            ]
+            description = "Network connection: Process {} {} Local Address {}:{} " \
+                          "Remote Address {}:{} State {} Protocol {} ".format(row_data[7], row_data[8],
+                                                                              row_data[2], row_data[3],
+                                                                              row_data[4], row_data[5],
+                                                                              row_data[6], row_data[1])
+            yield (description, timeliner.TimeLinerType.CREATED, row_data[9])
+
+    def run(self):
+        show_corrupt_results = self.config.get('include-corrupt', None)
+
+        return renderers.TreeGrid([
+            ("Offset", format_hints.Hex),
+            ("Proto", str),
+            ("LocalAddr", str),
+            ("LocalPort", int),
+            ("ForeignAddr", str),
+            ("ForeignPort", int),
+            ("State", str),
+            ("PID", int),
+            ("Owner", str),
+            ("Created", datetime.datetime),
+        ], self._generator(show_corrupt_results = show_corrupt_results))

--- a/volatility/framework/plugins/windows/netscan.py
+++ b/volatility/framework/plugins/windows/netscan.py
@@ -179,7 +179,7 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 (10, 0, 16299): "netscan-win10-16299-x64",
                 (10, 0, 17134): "netscan-win10-17134-x64",
                 (10, 0, 17763): "netscan-win10-17763-x64",
-                (10, 0, 18362): "netscan-win10-17763-x64",
+                (10, 0, 18362): "netscan-win10-18362-x64",
                 (10, 0, 18363): "netscan-win10-18363-x64",
                 (10, 0, 19041): "netscan-win10-19041-x64"
             }

--- a/volatility/framework/plugins/windows/netstat.py
+++ b/volatility/framework/plugins/windows/netstat.py
@@ -18,8 +18,8 @@ from volatility.plugins.windows import netscan, modules
 vollog = logging.getLogger(__name__)
 
 
-class NetList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
-    """Scans for network objects present in a particular windows memory image."""
+class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
+    """Traverses network tracking structures present in a particular windows memory image."""
 
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)

--- a/volatility/framework/symbols/windows/extensions/network.py
+++ b/volatility/framework/symbols/windows/extensions/network.py
@@ -199,21 +199,21 @@ class _TCP_ENDPOINT(_TCP_LISTENER):
     def is_valid(self):
 
         if self.State not in self.State.choices.values():
-            vollog.debug("invalid due to invalid tcp state {}".format(self.State))
+            vollog.debug("{} 0x{:x} invalid due to invalid tcp state {}".format(type(self), self.vol.offset, self.State))
             return False
 
         try:
             if self.get_address_family() not in (AF_INET, AF_INET6):
-                vollog.debug("invalid due to invalid address_family {}".format(self.get_address_family()))
+                vollog.debug("{} 0x{:x} invalid due to invalid address_family {}".format(type(self), self.vol.offset, self.get_address_family()))
                 return False
 
             if not self.get_local_address() and (not self.get_owner() or self.get_owner().UniqueProcessId == 0
                                                  or self.get_owner().UniqueProcessId > 65535):
-                vollog.debug("invalid due to invalid owner data")
+                vollog.debug("{} 0x{:x} invalid due to invalid owner data".format(type(self), self.vol.offset))
                 return False
 
         except exceptions.InvalidAddressException:
-            vollog.debug("invalid due to invalid address access")
+            vollog.debug("{} 0x{:x} invalid due to invalid address access".format(type(self), self.vol.offset))
             return False
 
         return True

--- a/volatility/framework/symbols/windows/netscan-win10-15063-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-15063-x64.json
@@ -92,6 +92,16 @@
 
                 }
             },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
             "Port": {
                 "offset": 120,
                 "type": {
@@ -114,6 +124,16 @@
                         "name": "nt_symbols!_EPROCESS"
                     }
 
+                }
+            },
+            "Next": {
+                "offset": 120,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
                 }
             },
             "CreateTime": {
@@ -193,6 +213,13 @@
                         "kind": "struct",
                         "name": "_INETAF"
                     }
+                }
+            },
+            "ListEntry": {
+                "offset": 40,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
                 }
             },
             "LocalPort": {
@@ -355,6 +382,173 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6144
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 32
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 232,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 216,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-15063-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-15063-x86.json
@@ -238,6 +238,16 @@
                     "kind": "base",
                     "name": "unsigned be short"
                 }
+            },
+            "Next": {
+                "offset": 76,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
             }
         },
         "kind": "struct",
@@ -290,6 +300,16 @@
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
+                }
+            },
+            "Next": {
+                "offset": 72,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
                 }
             }
         },
@@ -502,6 +522,173 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 324,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 20,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 4,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 8
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4096
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 152,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 144,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 4,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-16299-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-16299-x64.json
@@ -105,7 +105,7 @@
 
                 }
             },
-            "MaskedPrevObj": {
+            "Next": {
                 "offset": 112,
                 "type":{
                     "kind": "pointer",
@@ -175,7 +175,7 @@
                     "name": "unsigned be short"
                 }
             },
-            "MaskedPrevObj": {
+            "Next": {
                 "offset": 120,
                 "type":{
                     "kind": "pointer",
@@ -259,7 +259,7 @@
                     "name": "TCPStateEnum"
                 }
             },
-            "MaskedPrevObj": {
+            "Next": {
                 "offset": 112,
                 "type":{
                     "kind": "pointer",
@@ -459,7 +459,7 @@
     },
     "_PORT_ASSIGNMENT_ENTRY": {
         "fields": {
-            "MaskedObjectPtr": {
+            "Entry": {
                 "offset": 8,
                 "type": {
                     "kind": "pointer",

--- a/volatility/framework/symbols/windows/netscan-win10-16299-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-16299-x64.json
@@ -220,12 +220,9 @@
             },
             "ListEntry": {
                 "offset": 40,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LIST_ENTRY"
-                    }
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
                 }
             },
             "InetAF": {
@@ -552,6 +549,23 @@
                     "subtype": {
                       "kind": "struct",
                       "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
                     }
                 }
             }

--- a/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
@@ -242,7 +242,7 @@
                     "name": "unsigned be short"
                 }
             },
-            "HashTableEntry": {
+            "ListEntry": {
                 "offset": 40,
                 "type":{
                     "kind": "pointer",

--- a/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
@@ -555,6 +555,23 @@
         },
         "kind": "struct",
         "size": 128
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
@@ -49,7 +49,20 @@
             "endian": "little"
         }
     },
-  "symbols": {},
+  "symbols": {
+    "TcpCompartmentSet": {
+      "address": 2010312
+    },
+    "UdpCompartmentSet": {
+      "address": 2006416
+    },
+    "PartitionCount": {
+      "address": 2008196
+    },
+    "PartitionTable": {
+      "address": 2008200
+    }
+  },
   "user_types": {
       "_UDP_ENDPOINT": {
         "fields": {
@@ -90,6 +103,16 @@
                         "name": "_INETAF"
                     }
 
+                }
+            },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
                 }
             },
             "Port": {
@@ -143,6 +166,16 @@
                         "name": "_INETAF"
                     }
 
+                }
+            },
+            "Next": {
+                "offset": 120,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
                 }
             },
             "Port": {
@@ -209,11 +242,31 @@
                     "name": "unsigned be short"
                 }
             },
+            "HashTableEntry": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LIST_ENTRY"
+                    }
+                }
+            },
             "State": {
                 "offset": 108,
                 "type": {
                     "kind": "enum",
                     "name": "TCPStateEnum"
+                }
+            },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_ENDPOINT"
+                    }
                 }
             }
         },
@@ -355,6 +408,156 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6144
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 32
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 232,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 216,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17134-x64.json
@@ -244,12 +244,9 @@
             },
             "ListEntry": {
                 "offset": 40,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LIST_ENTRY"
-                    }
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
                 }
             },
             "State": {

--- a/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
@@ -242,7 +242,7 @@
                     "name": "unsigned be short"
                 }
             },
-            "HashTableEntry": {
+            "ListEntry": {
                 "offset": 40,
                 "type":{
                     "kind": "pointer",

--- a/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
@@ -555,6 +555,23 @@
         },
         "kind": "struct",
         "size": 128
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
@@ -244,12 +244,9 @@
             },
             "ListEntry": {
                 "offset": 40,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LIST_ENTRY"
-                    }
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
                 }
             },
             "Next": {

--- a/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-17763-x64.json
@@ -49,7 +49,20 @@
             "endian": "little"
         }
     },
-  "symbols": {},
+  "symbols": {
+    "TcpCompartmentSet": {
+      "address": 2010312
+    },
+    "UdpCompartmentSet": {
+      "address": 2006416
+    },
+    "PartitionCount": {
+      "address": 2008196
+    },
+    "PartitionTable": {
+      "address": 2008200
+    }
+  },
   "user_types": {
       "_UDP_ENDPOINT": {
         "fields": {
@@ -90,6 +103,16 @@
                         "name": "_INETAF"
                     }
 
+                }
+            },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
                 }
             },
             "Port": {
@@ -143,6 +166,16 @@
                         "name": "_INETAF"
                     }
 
+                }
+            },
+            "Next": {
+                "offset": 120,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
                 }
             },
             "Port": {
@@ -207,6 +240,26 @@
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
+                }
+            },
+            "HashTableEntry": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LIST_ENTRY"
+                    }
+                }
+            },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_ENDPOINT"
+                    }
                 }
             },
             "State": {
@@ -355,6 +408,156 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6144
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 32
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 232,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 216,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-18362-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18362-x64.json
@@ -555,6 +555,23 @@
         },
         "kind": "struct",
         "size": 128
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-18362-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18362-x64.json
@@ -244,12 +244,9 @@
             },
             "ListEntry": {
                 "offset": 40,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LIST_ENTRY"
-                    }
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
                 }
             },
             "Next": {

--- a/volatility/framework/symbols/windows/netscan-win10-18362-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18362-x64.json
@@ -51,16 +51,16 @@
     },
   "symbols": {
     "TcpCompartmentSet": {
-      "address": 2059400
+      "address": 2010312
     },
     "UdpCompartmentSet": {
-      "address": 2055504
+      "address": 2006416
     },
     "PartitionCount": {
-      "address": 2057284
+      "address": 2008196
     },
     "PartitionTable": {
-      "address": 2057288
+      "address": 2008200
     }
   },
   "user_types": {
@@ -168,13 +168,6 @@
 
                 }
             },
-            "Port": {
-                "offset": 114,
-                "type": {
-                    "kind": "base",
-                    "name": "unsigned be short"
-                }
-            },
             "Next": {
                 "offset": 120,
                 "type":{
@@ -184,15 +177,22 @@
                         "name": "_TCP_LISTENER"
                     }
                 }
+            },
+            "Port": {
+                "offset": 114,
+                "type": {
+                    "kind": "base",
+                    "name": "unsigned be short"
+                }
             }
         },
         "kind": "struct",
-        "size": 128
+        "size": 116
     },
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 624,
+                "offset": 656,
                 "type": {
                     "kind": "pointer",
                     "subtype": {
@@ -202,7 +202,7 @@
                 }
             },
             "CreateTime": {
-                "offset": 640,
+                "offset": 672,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"
@@ -215,16 +215,6 @@
                     "subtype": {
                         "kind": "struct",
                         "name": "_ADDRINFO"
-                    }
-                }
-            },
-            "ListEntry": {
-                "offset": 40,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LIST_ENTRY"
                     }
                 }
             },
@@ -252,11 +242,14 @@
                     "name": "unsigned be short"
                 }
             },
-            "State": {
-                "offset": 108,
-                "type": {
-                    "kind": "enum",
-                    "name": "TCPStateEnum"
+            "ListEntry": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LIST_ENTRY"
+                    }
                 }
             },
             "Next": {
@@ -267,6 +260,13 @@
                         "kind": "struct",
                         "name": "_TCP_ENDPOINT"
                     }
+                }
+            },
+            "State": {
+                "offset": 108,
+                "type": {
+                    "kind": "enum",
+                    "name": "TCPStateEnum"
                 }
             }
         },
@@ -509,7 +509,7 @@
     "_INET_PORT_POOL": {
         "fields": {
             "PortAssignments": {
-                "offset": 232,
+                "offset": 224,
                 "type": {
                     "count": 256,
                     "kind": "array",
@@ -523,7 +523,7 @@
                 }
             },
             "PortBitMap": {
-                "offset": 216,
+                "offset": 208,
                 "type": {
                     "kind": "struct",
                     "name": "nt_symbols!_RTL_BITMAP"

--- a/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
@@ -231,12 +231,9 @@
             },
             "ListEntry": {
                 "offset": 40,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_LIST_ENTRY"
-                    }
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
                 }
             },
             "Next": {

--- a/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
@@ -542,6 +542,23 @@
         },
         "kind": "struct",
         "size": 128
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
@@ -229,7 +229,7 @@
                     "name": "unsigned be short"
                 }
             },
-            "HashTableEntry": {
+            "ListEntry": {
                 "offset": 40,
                 "type":{
                     "kind": "pointer",
@@ -496,7 +496,7 @@
     "_INET_PORT_POOL": {
         "fields": {
             "PortAssignments": {
-                "offset": 232,
+                "offset": 224,
                 "type": {
                     "count": 256,
                     "kind": "array",
@@ -510,7 +510,7 @@
                 }
             },
             "PortBitMap": {
-                "offset": 216,
+                "offset": 208,
                 "type": {
                     "kind": "struct",
                     "name": "nt_symbols!_RTL_BITMAP"

--- a/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-18363-x64.json
@@ -92,6 +92,16 @@
 
                 }
             },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
             "Port": {
                 "offset": 128,
                 "type": {
@@ -143,6 +153,16 @@
                         "name": "_INETAF"
                     }
 
+                }
+            },
+            "Next": {
+                "offset": 120,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
                 }
             },
             "Port": {
@@ -207,6 +227,26 @@
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
+                }
+            },
+            "HashTableEntry": {
+                "offset": 40,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_LIST_ENTRY"
+                    }
+                }
+            },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_ENDPOINT"
+                    }
                 }
             },
             "State": {
@@ -355,6 +395,156 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6144
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 32
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 232,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 216,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-19041-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win10-19041-x64.json
@@ -71,6 +71,16 @@
                     "name": "_LARGE_INTEGER"
                 }
             },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
             "LocalAddr": {
                 "offset": 168,
                 "type":{
@@ -92,16 +102,6 @@
 
                 }
             },
-            "MaskedPrevObj": {
-                "offset": 112,
-                "type":{
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "struct",
-                        "name": "_UDP_ENDPOINT"
-                    }
-                }
-            },
             "Port": {
                 "offset": 160,
                 "type": {
@@ -111,7 +111,7 @@
             }
         },
         "kind": "struct",
-        "size": 132
+        "size": 168
     },
     "_TCP_LISTENER": {
         "fields": {
@@ -155,7 +155,7 @@
 
                 }
             },
-            "MaskedPrevObj": {
+            "Next": {
                 "offset": 120,
                 "type":{
                     "kind": "pointer",
@@ -203,6 +203,13 @@
                         "kind": "struct",
                         "name": "_ADDRINFO"
                     }
+                }
+            },
+            "ListEntry": {
+                "offset": 40,
+                "type": {
+                    "kind": "union",
+                    "name": "nt_symbols!_LIST_ENTRY"
                 }
             },
             "InetAF": {
@@ -375,6 +382,173 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 32
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 6144
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 24,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 32
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 224,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 208,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 192
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win10-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win10-x86.json
@@ -211,6 +211,16 @@
                     "name": "_LARGE_INTEGER"
                 }
             },
+            "Next": {
+                "offset": 76,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
             "LocalAddr": {
                 "offset": 56,
                 "type":{
@@ -291,10 +301,20 @@
                     "kind": "base",
                     "name": "unsigned be short"
                 }
+            },
+            "Next": {
+                "offset": 72,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
+                }
             }
         },
         "kind": "struct",
-        "size": 72
+        "size": 78
     },
     "_TCP_ENDPOINT": {
         "fields": {
@@ -502,6 +522,173 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 4,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 8
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4096
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 152,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 144,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 4,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win7-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win7-x64.json
@@ -489,72 +489,6 @@
         "kind": "struct",
         "size": 48
     },
-    "_PARTITION_TABLE": {
-        "fields": {
-            "HashTable": {
-                "offset": 0,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown2": {
-                "offset": 8,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown3": {
-                "offset": 16,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown4": {
-                "offset": 24,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown5": {
-                "offset": 32,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            },
-            "Unknown6": {
-                "offset": 40,
-                "type": {
-                    "kind": "pointer",
-                    "subtype": {
-                        "kind": "base",
-                        "name": "void"
-                    }
-                }
-            }
-        },
-        "kind": "struct",
-        "size": 128
-    },
     "_LARGE_INTEGER": {
       "fields": {
         "HighPart": {
@@ -732,6 +666,26 @@
                     "subtype": {
                       "kind": "struct",
                       "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PARTITION"
+                        }
                     }
                 }
             }

--- a/volatility/framework/symbols/windows/netscan-win7-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win7-x64.json
@@ -681,11 +681,8 @@
                     "count": 1,
                     "kind": "array",
                     "subtype": {
-                        "kind": "pointer",
-                        "subtype": {
-                          "kind": "struct",
-                          "name": "_PARTITION"
-                        }
+                        "kind": "struct",
+                        "name": "_PARTITION"
                     }
                 }
             }

--- a/volatility/framework/symbols/windows/netscan-win7-x64.json
+++ b/volatility/framework/symbols/windows/netscan-win7-x64.json
@@ -230,6 +230,16 @@
 
                 }
             },
+            "Next": {
+                "offset": 136,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
             "Port": {
                 "offset": 128,
                 "type": {
@@ -239,7 +249,7 @@
             }
         },
         "kind": "struct",
-        "size": 130
+        "size": 138
     },
     "_TCP_LISTENER": {
         "fields": {
@@ -288,6 +298,16 @@
                 "type": {
                     "kind": "base",
                     "name": "unsigned be short"
+                }
+            },
+            "Next": {
+                "offset": 112,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
                 }
             }
         },
@@ -568,6 +588,156 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4096
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 40
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 160,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 144,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 8,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 16,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 128
     }
   },
   "enums": {

--- a/volatility/framework/symbols/windows/netscan-win7-x86.json
+++ b/volatility/framework/symbols/windows/netscan-win7-x86.json
@@ -231,6 +231,16 @@
 
                 }
             },
+            "Next": {
+                "offset": 76,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_UDP_ENDPOINT"
+                    }
+                }
+            },
             "Port": {
                 "offset": 72,
                 "type": {
@@ -290,10 +300,20 @@
                     "kind": "base",
                     "name": "unsigned be short"
                 }
+            },
+            "Next": {
+                "offset": 64,
+                "type":{
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_TCP_LISTENER"
+                    }
+                }
             }
         },
         "kind": "struct",
-        "size": 64
+        "size": 72
     },
     "_TCP_ENDPOINT": {
         "fields": {
@@ -503,6 +523,173 @@
       },
       "kind": "union",
       "size": 8
+    },
+    "_INET_COMPARTMENT_SET": {
+        "fields": {
+            "InetCompartment": {
+                "offset": 328,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_INET_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 384
+    },
+    "_INET_COMPARTMENT": {
+        "fields": {
+            "ProtocolCompartment": {
+                "offset": 32,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PROTOCOL_COMPARTMENT"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 48
+    },
+    "_PROTOCOL_COMPARTMENT": {
+        "fields": {
+            "PortPool": {
+                "offset": 0,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_INET_PORT_POOL"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 16
+    },
+    "_PORT_ASSIGNMENT_ENTRY": {
+        "fields": {
+            "Entry": {
+                "offset": 4,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "base",
+                      "name": "void"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 8
+    },
+    "_PORT_ASSIGNMENT_LIST": {
+        "fields": {
+            "Assignments": {
+                "offset": 0,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PORT_ASSIGNMENT_ENTRY"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 4096
+    },
+    "_PORT_ASSIGNMENT": {
+        "fields": {
+            "InPaBigPoolBase": {
+                "offset": 20,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "_PORT_ASSIGNMENT_LIST"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 24
+    },
+    "_INET_PORT_POOL": {
+        "fields": {
+            "PortAssignments": {
+                "offset": 88,
+                "type": {
+                    "count": 256,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "pointer",
+                        "subtype": {
+                          "kind": "struct",
+                          "name": "_PORT_ASSIGNMENT"
+                        }
+                    }
+                }
+            },
+            "PortBitMap": {
+                "offset": 80,
+                "type": {
+                    "kind": "struct",
+                    "name": "nt_symbols!_RTL_BITMAP"
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 11200
+    },
+    "_PARTITION": {
+        "fields": {
+            "Endpoints" : {
+                "offset": 4,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            },
+            "UnknownHashTable" : {
+                "offset": 12,
+                "type": {
+                    "kind": "pointer",
+                    "subtype": {
+                      "kind": "struct",
+                      "name": "nt_symbols!_RTL_DYNAMIC_HASH_TABLE"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
+    },
+    "_PARTITION_TABLE": {
+        "fields": {
+            "Partitions": {
+                "offset": 0,
+                "type": {
+                    "count": 1,
+                    "kind": "array",
+                    "subtype": {
+                        "kind": "struct",
+                        "name": "_PARTITION"
+                    }
+                }
+            }
+        },
+        "kind": "struct",
+        "size": 64
     }
   },
   "enums": {


### PR DESCRIPTION
This plugin parses the "official" tcpip.sys kernel structures to find network connections, similar to what `netstat` does. 
~It is named `netlist` because it is to `netscan` what `pslist` is to `psscan`.~ Renamed to `netstat` for consistency :)

It finds...
- TCP Endpoints by parsing the TCP Partition Table (see _The Art of Memory Forensics_, chapter 11)
- UDP Endpoints by parsing the UDP port pool
- TCP Listeners by parsing the TCP port pool

It depends on some requirements:
- the given image must have its `tcpip.sys` PE image headers accessible in memory to fetch the PDB GUID (this has worked for every image I have tested this with, so I consider this given)
- the offsets must be correct, but that of course is required for every plugin with custom objects ;)

This plugin is of course way faster than `netscan`, but might not find every object the poolscanner will find (especially older, not-yet-deleted ones). Also, kernel-mode malware might be able to hide entries from the mentioned structures, but to counter that you can easily compare the outputs of `netscan` and `netstat`. (Also, if I was a rootkit, I'd "just" hook the enumeration APIs and not bother touching weird, undocumented structures deep inside drivers...)

For now it only supports 64-bit Windows as I haven't gotten around adding x86 support yet and I would prefer feedback earlier than later :)

List of supported builds (more will follow at some point):
- Win7x64
- Win10x64_16299
- Win10x64_17134
- Win10x64_17763
- Win10x64_18362
- Win10x64_18363

There is probably a lot of room for optimization in the code, but I wanted to get this one out for discussion :D

And of course, testing is welcome!!