### PR TITLE
Linux: Use native_layer when constructing from a pointer offset

### DIFF
--- a/volatility/framework/symbols/mac/extensions/__init__.py
+++ b/volatility/framework/symbols/mac/extensions/__init__.py
@@ -270,7 +270,7 @@ class vm_map_entry(objects.StructType):
 
         if found:
             vpager = context.object(config_prefix + constants.BANG + "vnode_pager",
-                                    layer_name = vnode_object.vol.layer_name,
+                                    layer_name = vnode_object.vol.native_layer_name,
                                     offset = vnode_object.pager)
             ret = vpager.vnode_handle
         else:


### PR DESCRIPTION
Spotted this, not sure if there's other instances of it, but might be worth a think if there's any other clearly similar locations where a pointer dereference from scanned objects situation might occur.  5:)

I'll merge it once you're happy with it (and the workflow discussion's happened).