### PR TITLE
Add PID support for Windows Server 2019 netstat

### DIFF
--- a/volatility3/framework/symbols/windows/netscan-win10-17763-x64.json
+++ b/volatility3/framework/symbols/windows/netscan-win10-17763-x64.json
@@ -192,7 +192,7 @@
     "_TCP_ENDPOINT": {
         "fields": {
             "Owner": {
-                "offset": 656,
+                "offset": 712,
                 "type": {
                     "kind": "pointer",
                     "subtype": {

--- a/volatility3/framework/symbols/windows/netscan-win10-17763-x64.json
+++ b/volatility3/framework/symbols/windows/netscan-win10-17763-x64.json
@@ -202,7 +202,7 @@
                 }
             },
             "CreateTime": {
-                "offset": 672,
+                "offset": 728,
                 "type": {
                     "kind": "union",
                     "name": "_LARGE_INTEGER"


### PR DESCRIPTION
The offset was incorrect for the AWS x64 Windows Server 2019 (17763) AMI

If PID is working for other samples, I don't know if somehow this is a different version with different offsets (AWS is using datacenter?). That worries me because that may require another symbol version.

Regardless, here is the existing output:

![image](https://user-images.githubusercontent.com/15677350/111020348-2f2f6b00-8393-11eb-9058-8395253d995c.png)

And the fix:

![image](https://user-images.githubusercontent.com/15677350/111020343-2343a900-8393-11eb-93c6-32bc5a5568a1.png)

And the updated output:

![image](https://user-images.githubusercontent.com/15677350/111020339-1cb53180-8393-11eb-9412-ffe698ad7e7d.png)
