### PR TITLE
Feature/timeliner partial caching

### DIFF
--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -107,7 +107,7 @@ class CommandLine:
                             default = None,
                             type = str)
         parser.add_argument("--parallelism",
-                            help = "Enables parallelism (defaults to processes if no argument given)",
+                            help = "Enables parallelism (defaults to off if no argument given)",
                             nargs = '?',
                             choices = ['processes', 'threads', 'off'],
                             const = 'processes',

--- a/volatility/framework/interfaces/configuration.py
+++ b/volatility/framework/interfaces/configuration.py
@@ -324,6 +324,14 @@ class RequirementInterface(metaclass = ABCMeta):
     def __repr__(self) -> str:
         return "<" + self.__class__.__name__ + ": " + self.name + ">"
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        for name in self.__dict__:
+            if other.__dict__.get(name, None) != self.__dict__[name]:
+                return False
+        return True
+
     @property
     def name(self) -> str:
         """The name of the Requirement.


### PR DESCRIPTION
Moves requirements found by automagic to other plugin with the identical requirements (including the descriptions).  This should save plugins rescanning if they use the same requirements as one that's already completed the scanning.