### PR TITLE
CLI: Dampen exceptions at low log levels

### DIFF
--- a/volatility/cli/__init__.py
+++ b/volatility/cli/__init__.py
@@ -188,6 +188,8 @@ class CommandLine:
             vollog.addHandler(file_logger)
             vollog.info("Logging started")
         if partial_args.verbosity < 3:
+            if partial_args.verbosity < 1:
+                sys.tracebacklimit = None
             console.setLevel(30 - (partial_args.verbosity * 10))
         else:
             console.setLevel(10 - (partial_args.verbosity - 2))


### PR DESCRIPTION
This removes tracebacks for the CLI when no `-v` has been specified.  The error message will still be given, but it should be less cluttered by python code.  Should be fine, I'll commit it to develop in 7 days if there's no complaints...