### PR TITLE
Automagic: Windows DTB finder was too limited

### DIFF
--- a/volatility/framework/automagic/windows.py
+++ b/volatility/framework/automagic/windows.py
@@ -225,8 +225,7 @@ class PageMapScanner(interfaces.layers.ScannerInterface):
             for page_offset in range(0, len(data), 0x1000):
                 result = test(data, data_offset, page_offset)
                 if result is not None:
-                    if result[0] < self.chunk_size:
-                        yield (test, result[0])
+                    yield (test, result[0])
 
 
 class WintelHelper(interfaces.automagic.AutomagicInterface):


### PR DESCRIPTION
The DTB finder test returns a full DTB, if that's over the scan chunk
size it'll get discarded, so we remove that test.

This is a small hotfix, and shouldn't have major consequences, but you never know.  Again, mostly waiting on the workflow discussion to happen.