### PR TITLE
Feature/disable caching

### DIFF
--- a/volatility/__init__.py
+++ b/volatility/__init__.py
@@ -10,6 +10,8 @@ from typing import List, TypeVar, Callable, Any, Optional
 _T = TypeVar("_T")
 _S = TypeVar("_S")
 
+CACHING = True
+
 
 class classproperty(property):
     """Class property decorator.

--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -22,6 +22,11 @@ import traceback
 from typing import Dict, Type, Union, Any
 from urllib import parse, request
 
+import volatility
+
+if "--live" in sys.argv:
+    volatility.CACHING = False
+
 import volatility.plugins
 import volatility.symbols
 from volatility import framework
@@ -134,6 +139,7 @@ class CommandLine:
                             help = "Log output to a file as well as the console",
                             default = None,
                             type = str)
+        parser.add_argument("--live", help = "Disable caching of layer reads", action = 'store_true')
         parser.add_argument("-o",
                             "--output-dir",
                             help = "Directory in which to output any generated files",

--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -107,7 +107,7 @@ class CommandLine:
                             default = None,
                             type = str)
         parser.add_argument("--parallelism",
-                            help = "Enables parallelism (defaults to processes if no argument given)",
+                            help = "Enables parallelism (defaults to off if no argument given)",
                             nargs = '?',
                             choices = ['processes', 'threads', 'off'],
                             const = 'processes',

--- a/volatility/framework/caching.py
+++ b/volatility/framework/caching.py
@@ -1,0 +1,9 @@
+import functools
+import volatility
+
+
+def lru_cache(*args, **kwargs):
+    if not volatility.CACHING:
+        return lambda x: x
+    raise Exception
+    return functools.lru_cache(*args, **kwargs)

--- a/volatility/framework/constants/__init__.py
+++ b/volatility/framework/constants/__init__.py
@@ -66,10 +66,13 @@ if sys.platform == 'windows':
 os.makedirs(CACHE_PATH, exist_ok = True)
 
 LINUX_BANNERS_PATH = os.path.join(CACHE_PATH, "linux_banners.cache")
-""""Default location to record information about available linux banners"""
+"""Default location to record information about available linux banners"""
 
 MAC_BANNERS_PATH = os.path.join(CACHE_PATH, "mac_banners.cache")
-""""Default location to record information about available mac banners"""
+"""Default location to record information about available mac banners"""
+
+CACHING = True
+"""Allows the disabling of caching for reads (which vastly speeds up object accesses and layer scanning)"""
 
 BUG_URL = "https://github.com/volatilityfoundation/volatility3/issues"
 

--- a/volatility/framework/contexts/__init__.py
+++ b/volatility/framework/contexts/__init__.py
@@ -12,7 +12,7 @@ import functools
 import hashlib
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
-from volatility.framework import constants, interfaces, symbols, exceptions
+from volatility.framework import constants, interfaces, symbols, exceptions, caching
 from volatility.framework.objects import templates
 
 
@@ -277,7 +277,7 @@ class SizedModule(Module):
         return self._size
 
     @property  # type: ignore # FIXME: mypy #5107
-    @functools.lru_cache()
+    @caching.lru_cache()
     def hash(self) -> str:
         """Hashes the module for equality checks.
 

--- a/volatility/framework/interfaces/layers.py
+++ b/volatility/framework/interfaces/layers.py
@@ -18,7 +18,7 @@ import types
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
-from volatility.framework import constants, exceptions, interfaces
+from volatility.framework import constants, exceptions, interfaces, caching
 
 vollog = logging.getLogger(__name__)
 
@@ -419,7 +419,7 @@ class TranslationLayerInterface(DataLayerInterface, metaclass = ABCMeta):
 
     # ## Read/Write functions for mapped pages
 
-    @functools.lru_cache(maxsize = 512)
+    @caching.lru_cache(maxsize = 512)
     def read(self, offset: int, length: int, pad: bool = False) -> bytes:
         """Reads an offset for length bytes and returns 'bytes' (not 'str') of
         length size."""

--- a/volatility/framework/layers/intel.py
+++ b/volatility/framework/layers/intel.py
@@ -3,14 +3,13 @@
 #
 
 import collections
-import functools
 import logging
 import math
 import struct
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from volatility import classproperty
-from volatility.framework import exceptions, interfaces, constants
+from volatility.framework import exceptions, interfaces, constants, caching
 from volatility.framework.configuration import requirements
 from volatility.framework.layers import linear
 
@@ -156,7 +155,7 @@ class Intel(linear.LinearlyMappedLayer):
 
         return entry, position
 
-    @functools.lru_cache(1025)
+    @caching.lru_cache(1025)
     def _get_valid_table(self, base_address: int) -> Optional[bytes]:
         """Extracts the table, validates it and returns it if it's valid."""
         table = self._context.layers.read(self._base_layer, base_address, self.page_size)

