### PR TITLE
add Is64Bit and IsPAE properties to the windows.info plugin

### DIFF
--- a/volatility/framework/plugins/windows/info.py
+++ b/volatility/framework/plugins/windows/info.py
@@ -5,7 +5,7 @@
 import time
 from typing import List, Tuple, Iterable
 
-from volatility.framework import constants, interfaces, layers
+from volatility.framework import constants, interfaces, layers, symbols
 from volatility.framework.configuration import requirements
 from volatility.framework.interfaces import plugins
 from volatility.framework.renderers import TreeGrid
@@ -158,6 +158,8 @@ class Info(plugins.PluginInterface):
         yield (0, ("Kernel Base", hex(self.config["primary.kernel_virtual_offset"])))
         yield (0, ("DTB", hex(self.config["primary.page_map_offset"])))
         yield (0, ("Symbols", self.config["nt_symbols.isf_url"]))
+        yield (0, ("Is64Bit", str(symbols.symbol_table_is_64bit(self.context, symbol_table))))
+        yield (0, ("IsPAE", str(self.context.layers[layer_name].metadata.get("pae", False))))
 
         for i, layer in self.get_depends(self.context, "primary"):
             yield (0, (layer.name, "{} {}".format(i, layer.__class__.__name__)))

--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -6,9 +6,8 @@ import collections.abc
 import datetime
 import functools
 import logging
-import struct
 import math
-from typing import Iterable, Iterator, Optional, Union, Dict, Tuple, List
+from typing import Iterable, Iterator, Optional, Union, Tuple, List
 
 from volatility.framework import constants, exceptions, interfaces, objects, renderers, symbols
 from volatility.framework.layers import intel


### PR DESCRIPTION
This adds the following new properties to the output of the `windows.info` plugin:

```
...
Kernel Base	0x81a0d000
DTB	0x1a8000
Symbols	file:///Users/analyst/GitHub/volatility3/volatility/symbols/windows/ntkrpamp.pdb/C6401D4EE1EC427283A8FA17771EFB53-1.json.xz
Is64Bit	False  <----------------------------------------------- (new)
IsPAE	False  <----------------------------------------------- (new)
primary	0 WindowsIntelPAE
memory_layer	1 FileLayer
KdDebuggerDataBlock	0x81bf3690
...
```