### PR TITLE
complete windows crash dump support

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -39,7 +39,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 1  # Number of releases of the library with a breaking change
-VERSION_MINOR = 0  # Number of changes that only add to the interface
+VERSION_MINOR = 1  # Number of changes that only add to the interface
 VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -97,9 +97,9 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
 
             offset = self.headerpages
             header.PhysicalMemoryBlockBuffer.Run.count = header.PhysicalMemoryBlockBuffer.NumberOfRuns
-            for x in header.PhysicalMemoryBlockBuffer.Run:
-                segments.append((x.BasePage * 0x1000, offset * 0x1000, x.PageCount * 0x1000, x.PageCount * 0x1000))
-                offset += x.PageCount
+            for run in header.PhysicalMemoryBlockBuffer.Run:
+                segments.append((run.BasePage * 0x1000, offset * 0x1000, run.PageCount * 0x1000, run.PageCount * 0x1000))
+                offset += run.PageCount
 
         elif self.dump_type == 0x05:
             summary_header = self.get_summary_header()

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -1,15 +1,13 @@
-
-  
 # This file is Copyright 2021 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
 import struct
-from typing import Tuple, Optional, Iterable
+from typing import Tuple, Optional
 
-from volatility.framework import constants, exceptions, interfaces
-from volatility.framework.layers import segmented
-from volatility.framework.symbols import intermed
+from volatility3.framework import constants, exceptions, interfaces
+from volatility3.framework.layers import segmented
+from volatility3.framework.symbols import intermed
 
 vollog = logging.getLogger(__name__)
 
@@ -30,7 +28,7 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
     VALIDDUMP = 0x504d5544
 
     crashdump_json = 'crash'
-    supported_dumptypes = [0x01]
+    supported_dumptypes = [0x01, 0x05] # we need 0x5 for 32-bit bitmaps
     dump_header_name = '_DUMP_HEADER'
 
     _magic_struct = struct.Struct('<II')
@@ -42,62 +40,118 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
         self._context = context
         self._config_path = config_path
         self._page_size = 0x1000
-        try: 
-            self._base_layer = self.config["base_layer"]
-        except KeyError:
-            self._base_layer = 'base_layer'
-            self.config['base_layer']='base_layer'
+        # no try/except needed. as seen in vmware.py
+        self._base_layer = self.config["base_layer"]
 
         # Create a custom SymbolSpace
         self._crash_table_name = intermed.IntermediateSymbolTable.create(context, self._config_path, 'windows',
                                                                          self.crashdump_json)
+
+        # the _SUMMARY_DUMP is shared between 32- and 64-bit
+        self._crash_common_table_name = intermed.IntermediateSymbolTable.create(context, self._config_path,
+                                                                                'windows',
+                                                                                'crash_common')
+
         # Check Header
         hdr_layer = self._context.layers[self._base_layer]
         hdr_offset = 0
         self.check_header(hdr_layer, hdr_offset)
 
         # Need to create a header object
-        header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
-                                     offset = hdr_offset,
-                                     layer_name = self._base_layer)
+        self._header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
+                                           offset = hdr_offset,
+                                           layer_name = self._base_layer)
 
         # Extract the DTB
-        self.dtb = int(header.DirectoryTableBase)
+        self.dtb = int(self._header.DirectoryTableBase)
 
-        self.dump_type = int(header.DumpType)
+        self.dump_type = int(self._header.DumpType)
 
         # Verify that it is a supported format
-        if header.DumpType not in self.supported_dumptypes:
-            vollog.log(constants.LOGLEVEL_VVVV, "unsupported dump format 0x{:x}".format(header.DumpType))
-            raise WindowsCrashDumpFormatException(name, "unsupported dump format 0x{:x}".format(header.DumpType))
+        if self._header.DumpType not in self.supported_dumptypes:
+            vollog.log(constants.LOGLEVEL_VVVV, "unsupported dump format 0x{:x}".format(self._header.DumpType))
+            raise WindowsCrashDumpFormatException(name, "unsupported dump format 0x{:x}".format(self._header.DumpType))
 
+        # Then call the super, which will call load_segments (which needs the base_layer before it'll work)
         super().__init__(context, config_path, name)
+
+    def get_header(self) -> interfaces.objects.ObjectInterface:
+        return self._header
 
     def _load_segments(self) -> None:
         """Loads up the segments from the meta_layer."""
-        
 
         segments = []
 