--- a/volatility/framework/layers/linear.py
+++ b/volatility/framework/layers/linear.py
@@ -1,7 +1,6 @@
-import functools
 from typing import List, Optional, Tuple, Iterable
 
-from volatility.framework import exceptions, interfaces
+from volatility.framework import exceptions, interfaces, caching
 
 
 class LinearlyMappedLayer(interfaces.layers.TranslationLayerInterface):
@@ -28,7 +27,7 @@ class LinearlyMappedLayer(interfaces.layers.TranslationLayerInterface):
     # ## Read/Write functions for mapped pages
     # Redefine read here for speed reasons (so we don't call a processing method
 
-    @functools.lru_cache(maxsize = 512)
+    @caching.lru_cache(maxsize = 512)
     def read(self, offset: int, length: int, pad: bool = False) -> bytes:
         """Reads an offset for length bytes and returns 'bytes' (not 'str') of
         length size."""

--- a/volatility/framework/layers/qemu.py
+++ b/volatility/framework/layers/qemu.py
@@ -6,7 +6,7 @@ import json
 import math
 from typing import Optional, Dict, Any, Tuple, List, Set
 
-from volatility.framework import interfaces, exceptions, constants
+from volatility.framework import interfaces, exceptions, constants, caching
 from volatility.framework.layers import segmented
 from volatility.framework.symbols import intermed
 
@@ -212,7 +212,7 @@ class QemuSuspendLayer(segmented.NonLinearlySegmentedLayer):
             return (data * 0x1000)[:output_length]
         return data
 
-    @functools.lru_cache(maxsize = 512)
+    @caching.lru_cache(maxsize = 512)
     def read(self, offset: int, length: int, pad: bool = False) -> bytes:
         return super().read(offset, length, pad)
 

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -4,13 +4,11 @@
 
 import collections.abc
 import datetime
-import functools
 import logging
-import struct
 import math
-from typing import Iterable, Iterator, Optional, Union, Dict, Tuple, List
+from typing import Iterable, Iterator, Optional, Union, Tuple, List
 
-from volatility.framework import constants, exceptions, interfaces, objects, renderers, symbols
+from volatility.framework import constants, exceptions, interfaces, objects, renderers, symbols, caching
 from volatility.framework.layers import intel
 from volatility.framework.renderers import conversion
 from volatility.framework.symbols import generic
@@ -36,7 +34,7 @@ class MMVAD_SHORT(objects.StructType):
     by VadRoot.
     """
 
-    @functools.lru_cache(maxsize = None)
+    @caching.lru_cache(maxsize = None)
     def get_tag(self):
         vad_address = self.vol.offset
 
@@ -896,8 +894,8 @@ class CONTROL_AREA(objects.StructType):
                 return False
 
             # The first SubsectionBase should not be page aligned
-            #subsection = self.get_subsection()
-            #if subsection.SubsectionBase & self.PAGE_MASK == 0:
+            # subsection = self.get_subsection()
+            # if subsection.SubsectionBase & self.PAGE_MASK == 0:
             #    return False
         except exceptions.InvalidAddressException:
             return False
@@ -946,7 +944,7 @@ class CONTROL_AREA(objects.StructType):
             subsection_offset = starting_sector * 0x200
 
             # Similar to the check in is_valid(), make sure the SubsectionBase is not page aligned.
-            #if subsection.SubsectionBase & self.PAGE_MASK == 0:
+            # if subsection.SubsectionBase & self.PAGE_MASK == 0:
             #    break
 
             ptecount = 0

--- a/volatility/framework/symbols/windows/extensions/pool.py
+++ b/volatility/framework/symbols/windows/extensions/pool.py
@@ -1,9 +1,8 @@
-import functools
 import logging
 import struct
 from typing import Optional, Tuple, List, Dict, Union
 
-from volatility.framework import objects, interfaces, constants, symbols, exceptions, renderers
+from volatility.framework import objects, interfaces, constants, symbols, exceptions, renderers, caching
 from volatility.framework.renderers import conversion
 
 vollog = logging.getLogger(__name__)
@@ -165,7 +164,7 @@ class POOL_HEADER(objects.StructType):
         return None
 
     @classmethod
-    @functools.lru_cache()
+    @caching.lru_cache()
     def _calculate_optional_header_lengths(cls, context: interfaces.context.ContextInterface,
                                            symbol_table_name: str) -> Tuple[List[str], List[int]]:
         headers = []


### PR DESCRIPTION
This feature adds support for (very early) deciding as to whether caching of layer reads should be enabled throughout the codebase.  It's not ideal because the main toggle *doesn't* live in volatility.frameworks.constants like it should, because volatility.framework imports other parts of the framework that already need to know whether the caching is enabled or not.  To avoid this issue, the toggle lives just in `volatility`.