### PR TITLE
refs #409 VACB does not expose is_valid() - do the validity check inline

### DIFF
--- a/volatility/framework/symbols/windows/extensions/__init__.py
+++ b/volatility/framework/symbols/windows/extensions/__init__.py
@@ -1051,7 +1051,7 @@ class SHARED_CACHE_MAP(objects.StructType):
                 continue
 
             vacb_obj = vacb_array[counter].dereference().cast(symbol_table_name + constants.BANG + "_VACB")
-            if vacb_obj.is_valid(shared_cache_map = self):
+            if vacb_obj.SharedCacheMap == self.vol.offset:
                 self.save_vacb(vacb_obj, vacb_list)
             else:
                 # Process the next level of the multi-level array


### PR DESCRIPTION
This should fix the remainder of #409 as reported by @mtressler and also @AsafEitani here: https://github.com/volatilityfoundation/volatility3/issues/409#issuecomment-759531448. 

The `_VACB` does not have an `is_valid()` method. The validity check can be moved inline instead. This fixes the dumpfiles plugin on 32-bit Windows 8. 