-        offset = self.headerpages
-        header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
-                                 offset = 0,
-                                 layer_name = self._base_layer)
-        offset = self.headerpages                      
-        header.PhysicalMemoryBlockBuffer.Run.count = header.PhysicalMemoryBlockBuffer.NumberOfRuns
-        for x in header.PhysicalMemoryBlockBuffer.Run:
-            segments.append((x.BasePage * 0x1000, offset * 0x1000, x.PageCount * 0x1000, x.PageCount * 0x1000))
-                # print("Segments {:x} {:x} {:x}".format(x.BasePage * 0x1000,
-                #                  offset * 0x1000,
-                #                  x.PageCount * 0x1000))
-            offset += x.PageCount
+        # instead of hard coding 0x2000, use 0x1000 * self.headerpages so this works for
+        # both 32- and 64-bit dumps
+        summary_header = self.context.object(self._crash_common_table_name + constants.BANG + "_SUMMARY_DUMP",
+                                             offset=0x1000 * self.headerpages,
+                                             layer_name=self._base_layer)
+        if self.dump_type == 0x1:
+            header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
+                                         offset=0,
+                                         layer_name=self._base_layer)
 
+            offset = self.headerpages
+            header.PhysicalMemoryBlockBuffer.Run.count = header.PhysicalMemoryBlockBuffer.NumberOfRuns
+            for x in header.PhysicalMemoryBlockBuffer.Run:
+                segments.append((x.BasePage * 0x1000, offset * 0x1000, x.PageCount * 0x1000, x.PageCount * 0x1000))
+                offset += x.PageCount
+
+        elif self.dump_type == 0x05:
+
+            ## NOTE: In the original crash64.json, _SUMMARY_DUMP.Pages was offset 48 and
+            ## _SUMMARY_DUMP.BitmapSize was offset 40. From the volatility2 vtypes, that is
+            ## backwards! The correct offsets should be:
+            ##
+            ## 'Pages' : [ 0x28, ['unsigned long long']],    -> This is 40 decimal
+            ## 'BitmapSize': [0x30, ['unsigned long long']], -> This is 48 decimal
+            ##
+            ## Most likely, some of the code that follows needs to be adjusted with those
+            ## newly refactored offsets in mind. I commented out the "+ 0x2000" below, and
+            ## this still works on Win10x64_17763_crash.dmp, but it fails on
+            ## the Win10x86_17763_crash.dmp version. 
+
+            # Add 0x2000 as some bitmaps are too short by one offset
+            summary_header.BufferLong.count = (summary_header.BitmapSize + 31) // 32 # + 0x2000
+            previous_bit = 0
+            start_position = 0
+            # We cast as an int because we don't want to carry the context around with us for infinite loop reasons
+            mapped_offset = int(summary_header.HeaderSize)
+            current_word = None
+            bitmap_len = len(summary_header.BufferLong) * 32
+
+            for bit_position in range(bitmap_len):
+                if (bit_position % 32) == 0:
+                    current_word = summary_header.BufferLong[bit_position // 32]
+                current_bit = (current_word >> (bit_position % 32)) & 1
+
+                if current_bit != previous_bit:
+                    if previous_bit == 0:
+                        # Start
+                        start_position = bit_position
+                    else:
+                        # Finish
+                        length = (bit_position - start_position) * 0x1000
+                        segments.append((start_position * 0x1000, mapped_offset, length, length))
+                        mapped_offset += length
+
+                # Find the last segment in a file which will be at the end or two pages from the end. We multiply by 32 as we want to offset bby words rather than bits
+                if (bit_position == bitmap_len - 1 or bit_position == bitmap_len - 1 - 32 * 0x2000) and current_bit == 1:
+                    length = (bit_position - start_position) * 0x1000
+                    segments.append((start_position * 0x1000, mapped_offset, length, length))
+                    mapped_offset += length
+                    break
+                previous_bit = current_bit
+        else:
+            vollog.log(constants.LOGLEVEL_VVVV, "unsupported dump format 0x{:x}".format(self.dump_type))
+            raise WindowsCrashDumpFormatException(self.name, "unsupported dump format 0x{:x}".format(self.dump_type))
 
         if len(segments) == 0:
             raise WindowsCrashDumpFormatException(self.name, "No Crash segments defined in {}".format(self._base_layer))
+
         self._segments = segments
-
-
 
     @classmethod
     def check_header(cls, base_layer: interfaces.layers.DataLayerInterface, offset: int = 0) -> Tuple[int, int]:
@@ -131,69 +185,6 @@ class WindowsCrashDump64Layer(WindowsCrashDump32Layer):
     dump_header_name = '_DUMP_HEADER64'
     supported_dumptypes = [0x1, 0x05]
     headerpages = 2
-
-    def _load_segments(self) -> None:
-        """Loads up the segments from the meta_layer."""
-
-        segments = []
-
-        summary_header = self.context.object(self._crash_table_name + constants.BANG + "_SUMMARY_DUMP64",
-                                             offset = 0x2000,
-                                             layer_name = self._base_layer)
-        if self.dump_type == 0x1:
-            header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
-                                         offset = 0,
-                                         layer_name = self._base_layer)
-
-            offset = self.headerpages
-            header.PhysicalMemoryBlockBuffer.Run.count = header.PhysicalMemoryBlockBuffer.NumberOfRuns
-            for x in header.PhysicalMemoryBlockBuffer.Run:
-                segments.append((x.BasePage * 0x1000, offset * 0x1000, x.PageCount * 0x1000, x.PageCount * 0x1000))
-                offset += x.PageCount
-
-        elif self.dump_type == 0x05:
-            #Add 0x2000 as some bitmaps are too short by one offset
-            summary_header.BufferLong.count = (summary_header.BitmapSize + 31) // 32 + 0x2000 
-            previous_bit = 0
-            start_position = 0
-            # We cast as an int because we don't want to carry the context around with us for infinite loop reasons
-            mapped_offset = int(summary_header.HeaderSize)
-            current_word = None
-            bitmap_len=len(summary_header.BufferLong) * 32
-            for bit_position in range(bitmap_len):
-                if (bit_position % 32) == 0:
-                    current_word = summary_header.BufferLong[bit_position // 32]
-                current_bit = (current_word >> (bit_position % 32)) & 1
-
-                if current_bit != previous_bit:
-                    if previous_bit == 0:
-                        # Start
-                        start_position = bit_position
-                    else:
-                        # Finish
-                        length = (bit_position - start_position) * 0x1000
-                        segments.append((start_position * 0x1000, mapped_offset, length, length))
-                        mapped_offset += length
-
-
-                # Find the last segment in a file which will be at the end or two pages from the end. We multiply by 32 as we want to offset bby words rather than bits
-                if (bit_position == bitmap_len - 1 or bit_position == bitmap_len - 1 -32*0x2000) and current_bit == 1:
-                    length = (bit_position - start_position) * 0x1000
-                    segments.append((start_position * 0x1000, mapped_offset, length, length))
-                    mapped_offset += length
-                    break
-
-
-
-                previous_bit = current_bit
-        else:
-            vollog.log(constants.LOGLEVEL_VVVV, "unsupported dump format 0x{:x}".format(self.dump_type))
-            raise WindowsCrashDumpFormatException(self.name, "unsupported dump format 0x{:x}".format(self.dump_type))
-
-        if len(segments) == 0:
-            raise WindowsCrashDumpFormatException(self.name, "No Crash segments defined in {}".format(self._base_layer))
-        
-        self._segments = segments
 
 
 class WindowsCrashDumpStacker(interfaces.automagic.StackerLayerInterface):

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -29,7 +29,7 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
     VALIDDUMP = 0x504d5544
 
     crashdump_json = 'crash'
-    supported_dumptypes = [0x01, 0x05] # we need 0x5 for 32-bit bitmaps
+    supported_dumptypes = [0x01, 0x05]  # we need 0x5 for 32-bit bitmaps
     dump_header_name = '_DUMP_HEADER'
 
     _magic_struct = struct.Struct('<II')
@@ -49,10 +49,11 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
                                                                          self.crashdump_json)
 
         # the _SUMMARY_DUMP is shared between 32- and 64-bit
