### PR TITLE
Fixes transition-PDEs being treated as large pages

### DIFF
--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -134,7 +134,7 @@ class Intel(linear.LinearlyMappedLayer):
                 raise exceptions.PagedInvalidAddressException(self.name, offset, position + 1, entry,
                                                               "Page Fault at entry " + hex(entry) + " in table " + name)
             # Check if we're a large page
-            if large_page and (entry & (1 << 7)):
+            if large_page and (entry & 1) and (entry & (1 << 7)):
                 # We're a large page, the rest is finished below
                 # If we want to implement PSE-36, it would need to be done here
                 break


### PR DESCRIPTION
For windows, the overloaded _page_is_valid is used (from WindowsMixin), which also returns true if a PTE/PDE is in transition state. While this is fine for most cases (normal/4kb pages resp. PTEs), this does not work when checking for large pages. Large pages are not paged out (at least not so far; see Windows Internals 7th Edition Part 1, page 304), so they don't reach the transition state. Hence, _MMPTE_TRANSITION does not contain the LargePage bit, but instead contains the page protection where also the LargePage bit would be. _translate_entry does, however, check bit 7 (which is only for _MMPTE_HARDWARE the LargePage bit) in both cases, and hence treats a PDE in transition state as a large page, that actually references a Page Table.

Here an example for the translation of an affected virtual address. In the first case without the fix, in the second with the fix. The final PTE in the second case has a value of 0x0, so the exception is expected:

(primary_Process5032_1) >>> proc_layer.translate(0x7fff30400000)
(5970591744, 'memory_layer')

# With the fix:
(primary_Process5032_1) >>> proc_layer.translate(0x7fff30400000)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/opt/forensic_volatility3/volatility3/framework/layers/linear.py", line 14, in translate
    mapping = list(self.mapping(offset, 0, ignore_errors))
  File "/opt/forensic_volatility3/volatility3/framework/layers/intel.py", line 203, in mapping
    mapped_offset, _, layer_name = self._translate(offset)
  File "/opt/forensic_volatility3/volatility3/framework/layers/intel.py", line 343, in _translate
    return self._translate_swap(self, offset, self._bits_per_register // 2)
  File "/opt/forensic_volatility3/volatility3/framework/layers/intel.py", line 295, in _translate_swap
    return super()._translate(offset)
  File "/opt/forensic_volatility3/volatility3/framework/layers/intel.py", line 107, in _translate
    entry, position = self._translate_entry(offset)
  File "/opt/forensic_volatility3/volatility3/framework/layers/intel.py", line 137, in _translate_entry
    "Page Fault at entry " + hex(entry) + " in table " + name)
volatility3.framework.exceptions.PagedInvalidAddressException: Page Fault at entry 0x0 in table page directory