### PR TITLE
Issues/optional symbol shift

### DIFF
--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -303,7 +303,7 @@ class SymbolTableInterface(BaseSymbolTableInterface, configuration.ConfigurableI
     @classmethod
     def get_requirements(cls) -> List[RequirementInterface]:
         return super().get_requirements() + [
-            requirements.IntRequirement(name = 'symbol_shift', description = 'Symbol Shift', optional = False),
+            requirements.IntRequirement(name = 'symbol_shift', description = 'Symbol Shift', optional = True),
             requirements.IntRequirement(
                 name = 'symbol_mask', description = 'Address mask for symbols', optional = True, default = 0),
         ]

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -303,7 +303,8 @@ class SymbolTableInterface(BaseSymbolTableInterface, configuration.ConfigurableI
     @classmethod
     def get_requirements(cls) -> List[RequirementInterface]:
         return super().get_requirements() + [
-            requirements.IntRequirement(name = 'symbol_shift', description = 'Symbol Shift', optional = True),
+            requirements.IntRequirement(
+                name = 'symbol_shift', description = 'Symbol Shift', optional = True, default = 0),
             requirements.IntRequirement(
                 name = 'symbol_mask', description = 'Address mask for symbols', optional = True, default = 0),
         ]


### PR DESCRIPTION
I don't think will have any negative effect, but I've only got the one ASLR image to test it on.  As best I can tell, I thought we needed to be able to tell the difference between 0 and not-yet-set, but it looks like all our tests will take either, and I'd feel happier with this defaulting to 0 rather than None.

@atcuno If you can give it a review at some point please (no rush), I'll merge it into develop (I don't think it's critical enough to go into the release).  Thanks!  5:)