-        self._crash_common_table_name = intermed.IntermediateSymbolTable.create(context, self._config_path,
+        self._crash_common_table_name = intermed.IntermediateSymbolTable.create(context,
+                                                                                self._config_path,
                                                                                 'windows',
                                                                                 'crash_common',
-                                                                                class_types=crash.class_types)
+                                                                                class_types = crash.class_types)
 
         # Check Header
         hdr_layer = self._context.layers[self._base_layer]
@@ -77,13 +78,13 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
 
     def get_header(self) -> interfaces.objects.ObjectInterface:
         return self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
-                                   offset=0,
-                                   layer_name=self._base_layer)
+                                   offset = 0,
+                                   layer_name = self._base_layer)
 
     def get_summary_header(self) -> interfaces.objects.ObjectInterface:
         return self.context.object(self._crash_common_table_name + constants.BANG + "_SUMMARY_DUMP",
-                                   offset=0x1000 * self.headerpages,
-                                   layer_name=self._base_layer)
+                                   offset = 0x1000 * self.headerpages,
+                                   layer_name = self._base_layer)
 
     def _load_segments(self) -> None:
         """Loads up the segments from the meta_layer."""
@@ -92,13 +93,14 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
 
         if self.dump_type == 0x1:
             header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
-                                         offset=0,
-                                         layer_name=self._base_layer)
+                                         offset = 0,
+                                         layer_name = self._base_layer)
 
             offset = self.headerpages
             header.PhysicalMemoryBlockBuffer.Run.count = header.PhysicalMemoryBlockBuffer.NumberOfRuns
             for run in header.PhysicalMemoryBlockBuffer.Run:
