### PR TITLE
Fix issue #522: private attribute names mangle

### DIFF
--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -733,14 +733,13 @@ class AggregateType(interfaces.objects.ObjectInterface):
     def __getattr__(self, attr: str) -> Any:
         """Method for accessing members of the type."""
 
-        if  attr.startswith("_") and not attr.startswith("__") and "__" in attr:
-            attr = attr[attr.find("_", 1):]  # See issue #522
-
         if attr in ['_concrete_members', 'vol']:
             raise AttributeError("Object has not been properly initialized")
         if attr in self._concrete_members:
             return self._concrete_members[attr]
-        elif attr in self.vol.members:
+        if  attr.startswith("_") and not attr.startswith("__") and "__" in attr:
+            attr = attr[attr.find("_", 1):]  # See issue #522
+        if attr in self.vol.members:
             mask = self._context.layers[self.vol.layer_name].address_mask
             relative_offset, template = self.vol.members[attr]
             if isinstance(template, templates.ReferenceTemplate):

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -732,6 +732,10 @@ class AggregateType(interfaces.objects.ObjectInterface):
 
     def __getattr__(self, attr: str) -> Any:
         """Method for accessing members of the type."""
+
+        if  attr.startswith("_") and not attr.startswith("__") and "__" in attr:
+            attr = attr[attr.find("_", 1):]  # See issue #522
+
         if attr in ['_concrete_members', 'vol']:
             raise AttributeError("Object has not been properly initialized")
         if attr in self._concrete_members:

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -738,7 +738,7 @@ class AggregateType(interfaces.objects.ObjectInterface):
         if attr in self._concrete_members:
             return self._concrete_members[attr]
         if  attr.startswith("_") and not attr.startswith("__") and "__" in attr:
-            attr = attr[attr.find("_", 1):]  # See issue #522
+            attr = attr[attr.find("__", 1):]  # See issue #522
         if attr in self.vol.members:
             mask = self._context.layers[self.vol.layer_name].address_mask
             relative_offset, template = self.vol.members[attr]


### PR DESCRIPTION
As per https://docs.python.org/3/tutorial/classes.html#private-variables
Python will mangle private attribute names from `__attrname` to `_classname__attrname` to avoid name clashes of names with names defined by subclasses.
This will happen even if subclasses are not involved i.e.: calling `type_member.__foo` from a plugin classmethod.
Note that `__foo` is not meant to be a Python private attribute, but the actual name of the type member.
Like sock.__sk_common here: https://github.com/torvalds/linux/blob/62fb9874f5da54fdb243003b386128037319b219/include/net/sock.h#L354

We need to strip the '_classname' prefix from the attribute's name before continuing with the member attribute lookup.