### PR TITLE
netstat: fixes two off-by-one errors in port bitmap parsing

### DIFF
--- a/volatility/framework/plugins/windows/netstat.py
+++ b/volatility/framework/plugins/windows/netstat.py
@@ -97,7 +97,7 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         for idx in range(bitmap_size_in_byte-1):
             current_byte = context.layers[layer_name].read(bitmap_offset + idx, 1)[0]
             current_offs = idx * 8
-            for bit in range(7):
+            for bit in range(8):
                 if current_byte & (1 << bit) != 0:
                     ret.append(bit + current_offs)
         return ret

--- a/volatility/framework/plugins/windows/netstat.py
+++ b/volatility/framework/plugins/windows/netstat.py
@@ -94,7 +94,7 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             The list of indices at which a 1 was found.
         """
         ret = []
-        for idx in range(bitmap_size_in_byte-1):
+        for idx in range(bitmap_size_in_byte):
             current_byte = context.layers[layer_name].read(bitmap_offset + idx, 1)[0]
             current_offs = idx * 8
             for bit in range(8):


### PR DESCRIPTION
The current implementation has two bugs:

- if a port index in the port bitmap was at the 7th bit of the currently parsed byte (e.g. ports 7, 15, 23 and so on) it got skipped due to the range not including index 7
- the last byte of the bitmap (meaning ports 65528 - 65535) were skipped due to another range mistake. 

To reproduce start a listener on port 7, 15, ... and on port 65535, then run `netstat`.

`netstat` output without fix:
```
* | 0x83092e6f8a70 | TCPv6 |                        :: |     49669 |            :: |           0 |   LISTENING |  684 |   services.exe | 2020-12-25 14:53:02.000000 
* | 0x83092e6f8910 | TCPv4 |                   0.0.0.0 |     49669 |       0.0.0.0 |           0 |   LISTENING |  684 |   services.exe | 2020-12-25 14:53:02.000000 
* | 0x830930b3e0d0 | UDPv4 |            172.16.217.128 |       137 |             * |           0 |             |    4 |         System | 2021-01-10 16:01:15.000000 
* | 0x8309337997a0 | UDPv4 |              172.16.1.128 |       137 |             * |           0 |             |    4 |         System | 2021-01-10 16:01:23.000000 
...
* | 0x83092ed8d670 | UDPv4 |                   0.0.0.0 |     63437 |             * |           0 |             | 2960 |    svchost.exe | 2020-12-25 14:53:04.000000 
* | 0x83092ed8d670 | UDPv6 |                        :: |     63437 |             * |           0 |             | 2960 |    svchost.exe | 2020-12-25 14:53:04.000000 
```

with fix:
```
* | 0x83092e6f8a70 | TCPv6 |                        :: |     49669 |            :: |           0 |   LISTENING |  684 |   services.exe | 2020-12-25 14:53:02.000000 
* | 0x83092e6f8910 | TCPv4 |                   0.0.0.0 |     49669 |       0.0.0.0 |           0 |   LISTENING |  684 |   services.exe | 2020-12-25 14:53:02.000000 
* | 0x830934c051e0 | UDPv4 |              172.16.1.128 |         7 |             * |           0 |             |  448 | udp-listener.e | 2021-01-10 16:04:05.000000 
* | 0x830930b3e0d0 | UDPv4 |            172.16.217.128 |       137 |             * |           0 |             |    4 |         System | 2021-01-10 16:01:15.000000 
* | 0x8309337997a0 | UDPv4 |              172.16.1.128 |       137 |             * |           0 |             |    4 |         System | 2021-01-10 16:01:23.000000 
...
* | 0x83092ed8d670 | UDPv4 |                   0.0.0.0 |     63437 |             * |           0 |             | 2960 |    svchost.exe | 2020-12-25 14:53:04.000000 
* | 0x83092ed8d670 | UDPv6 |                        :: |     63437 |             * |           0 |             | 2960 |    svchost.exe | 2020-12-25 14:53:04.000000 
* | 0x830932791dc0 | UDPv4 |              172.16.1.128 |     65534 |             * |           0 |             | 8160 | udp-listener.e | 2021-01-10 16:13:17.000000 
* | 0x83093278e8a0 | UDPv4 |              172.16.1.128 |     65535 |             * |           0 |             | 5844 | udp-listener.e | 2021-01-10 16:12:48.000000
```

Sorry for that. Hooray to magic numbers in the code!