-                segments.append((run.BasePage * 0x1000, offset * 0x1000, run.PageCount * 0x1000, run.PageCount * 0x1000))
+                segments.append(
+                    (run.BasePage * 0x1000, offset * 0x1000, run.PageCount * 0x1000, run.PageCount * 0x1000))
                 offset += run.PageCount
 
         elif self.dump_type == 0x05:
@@ -150,18 +152,17 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
             # report the segments for debugging. this is valuable for dev/troubleshooting but
             # not important enough for a dedicated plugin.
             for idx, (start_position, mapped_offset, length, _) in enumerate(segments):
-                vollog.log(constants.LOGLEVEL_VVVV,
-                           "Segment {}: Position {:#x} Offset {:#x} Length {:#x}".format(idx,
-                                                                                         start_position,
-                                                                                         mapped_offset,
-                                                                                         length))
+                vollog.log(
+                    constants.LOGLEVEL_VVVV,
+                    "Segment {}: Position {:#x} Offset {:#x} Length {:#x}".format(idx, start_position, mapped_offset,
+                                                                                  length))
 
         self._segments = segments
 
     @classmethod
     def check_header(cls, base_layer: interfaces.layers.DataLayerInterface, offset: int = 0) -> Tuple[int, int]:
         # Verify the Window's crash dump file magic
-        
+
         try:
             header_data = base_layer.read(offset, cls._magic_struct.size)
         except exceptions.InvalidAddressException:
@@ -209,4 +210,3 @@ class WindowsCrashDumpStacker(interfaces.automagic.StackerLayerInterface):
             except WindowsCrashDumpFormatException:
                 pass
         return None
-

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -78,6 +78,11 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
                                    offset=0,
                                    layer_name=self._base_layer)
 
+    def get_summary_header(self) -> interfaces.objects.ObjectInterface:
+        return self.context.object(self._crash_common_table_name + constants.BANG + "_SUMMARY_DUMP",
+                                   offset=0x1000 * self.headerpages,
+                                   layer_name=self._base_layer)
+
     def _load_segments(self) -> None:
         """Loads up the segments from the meta_layer."""
 
@@ -85,9 +90,7 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
 
         # instead of hard coding 0x2000, use 0x1000 * self.headerpages so this works for
         # both 32- and 64-bit dumps
-        summary_header = self.context.object(self._crash_common_table_name + constants.BANG + "_SUMMARY_DUMP",
-                                             offset=0x1000 * self.headerpages,
-                                             layer_name=self._base_layer)
+        summary_header = self.get_summary_header()
         if self.dump_type == 0x1:
             header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
                                          offset=0,

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -58,25 +58,25 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
         self.check_header(hdr_layer, hdr_offset)
 
         # Need to create a header object
-        self._header = self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
-                                           offset = hdr_offset,
-                                           layer_name = self._base_layer)
+        header = self.get_header()
 
         # Extract the DTB
-        self.dtb = int(self._header.DirectoryTableBase)
+        self.dtb = int(header.DirectoryTableBase)
 
-        self.dump_type = int(self._header.DumpType)
+        self.dump_type = int(header.DumpType)
 
         # Verify that it is a supported format
-        if self._header.DumpType not in self.supported_dumptypes:
-            vollog.log(constants.LOGLEVEL_VVVV, "unsupported dump format 0x{:x}".format(self._header.DumpType))
-            raise WindowsCrashDumpFormatException(name, "unsupported dump format 0x{:x}".format(self._header.DumpType))
+        if header.DumpType not in self.supported_dumptypes:
+            vollog.log(constants.LOGLEVEL_VVVV, "unsupported dump format 0x{:x}".format(header.DumpType))
+            raise WindowsCrashDumpFormatException(name, "unsupported dump format 0x{:x}".format(header.DumpType))
 
         # Then call the super, which will call load_segments (which needs the base_layer before it'll work)
         super().__init__(context, config_path, name)
 
     def get_header(self) -> interfaces.objects.ObjectInterface:
-        return self._header
+        return self.context.object(self._crash_table_name + constants.BANG + self.dump_header_name,
+                                   offset=0,
+                                   layer_name=self._base_layer)
 
     def _load_segments(self) -> None:
         """Loads up the segments from the meta_layer."""

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -150,6 +150,15 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
 
         if len(segments) == 0:
             raise WindowsCrashDumpFormatException(self.name, "No Crash segments defined in {}".format(self._base_layer))
