### PR TITLE
Windows: Ensure DTBs don't have all valid entries

### DIFF
--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -124,8 +124,7 @@ class DtbTest32bit(DtbTest):
         super().__init__(layer_type = layers.intel.WindowsIntel,
                          ptr_struct = "I",
                          ptr_reference = [0x300],
-                         mask = 0xFFFFF000,
-                         num_entries = 1024)
+                         mask = 0xFFFFF000)
 
 
 class DtbTest64bit(DtbTest):
@@ -134,8 +133,7 @@ class DtbTest64bit(DtbTest):
         super().__init__(layer_type = layers.intel.WindowsIntel32e,
                          ptr_struct = "Q",
                          ptr_reference = range(0x1ff, 0x100, -1),
-                         mask = 0x3FFFFFFFFFF000,
-                         num_entries = 512)
+                         mask = 0x3FFFFFFFFFF000)
 
     # As of Windows-10 RS1+, the ptr_reference is randomized:
     # https://blahcat.github.io/2020/06/15/playing_with_self_reference_pml4_entry/

--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -58,7 +58,6 @@ class DtbTest:
         # but they can have all four entries filled, so we'd want this test off anyway
         self.num_entries = self.page_size // self.ptr_size
 
-
     def _unpack(self, value: bytes) -> int:
         return struct.unpack("<" + self.ptr_struct, value)[0]
 
@@ -76,7 +75,7 @@ class DtbTest:
         """
         for ptr_reference in self.ptr_reference:
             value = data[page_offset + (ptr_reference * self.ptr_size):page_offset +
-                         ((ptr_reference + 1) * self.ptr_size)]
+                                                                       ((ptr_reference + 1) * self.ptr_size)]
             try:
                 ptr = self._unpack(value)
             except struct.error:
@@ -179,8 +178,6 @@ class DtbTestPae(DtbTest):
         return None
 
 
-
-
 class PageMapScanner(interfaces.layers.ScannerInterface):
     """Scans through all pages using DTB tests to determine a dtb offset and
     architecture."""
@@ -194,6 +191,7 @@ class PageMapScanner(interfaces.layers.ScannerInterface):
         self.tests = tests
 
     def __call__(self, data: bytes, data_offset: int) -> Generator[Tuple[DtbTest, int], None, None]:
+
         for test in self.tests:
             for page_offset in range(0, len(data), 0x1000):
                 result = test(data, data_offset, page_offset)


### PR DESCRIPTION
We were finding that PAE results were being masked by certain pages with
64bit results.  The DTBs could be distinguished from good DTBs because
every entry was valid (which for a 64-bit or even 32-bit DTB is
extremely unlikely except on systems with *vast* quanties of memory.

As such, this now tests for all entries being allocated and doesn't return the
DTB if this is the case.