### PR TITLE
Objects: Make repr(object) more useful

### DIFF
--- a/volatility/framework/objects/__init__.py
+++ b/volatility/framework/objects/__init__.py
@@ -549,6 +549,10 @@ class Array(interfaces.objects.ObjectInterface, collections.abc.Sequence):
         self._vol['count'] = value
         self._vol['size'] = value * self._vol['subtype'].size
 
+    def __repr__(self) -> str:
+        """Describes the object appropriately"""
+        return AggregateType.__repr__(self)
+
     class VolTemplateProxy(interfaces.objects.ObjectInterface.VolTemplateProxy):
 
         @classmethod
@@ -642,6 +646,15 @@ class AggregateType(interfaces.objects.ObjectInterface):
         """Returns whether the object would contain a member called
         member_name."""
         return member_name in self.vol.members
+
+    def __repr__(self) -> str:
+        """Describes the object appropriately"""
+        extras = member_name = ''
+        if self.vol.native_layer_name != self.vol.layer_name:
+            extras += f' (Native: {self.vol.native_layer_name})'
+        if self.vol.member_name:
+            member_name = f' (.{self.vol.member_name})'
+        return f'<{self.__class__.__name__} {self.vol.type_name}{member_name}: {self.vol.layer_name} @ 0x{self.vol.offset:x} #{self.vol.size}{extras}>'
 
     class VolTemplateProxy(interfaces.objects.ObjectInterface.VolTemplateProxy):
 


### PR DESCRIPTION
When working on volshell, just getting the standard object repr kinda always requires an extra step to get information about the object.  This provides most of it up-front.  I've opted for only ever returning common data for all objects (mostly just structs and arrays), but we *could* change the output to include for example the array count (although technically the size will give that way) and things like the array's subtype/target.  I think I'm happy at this level, but as always, open for review...  5:)