+        else:
+            # report the segments for debugging. this is valuable for dev/troubleshooting but
+            # not important enough for a dedicated plugin.
+            for idx, (start_position, mapped_offset, length, _) in enumerate(segments):
+                vollog.log(constants.LOGLEVEL_VVVV,
+                           "Segment {}: Position {:#x} Offset {:#x} Length {:#x}".format(idx,
+                                                                                         start_position,
+                                                                                         mapped_offset,
+                                                                                         length))
 
         self._segments = segments
 

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -23,7 +23,7 @@ class Crashinfo(interfaces.plugins.PluginInterface):
                                                      architectures = ["Intel32", "Intel64"]), 
             ]
         
-    def _generator(self, layer):
+    def _generator(self, layer: crash.WindowsCrashDump32Layer):
         header = layer.get_header()
         uptime = datetime.timedelta(microseconds=int(header.SystemUpTime) / 10)
 

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -12,6 +12,7 @@ from volatility3.framework.layers import crash
 
 vollog = logging.getLogger(__name__)
 
+
 class Crashinfo(interfaces.plugins.PluginInterface):
     _required_framework_version = (1, 0, 0)
 
@@ -20,12 +21,12 @@ class Crashinfo(interfaces.plugins.PluginInterface):
         return [
             requirements.TranslationLayerRequirement(name = 'primary',
                                                      description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]), 
-            ]
-        
+                                                     architectures = ["Intel32", "Intel64"]),
+        ]
+
     def _generator(self, layer: crash.WindowsCrashDump32Layer):
         header = layer.get_header()
-        uptime = datetime.timedelta(microseconds=int(header.SystemUpTime) / 10)
+        uptime = datetime.timedelta(microseconds = int(header.SystemUpTime) / 10)
 
         if header.DumpType == 0x1:
             dump_type = "Full Dump (0x1)"
@@ -43,24 +44,25 @@ class Crashinfo(interfaces.plugins.PluginInterface):
         else:
             bitmap_header_size = bitmap_size = bitmap_pages = renderers.NotApplicableValue()
 
-        yield(0, (utility.array_to_string(header.Signature),
-                  header.MajorVersion,
-                  header.MinorVersion,
-                  format_hints.Hex(header.DirectoryTableBase),
-                  format_hints.Hex(header.PfnDataBase),
-                  format_hints.Hex(header.PsLoadedModuleList),
-                  format_hints.Hex(header.PsActiveProcessHead),
-                  header.MachineImageType,
-                  header.NumberProcessors,
-                  format_hints.Hex(header.KdDebuggerDataBlock),
-                  dump_type,
-                  str(uptime),
-                  utility.array_to_string(header.Comment),
-                  conversion.wintime_to_datetime(header.SystemTime),
-                  bitmap_header_size,
-                  bitmap_size,
-                  bitmap_pages,
-                  ))
+        yield (0, (
+            utility.array_to_string(header.Signature),
+            header.MajorVersion,
+            header.MinorVersion,
+            format_hints.Hex(header.DirectoryTableBase),
+            format_hints.Hex(header.PfnDataBase),
+            format_hints.Hex(header.PsLoadedModuleList),
+            format_hints.Hex(header.PsActiveProcessHead),
+            header.MachineImageType,
+            header.NumberProcessors,
+            format_hints.Hex(header.KdDebuggerDataBlock),
+            dump_type,
+            str(uptime),
+            utility.array_to_string(header.Comment),
+            conversion.wintime_to_datetime(header.SystemTime),
+            bitmap_header_size,
+            bitmap_size,
+            bitmap_pages,
+        ))
 
     def run(self):
         crash_layer = None
@@ -74,21 +76,22 @@ class Crashinfo(interfaces.plugins.PluginInterface):
             vollog.error("This plugin requires a Windows crash dump")
             raise
 
-        return renderers.TreeGrid([("Signature", str),
-                                   ("MajorVersion", int),
-                                   ("MinorVersion", int),
-                                   ("DirectoryTableBase", format_hints.Hex),
-                                   ("PfnDataBase", format_hints.Hex),
-                                   ("PsLoadedModuleList", format_hints.Hex),
-                                   ("PsActiveProcessHead", format_hints.Hex),
-                                   ("MachineImageType", int),
-                                   ("NumberProcessors", int),
-                                   ("KdDebuggerDataBlock", format_hints.Hex),
-                                   ("DumpType", str),
-                                   ("SystemUpTime", str),
-                                   ("Comment", str),
-                                   ("SystemTime", datetime.datetime),
-                                   ("BitmapHeaderSize", format_hints.Hex),
-                                   ("BitmapSize", format_hints.Hex),
-                                   ("BitmapPages", format_hints.Hex),
-                                   ], self._generator(crash_layer))
+        return renderers.TreeGrid([
+            ("Signature", str),
+            ("MajorVersion", int),
+            ("MinorVersion", int),
+            ("DirectoryTableBase", format_hints.Hex),
+            ("PfnDataBase", format_hints.Hex),
+            ("PsLoadedModuleList", format_hints.Hex),
+            ("PsActiveProcessHead", format_hints.Hex),
+            ("MachineImageType", int),
+            ("NumberProcessors", int),
+            ("KdDebuggerDataBlock", format_hints.Hex),
+            ("DumpType", str),
+            ("SystemUpTime", str),
+            ("Comment", str),
+            ("SystemTime", datetime.datetime),
+            ("BitmapHeaderSize", format_hints.Hex),
+            ("BitmapSize", format_hints.Hex),
+            ("BitmapPages", format_hints.Hex),
+        ], self._generator(crash_layer))

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -14,7 +14,7 @@ vollog = logging.getLogger(__name__)
 
 
 class Crashinfo(interfaces.plugins.PluginInterface):
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls):

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -8,6 +8,7 @@ from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints, conversion
 from volatility3.framework.objects import utility
