### PR TITLE
Temporary workaround for changes in transition PTE

### DIFF
--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -265,7 +265,7 @@ class Intel32e(Intel):
     _direct_metadata = collections.ChainMap({'architecture': 'Intel64'}, Intel._direct_metadata)
     _entry_format = "<Q"
     _bits_per_register = 64
-    _maxphyaddr = 44
+    _maxphyaddr = 52
     _maxvirtaddr = 48
     _structure = [('page map layer 4', 9, False), ('page directory pointer', 9, True), ('page directory', 9, True),
                   ('page table', 9, True)]
@@ -329,5 +329,7 @@ class WindowsIntelPAE(WindowsMixin, IntelPAE):
 
 class WindowsIntel32e(WindowsMixin, Intel32e):
 
+    _maxphyaddr = 45
+    
     def _translate(self, offset: int) -> Tuple[int, int, str]:
         return self._translate_swap(self, offset, self._bits_per_register // 2)

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -329,6 +329,10 @@ class WindowsIntelPAE(WindowsMixin, IntelPAE):
 
 class WindowsIntel32e(WindowsMixin, Intel32e):
 
+    # TODO: Fix appropriately in a future release.
+    # Currently just a temprorary workaround to deal with custom bit flag
+    # in the PFN field for pages in transition state.
+    # See https://github.com/volatilityfoundation/volatility3/pull/475
     _maxphyaddr = 45
     
     def _translate(self, offset: int) -> Tuple[int, int, str]:

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -265,7 +265,7 @@ class Intel32e(Intel):
     _direct_metadata = collections.ChainMap({'architecture': 'Intel64'}, Intel._direct_metadata)
     _entry_format = "<Q"
     _bits_per_register = 64
-    _maxphyaddr = 52
+    _maxphyaddr = 44
     _maxvirtaddr = 48
     _structure = [('page map layer 4', 9, False), ('page directory pointer', 9, True), ('page directory', 9, True),
                   ('page table', 9, True)]

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -972,7 +972,8 @@ class CONTROL_AREA(objects.StructType):
 
                 # If the entry is not a valid physical address then see if it is in transition.
                 elif mmpte.u.Trans.Transition == 1:
-                    physoffset = (mmpte.u.Trans.PageFrameNumber &~ (0b1111 << 32)) << 12
+                    # Strips the bit flag in 'PageFrameNumber' for pages in transition state 
+                    physoffset = (mmpte.u.Trans.PageFrameNumber & (( 1 << 33 ) - 1 ) ) << 12
                     yield physoffset, file_offset, self.PAGE_SIZE
 
                 # Go to the next PTE entry

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -972,7 +972,7 @@ class CONTROL_AREA(objects.StructType):
 
                 # If the entry is not a valid physical address then see if it is in transition.
                 elif mmpte.u.Trans.Transition == 1:
-                    physoffset = mmpte.u.Trans.PageFrameNumber << 12
+                    physoffset = (mmpte.u.Trans.PageFrameNumber &~ (0b1111 << 32)) << 12
                     yield physoffset, file_offset, self.PAGE_SIZE
 
                 # Go to the next PTE entry

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -972,8 +972,12 @@ class CONTROL_AREA(objects.StructType):
 
                 # If the entry is not a valid physical address then see if it is in transition.
                 elif mmpte.u.Trans.Transition == 1:
-                    # Strips the bit flag in 'PageFrameNumber' for pages in transition state 
+                    # TODO: Fix appropriately in a future release.
+                    # Currently just a temprorary workaround to deal with custom bit flag
+                    # in the PFN field for pages in transition state.
+                    # See https://github.com/volatilityfoundation/volatility3/pull/475
                     physoffset = (mmpte.u.Trans.PageFrameNumber & (( 1 << 33 ) - 1 ) ) << 12
+                    
                     yield physoffset, file_offset, self.PAGE_SIZE
 
                 # Go to the next PTE entry


### PR DESCRIPTION
When a PTE is in Transition state, Windows 10 since at least 1909 seems to use some of the higher bits of the PageFrameNumber field as flags, leading to a wrong physical offset during the address translation process.

Here the WinDBG output for such a case. The page for the virtual address 246af810000 is in transition:

```
1: kd> !pte 246af810000
                                           VA 00000246af810000
PXE at FFFFE3F1F8FC7020    PPE at FFFFE3F1F8E048D0    PDE at FFFFE3F1C091ABE0    PTE at FFFFE3812357C080
contains 8A00000059B75867  contains 0A0000005EAE3867  contains 0A00000061030867  contains 0000200060533860
pfn 59b75     ---DA--UW-V  pfn 5eae3     ---DA--UWEV  pfn 61030     ---DA--UWEV  not valid
                                                                                  Transition: 60533
                                                                                  Protect: 3 - ExecuteRead


1: kd> dt _MMPTE_TRANSITION FFFFE3812357C080
nt!_MMPTE_TRANSITION
   +0x000 Valid            : 0y0
   +0x000 Write            : 0y0
   +0x000 Spare            : 0y0
   +0x000 IoTracker        : 0y0
   +0x000 SwizzleBit       : 0y0
   +0x000 Protection       : 0y00011 (0x3)
   +0x000 Prototype        : 0y0
   +0x000 Transition       : 0y1
   +0x000 PageFrameNumber  : 0y001000000000000001100000010100110011 (0x200060533)
   +0x000 Unused           : 0y0000000000000000 (0)

!pte reports a PFN of 0x60533 while the field states 0x200060533.

```

This issue also reflects in other areas.
dumpfiles plugin output without fix:

```
ImageSectionObject      0xd806a4c65e70  InputService.dll        Error dumping file
ImageSectionObject      0xd806a4c66320  TextInputFramework.dll  Error dumping file
ImageSectionObject      0xd806a4c62c70  msutb.dll       Error dumping file
ImageSectionObject      0xd806a2e5a460  winsta.dll      Error dumping file
ImageSectionObject      0xd806a2f09d70  CoreMessaging.dll       Error dumping file
ImageSectionObject      0xd806a2faa210  CoreUIComponents.dll    Error dumping file
ImageSectionObject      0xd806a2faa850  WinTypes.dll    Error dumping file
ImageSectionObject      0xd806a2ff96c0  policymanager.dll       Error dumping file
ImageSectionObject      0xd806a5baed50  WordBreakers.dll        Error dumping file
ImageSectionObject      0xd806a2f082e0  propsys.dll     Error dumping file
ImageSectionObject      0xd806a2f0a6d0  msvcp110_win.dll        Error dumping file
ImageSectionObject      0xd806a2f05ef0  uxtheme.dll     Error dumping file
ImageSectionObject      0xd806a270b860  ntmarta.dll     Error dumping file
ImageSectionObject      0xd806a0e94a20  bcryptprimitives.dll    Error dumping file
ImageSectionObject      0xd806a25c66a0  kernel.appcore.dll      Error dumping file
ImageSectionObject      0xd806a0e94700  gdi32full.dll   Error dumping file
ImageSectionObject      0xd806a0e94bb0  KernelBase.dll  Error dumping file
ImageSectionObject      0xd806a0e94570  msvcp_win.dll   Error dumping file
ImageSectionObject      0xd806a0e95830  ucrtbase.dll    Error dumping file
ImageSectionObject      0xd806a0e95e70  win32u.dll      Error dumping file
ImageSectionObject      0xd806a23510c0  kernel32.dll    Error dumping file
ImageSectionObject      0xd806a23526a0  msctf.dll       Error dumping file
ImageSectionObject      0xd806a0e95b50  ole32.dll       Error dumping file
ImageSectionObject      0xd806a0e95510  gdi32.dll       Error dumping file
ImageSectionObject      0xd806a2351250  imm32.dll       Error dumping file
ImageSectionObject      0xd806a2351890  clbcatq.dll     Error dumping file
ImageSectionObject      0xd806a2352ce0  sechost.dll     Error dumping file
ImageSectionObject      0xd806a2351bb0  advapi32.dll    Error dumping file
ImageSectionObject      0xd806a23529c0  SHCore.dll      Error dumping file
ImageSectionObject      0xd806a2351d40  combase.dll     Error dumping file
ImageSectionObject      0xd806a0539890  rpcrt4.dll      Error dumping file
ImageSectionObject      0xd806a06896a0  msvcrt.dll      Error dumping file
ImageSectionObject      0xd806a0539d40  user32.dll      Error dumping file
ImageSectionObject      0xd806a0426210  ntdll.dll       Error dumping file
```

After the transition fix in volatility3/framework/symbols/windows/extensions/__init__.py:

```
ImageSectionObject      0xd806a4c65e70  InputService.dll        file.0xd806a4c65e70.0xd806a4c52010.ImageSectionObject.InputService.dll.img
ImageSectionObject      0xd806a4c66320  TextInputFramework.dll  file.0xd806a4c66320.0xd806a494ac40.ImageSectionObject.TextInputFramework.dll.img
ImageSectionObject      0xd806a4c62c70  msutb.dll       file.0xd806a4c62c70.0xd806a242d2b0.ImageSectionObject.msutb.dll.img
ImageSectionObject      0xd806a2e5a460  winsta.dll      file.0xd806a2e5a460.0xd806a2639d50.ImageSectionObject.winsta.dll.img
ImageSectionObject      0xd806a2f09d70  CoreMessaging.dll       file.0xd806a2f09d70.0xd806a0b9ccb0.ImageSectionObject.CoreMessaging.dll.img
ImageSectionObject      0xd806a2faa210  CoreUIComponents.dll    file.0xd806a2faa210.0xd806a08edcb0.ImageSectionObject.CoreUIComponents.dll.img
ImageSectionObject      0xd806a2faa850  WinTypes.dll    file.0xd806a2faa850.0xd806a090acb0.ImageSectionObject.WinTypes.dll.img
ImageSectionObject      0xd806a2ff96c0  policymanager.dll       file.0xd806a2ff96c0.0xd806a096ecb0.ImageSectionObject.policymanager.dll.img
ImageSectionObject      0xd806a5baed50  WordBreakers.dll        file.0xd806a5baed50.0xd806a4e8fbf0.ImageSectionObject.WordBreakers.dll.img
ImageSectionObject      0xd806a2f082e0  propsys.dll     file.0xd806a2f082e0.0xd806a0b93cb0.ImageSectionObject.propsys.dll.img
ImageSectionObject      0xd806a2f0a6d0  msvcp110_win.dll        file.0xd806a2f0a6d0.0xd806a0bb6cb0.ImageSectionObject.msvcp110_win.dll.img
ImageSectionObject      0xd806a2f05ef0  uxtheme.dll     file.0xd806a2f05ef0.0xd806a0addcb0.ImageSectionObject.uxtheme.dll.img
ImageSectionObject      0xd806a270b860  ntmarta.dll     file.0xd806a270b860.0xd806a0ad1cb0.ImageSectionObject.ntmarta.dll.img
ImageSectionObject      0xd806a0e94a20  bcryptprimitives.dll    file.0xd806a0e94a20.0xd806a0854cb0.ImageSectionObject.bcryptprimitives.dll.img
ImageSectionObject      0xd806a25c66a0  kernel.appcore.dll      file.0xd806a25c66a0.0xd806a08a0cb0.ImageSectionObject.kernel.appcore.dll.img
ImageSectionObject      0xd806a0e94700  gdi32full.dll   file.0xd806a0e94700.0xd806a089ecb0.ImageSectionObject.gdi32full.dll.img
ImageSectionObject      0xd806a0e94bb0  KernelBase.dll  file.0xd806a0e94bb0.0xd806a089acb0.ImageSectionObject.KernelBase.dll.img
ImageSectionObject      0xd806a0e94570  msvcp_win.dll   file.0xd806a0e94570.0xd806a08a9cb0.ImageSectionObject.msvcp_win.dll.img
ImageSectionObject      0xd806a0e95830  ucrtbase.dll    file.0xd806a0e95830.0xd806a0857cb0.ImageSectionObject.ucrtbase.dll.img
ImageSectionObject      0xd806a0e95e70  win32u.dll      file.0xd806a0e95e70.0xd806a0856cb0.ImageSectionObject.win32u.dll.img
ImageSectionObject      0xd806a23510c0  kernel32.dll    file.0xd806a23510c0.0xd806a085bcb0.ImageSectionObject.kernel32.dll.img
ImageSectionObject      0xd806a23526a0  msctf.dll       file.0xd806a23526a0.0xd806a0888cb0.ImageSectionObject.msctf.dll.img
ImageSectionObject      0xd806a0e95b50  ole32.dll       file.0xd806a0e95b50.0xd806a088ecb0.ImageSectionObject.ole32.dll.img
ImageSectionObject      0xd806a0e95510  gdi32.dll       file.0xd806a0e95510.0xd806a088fcb0.ImageSectionObject.gdi32.dll.img
ImageSectionObject      0xd806a2351250  imm32.dll       file.0xd806a2351250.0xd806a0889cb0.ImageSectionObject.imm32.dll.img
ImageSectionObject      0xd806a2351890  clbcatq.dll     file.0xd806a2351890.0xd806a088ccb0.ImageSectionObject.clbcatq.dll.img
ImageSectionObject      0xd806a2352ce0  sechost.dll     file.0xd806a2352ce0.0xd806a087fcb0.ImageSectionObject.sechost.dll.img
ImageSectionObject      0xd806a2351bb0  advapi32.dll    file.0xd806a2351bb0.0xd806a0883cb0.ImageSectionObject.advapi32.dll.img
ImageSectionObject      0xd806a23529c0  SHCore.dll      file.0xd806a23529c0.0xd806a0881cb0.ImageSectionObject.SHCore.dll.img
ImageSectionObject      0xd806a2351d40  combase.dll     file.0xd806a2351d40.0xd806a087ccb0.ImageSectionObject.combase.dll.img
ImageSectionObject      0xd806a0539890  rpcrt4.dll      file.0xd806a0539890.0xd806a0878cb0.ImageSectionObject.rpcrt4.dll.img
ImageSectionObject      0xd806a06896a0  msvcrt.dll      file.0xd806a06896a0.0xd806a085ccb0.ImageSectionObject.msvcrt.dll.img
ImageSectionObject      0xd806a0539d40  user32.dll      file.0xd806a0539d40.0xd806a0879cb0.ImageSectionObject.user32.dll.img
ImageSectionObject      0xd806a0426210  ntdll.dll       file.0xd806a0426210.0xd806a02bbcf0.ImageSectionObject.ntdll.dll.img
```