### PR TITLE
Fixed CM_KEY_VALUE get_decode method

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/registry.py
+++ b/volatility3/framework/symbols/windows/extensions/registry.py
@@ -260,7 +260,7 @@ class CM_KEY_VALUE(objects.StructType):
             # but the length at the start could be negative so just adding 4 to jump past it
             data = layer.read(self.Data + 4, datalen)
 
-        self_type = RegValueTypes.get(self.Type)
+        self_type = RegValueTypes(self.Type)
         if self_type == RegValueTypes.REG_DWORD:
             if len(data) != struct.calcsize("<L"):
                 raise ValueError("Size of data does not match the type of registry value {}".format(self.get_name()))


### PR DESCRIPTION
Commit 0214fa35a11697f03e7af33a6f90644cde0325c5 made the decode_data() method in registry.py not work anymore because of the removed get() method.
Changed to use the new __missing__ method added in the aforementioned commit.