### PR TITLE
Create a list_head to fix tty_check bug

### DIFF
--- a/volatility3/framework/plugins/linux/tty_check.py
+++ b/volatility3/framework/plugins/linux/tty_check.py
@@ -41,7 +41,7 @@ class tty_check(plugins.PluginInterface):
                                                                      self.config['vmlinux'], modules)
 
         try:
-            tty_drivers = vmlinux.object_from_symbol("tty_drivers")
+            tty_drivers = vmlinux.object_from_symbol("tty_drivers").cast("list_head")
         except exceptions.SymbolError:
             tty_drivers = None
 


### PR DESCRIPTION
This PR casts `tty_driver` to a `list_head` to fix an `AttributeError` in the linux `tty_check` plugin. The error occurs because `to_list` only works for `list_head` objects, not `Void` types.

For context, the original `AttributeError` backtrace in the `tty_check` plugin looks like:
```
Name	Address	Module	Symbol
Traceback (most recent call last):
  File "/Users/fgomulka/virtualenv/vol3/bin/vol", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/lib/python3.9/site-packages/volatility3/cli/__init__.py", line 587, in main
    CommandLine().run()
  File "/opt/homebrew/lib/python3.9/site-packages/volatility3/cli/__init__.py", line 317, in run
    renderers[args.renderer]().render(constructed.run())
  File "/opt/homebrew/lib/python3.9/site-packages/volatility3/cli/text_renderer.py", line 178, in render
    grid.populate(visitor, outfd)
  File "/opt/homebrew/lib/python3.9/site-packages/volatility3/framework/renderers/__init__.py", line 211, in populate
    for (level, item) in self._generator:
  File "/opt/homebrew/lib/python3.9/site-packages/volatility3/framework/plugins/linux/tty_check.py", line 55, in _generator
    for tty in tty_drivers.to_list(vmlinux.name + constants.BANG + "tty_driver", "tty_drivers"):
  File "/opt/homebrew/lib/python3.9/site-packages/volatility3/framework/interfaces/objects.py", line 123, in __getattr__
    raise AttributeError
AttributeError

?1
```