+from volatility3.framework.layers import crash
 
 vollog = logging.getLogger(__name__)
 
@@ -63,6 +64,10 @@ class Crashinfo(interfaces.plugins.PluginInterface):
 
     def run(self):
         layer = self._context.layers[self.config['primary.memory_layer']]
+        if not isinstance(layer, crash.WindowsCrashDump32Layer):
+            vollog.error("This plugin requires a Windows crash dump")
+            raise
+
         return renderers.TreeGrid([("Signature", str),
                                    ("MajorVersion", int),
                                    ("MinorVersion", int),

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -1,0 +1,33 @@
+  
+# This file is Copyright 2021 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from volatility.framework import interfaces, renderers
+from volatility.framework.configuration import requirements
+from volatility.framework.layers import crash
+from volatility.framework import exceptions
+
+vollog = logging.getLogger(__name__)
+
+class Crashinfo(interfaces.plugins.PluginInterface):
+    _required_framework_version = (2, 0, 0)
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.TranslationLayerRequirement(name = 'primary',
+                                                     description = 'Memory layer for the kernel',
+                                                     architectures = ["Intel32", "Intel64"]), 
+            ]
+        
+    def _generator(self, layer):
+        for offset, length, mapped_offset in layer.mapping(0x0, layer.maximum_address, ignore_errors = True):
+            yield(0,(offset,length,mapped_offset))
+
+    def run(self):
+
+        layer = self._context.layers[self.config['primary.memory_layer']]
+
+        return renderers.TreeGrid([("StartAddress", int),("FileOffset", int),("Length", int)],self._generator(layer))

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -1,18 +1,18 @@
-  
 # This file is Copyright 2021 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
 import logging
-from volatility.framework import interfaces, renderers
-from volatility.framework.configuration import requirements
-from volatility.framework.layers import crash
-from volatility.framework import exceptions
+import datetime
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.renderers import format_hints, conversion
+from volatility3.framework.objects import utility
 
 vollog = logging.getLogger(__name__)
 
 class Crashinfo(interfaces.plugins.PluginInterface):
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls):
@@ -23,11 +23,39 @@ class Crashinfo(interfaces.plugins.PluginInterface):
             ]
         
     def _generator(self, layer):
-        for offset, length, mapped_offset in layer.mapping(0x0, layer.maximum_address, ignore_errors = True):
-            yield(0,(offset,length,mapped_offset))
+        header = layer.get_header()
+        uptime = datetime.timedelta(microseconds=int(header.SystemUpTime) / 10)
+
+        yield(0, (utility.array_to_string(header.Signature),
+                  header.MajorVersion,
+                  header.MinorVersion,
+                  format_hints.Hex(header.DirectoryTableBase),
+                  format_hints.Hex(header.PfnDataBase),
+                  format_hints.Hex(header.PsLoadedModuleList),
+                  format_hints.Hex(header.PsActiveProcessHead),
+                  header.MachineImageType,
+                  header.NumberProcessors,
+                  format_hints.Hex(header.KdDebuggerDataBlock),
+                  header.DumpType,
+                  str(uptime),
+                  utility.array_to_string(header.Comment),
+                  conversion.wintime_to_datetime(header.SystemTime),
+                  ))
 
     def run(self):
-
         layer = self._context.layers[self.config['primary.memory_layer']]
-
-        return renderers.TreeGrid([("StartAddress", int),("FileOffset", int),("Length", int)],self._generator(layer))
+        return renderers.TreeGrid([("Signature", str),
+                                   ("MajorVersion", int),
+                                   ("MinorVersion", int),
+                                   ("DirectoryTableBase", format_hints.Hex),
+                                   ("PfnDataBase", format_hints.Hex),
+                                   ("PsLoadedModuleList", format_hints.Hex),
+                                   ("PsActiveProcessHead", format_hints.Hex),
+                                   ("MachineImageType", int),
+                                   ("NumberProcessors", int),
+                                   ("KdDebuggerDataBlock", format_hints.Hex),
+                                   ("DumpType", int),
+                                   ("SystemUpTime", str),
+                                   ("Comment", str),
+                                   ("SystemTime", datetime.datetime),
+                                   ], self._generator(layer))

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -63,8 +63,14 @@ class Crashinfo(interfaces.plugins.PluginInterface):
                   ))
 
     def run(self):
