### PR TITLE
Issues/more efficient scanning

### DIFF
--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -491,15 +491,20 @@ class TranslationLayerInterface(DataLayerInterface, metaclass = ABCMeta):
                 # Setup the variables for this block
                 block_start = offset
                 block_end = offset + sublength
-                conversion = mapped_offset - offset
+
+                # Setup the necessary bits for non-linear mappings
+                # For linear we give one layer down and mapped offsets (therefore the conversion)
+                # This saves an tiny amount of time not have to redo lookups we've already done
+                # For non-linear layers, we give the layer name and the offset in the layer name
+                # so that the read/conversion occurs properly
+                conversion = mapped_offset - offset if linear else 0
+                return_name = layer_name if linear else self.name
 
                 # If this isn't contiguous, start a new chunk
                 if chunk_position < block_start:
                     yield output, chunk_position
                     output = []
                     chunk_start = chunk_position = block_start
-
-                return_name = self.name if not linear else layer_name
 
                 # Halfway through a chunk, finish the chunk, then take more
                 if chunk_position != chunk_start:


### PR DESCRIPTION
This speeds up scanning on virtual/holey layers, by letting the layer determine what's present and what's absent efficiently and chunking up the results, rather than creating the chunk positions and then filling them from the layer.

Quite a big change, but I've tried to comment it clearly and my tests have shown it working, but a second set of eyes is always appareciated...  5;)  Happy to save this to 2.0.1 or whatever the next version is.

I don't think we've any other person specifically knowledgable about scanning, so happy for a review from any of you...  5:)