-        layer = self._context.layers[self.config['primary.memory_layer']]
-        if not isinstance(layer, crash.WindowsCrashDump32Layer):
+        crash_layer = None
+        for layer_name in self._context.layers:
+            layer = self._context.layers[layer_name]
+            if isinstance(layer, crash.WindowsCrashDump32Layer):
+                crash_layer = layer
+                break
+
+        if crash_layer is None:
             vollog.error("This plugin requires a Windows crash dump")
             raise
 
@@ -85,4 +91,4 @@ class Crashinfo(interfaces.plugins.PluginInterface):
                                    ("BitmapHeaderSize", format_hints.Hex),
                                    ("BitmapSize", format_hints.Hex),
                                    ("BitmapPages", format_hints.Hex),
-                                   ], self._generator(layer))
+                                   ], self._generator(crash_layer))

--- a/volatility3/framework/symbols/windows/crash64.json
+++ b/volatility3/framework/symbols/windows/crash64.json
@@ -65,25 +65,25 @@
           "offset": 40,
           "type": {
             "kind": "base",
-            "name": "unsigned long"
+            "name": "unsigned long long"
           }
         },
         "MachineImageType": {
-          "offset": 44,
-          "type": {
-            "kind": "base",
-            "name": "unsigned long"
-          }
-        },
-        "NumberProcessors": {
           "offset": 48,
           "type": {
             "kind": "base",
             "name": "unsigned long"
           }
         },
+        "NumberProcessors": {
+          "offset": 52,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
         "BugCheckCode": {
-          "offset": 60,
+          "offset": 56,
           "type": {
             "kind": "base",
             "name": "unsigned long"
@@ -157,7 +157,7 @@
             "name": "unsigned long long"
           }
         },
-        "SystemUpTime": {
+        "SystemTime": {
           "offset": 4008,
           "type": {
             "kind": "base",
@@ -175,7 +175,7 @@
             }
           }
         },
-        "SystemTime": {
+        "SystemUpTime": {
           "offset": 4144,
           "type": {
             "kind": "base",
@@ -241,84 +241,6 @@
       },
       "kind": "struct",
       "size": 8192
-    },
-    "_SUMMARY_DUMP64": {
-      "fields": {
-        "Signature": {
-          "offset": 0,
-          "type": {
-            "count": 4,
-            "kind": "array",
-            "subtype": {
-              "kind": "base",
-              "name": "unsigned char"
-            }
-          }
-        },
-        "ValidDump": {
-          "offset": 4,
-          "type": {
-            "count": 4,
-            "kind": "array",
-            "subtype": {
-              "kind": "base",
-              "name": "unsigned char"
-            }
-          }
-        },
-        "DumpOptions": {
-          "offset": 8,
-          "type": {
-            "kind": "base",
-            "name": "unsigned long"
-          }
-        },
-        "HeaderSize": {
-          "offset": 32,
-          "type": {
-            "kind": "base",
-            "name": "unsigned long long"
-          }
-        },
-        "BitmapSize": {
-          "offset": 40,
-          "type": {
-            "kind": "base",
-            "name": "unsigned long long"
-          }
-        },
-        "Pages": {
-          "offset": 48,
-          "type": {
-            "kind": "base",
-            "name": "unsigned long long"
-          }
-        },
-        "BufferLong": {
-          "offset": 56,
-          "type": {
-            "kind": "array",
-            "count": 1,
-            "subtype": {
-              "kind": "base",
-              "name": "unsigned long"
-            }
-          }
-        },
-        "BufferChar": {
-          "offset": 56,
-          "type": {
-            "kind": "array",
-            "count": 1,
-            "subtype": {
-              "kind": "base",
-              "name": "unsigned char"
-            }
-          }
-        }
-      },
-      "kind": "struct",
-      "size": 56
     },
     "_EXCEPTION_RECORD64": {
       "fields": {

--- a/volatility3/framework/symbols/windows/crash_common.json
+++ b/volatility3/framework/symbols/windows/crash_common.json
@@ -1,0 +1,138 @@
+{
+  "symbols": {
+  },
+  "user_types": {
+    "_SUMMARY_DUMP": {
+      "fields": {
+        "Signature": {
+          "offset": 0,
+          "type": {
+            "count": 4,
+            "kind": "array",
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        },
+        "ValidDump": {
+          "offset": 4,
+          "type": {
+            "count": 4,
+            "kind": "array",
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        },
+        "DumpOptions": {
+          "offset": 8,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "HeaderSize": {
+          "offset": 32,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long long"
+          }
+        },
+        "Pages": {
+          "offset": 40,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long long"
+          }
+        },
+        "BitmapSize": {
+          "offset": 48,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long long"
+          }
+        },
+        "BufferLong": {
+          "offset": 56,
+          "type": {
+            "kind": "array",
+            "count": 1,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned long"
+            }
+          }
+        },
+        "BufferChar": {
+          "offset": 56,
+          "type": {
+            "kind": "array",
+            "count": 1,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      },
+      "kind": "struct",
+      "size": 56
+    }
+  },
+  "enums": {
+  },
+  "base_types": {
+    "unsigned char": {
+      "endian": "little",
+      "kind": "char",
+      "signed": false,
+      "size": 1
+    },
+    "unsigned short": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 2
+    },
+    "long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": true,
+      "size": 4
+    },
+    "char": {
+      "endian": "little",
+      "kind": "char",
+      "signed": true,
+      "size": 1
+    },
+    "unsigned long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 4
+    },
+    "long long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": true,
+      "size": 8
+    },
+    "unsigned long long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 8
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "ikelos-by-hand",
+      "datetime": "2020-09-10T00:20:00"
+    },
+    "format": "6.2.0"
+  }
+}

--- a/volatility3/framework/symbols/windows/extensions/crash.py
+++ b/volatility3/framework/symbols/windows/extensions/crash.py
@@ -1,4 +1,4 @@
-# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# This file is Copyright 2021 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 

--- a/volatility3/framework/symbols/windows/extensions/crash.py
+++ b/volatility3/framework/symbols/windows/extensions/crash.py
@@ -11,17 +11,17 @@ class SUMMARY_DUMP(objects.StructType):
     def get_buffer(self, sub_type: str, count: int) -> interfaces.objects.ObjectInterface:
         symbol_table_name = self.get_symbol_table_name()
         subtype = self._context.symbol_space.get_type(symbol_table_name + constants.BANG + sub_type)
-        return self._context.object(object_type=symbol_table_name + constants.BANG + "array",
-                                    layer_name=self.vol.layer_name,
-                                    offset=self.BufferChar.vol.offset,
-                                    count=count,
-                                    subtype=subtype)
+        return self._context.object(object_type = symbol_table_name + constants.BANG + "array",
+                                    layer_name = self.vol.layer_name,
+                                    offset = self.BufferChar.vol.offset,
+                                    count = count,
+                                    subtype = subtype)
 
     def get_buffer_char(self) -> interfaces.objects.ObjectInterface:
-        return self.get_buffer(sub_type="unsigned char", count=(self.BitmapSize + 7) // 8)
+        return self.get_buffer(sub_type = "unsigned char", count = (self.BitmapSize + 7) // 8)
 
     def get_buffer_long(self) -> interfaces.objects.ObjectInterface:
-        return self.get_buffer(sub_type="unsigned long", count=(self.BitmapSize + 31) // 32)
+        return self.get_buffer(sub_type = "unsigned long", count = (self.BitmapSize + 31) // 32)
 
 
 class_types = {'_SUMMARY_DUMP': SUMMARY_DUMP}

--- a/volatility3/framework/symbols/windows/extensions/crash.py
+++ b/volatility3/framework/symbols/windows/extensions/crash.py
@@ -1,0 +1,27 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+from volatility3.framework import interfaces, constants
+from volatility3.framework import objects
+
+
+class SUMMARY_DUMP(objects.StructType):
+
+    def get_buffer(self, sub_type: str, count: int) -> interfaces.objects.ObjectInterface:
+        symbol_table_name = self.get_symbol_table_name()
+        subtype = self._context.symbol_space.get_type(symbol_table_name + constants.BANG + sub_type)
+        return self._context.object(object_type=symbol_table_name + constants.BANG + "array",
+                                    layer_name=self.vol.layer_name,
+                                    offset=self.BufferChar.vol.offset,
+                                    count=count,
+                                    subtype=subtype)
+
+    def get_buffer_char(self) -> interfaces.objects.ObjectInterface:
+        return self.get_buffer(sub_type="unsigned char", count=(self.BitmapSize + 7) // 8)
+
+    def get_buffer_long(self) -> interfaces.objects.ObjectInterface:
+        return self.get_buffer(sub_type="unsigned long", count=(self.BitmapSize + 31) // 32)
+
+
+class_types = {'_SUMMARY_DUMP': SUMMARY_DUMP}


### PR DESCRIPTION
This MR supersedes https://github.com/volatilityfoundation/volatility3/pull/452. In particular, it completes the support for Windows crash dumps, including both type 0x1 (list) and 0x5 (bitmap). 