### PR TITLE
Feature/linux mac repo

### DIFF
--- a/development/banner_server.py
+++ b/development/banner_server.py
@@ -28,7 +28,7 @@ class BannerCacheGenerator:
 
     def run(self):
         context = contexts.Context()
-        json_output = {}
+        json_output = {'version': 1}
 
         path = self._path
         filename = '*'

--- a/development/banner_server.py
+++ b/development/banner_server.py
@@ -1,0 +1,77 @@
+import argparse
+import base64
+import json
+import logging
+import os
+import pathlib
+import urllib
+
+from volatility3.cli import PrintedProgress
+from volatility3.framework import contexts, constants
+from volatility3.framework.automagic import linux, mac
+
+vollog = logging.getLogger(__name__)
+
+
+class BannerCacheGenerator:
+
+    def __init__(self, path: str, url_prefix: str):
+        self._path = path
+        self._url_prefix = url_prefix
+
+    def convert_url(self, url):
+        parsed = urllib.parse.urlparse(url)
+
+        relpath = os.path.relpath(parsed.path, os.path.abspath(self._path))
+
+        return urllib.parse.urljoin(self._url_prefix, relpath)
+
+    def run(self):
+        context = contexts.Context()
+        json_output = {}
+
+        path = self._path
+        filename = '*'
+
+        for banner_cache in [linux.LinuxBannerCache, mac.MacBannerCache]:
+            sub_path = banner_cache.os
+            potentials = []
+            for extension in constants.ISF_EXTENSIONS:
+                # Hopefully these will not be large lists, otherwise this might be slow
+                try:
+                    for found in pathlib.Path(path).joinpath(sub_path).resolve().rglob(filename + extension):
+                        potentials.append(found.as_uri())
+                except FileNotFoundError:
+                    # If there's no linux symbols, don't cry about it
+                    pass
+
+            new_banners = banner_cache.read_new_banners(context, 'BannerServer', potentials, banner_cache.symbol_name,
+                                                        banner_cache.os, progress_callback = PrintedProgress())
+            result_banners = {}
+            for new_banner in new_banners:
+                # Only accept file schemes
+                value = [self.convert_url(url) for url in new_banners[new_banner] if
+                         urllib.parse.urlparse(url).scheme == 'file']
+                if value and new_banner:
+                    # Convert files into URLs
+                    result_banners[str(base64.b64encode(new_banner), 'latin-1')] = value
+
+            json_output[banner_cache.os] = result_banners
+
+        output_path = os.path.join(self._path, 'banners.json')
+        with open(output_path, 'w') as fp:
+            vollog.warning(f"Banners file written to {output_path}")
+            json.dump(json_output, fp)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--path', default = os.path.dirname(__file__))
+    parser.add_argument('--urlprefix', help = 'Web prefix that will eventually serve the ISF files',
+                        default = 'http://localhost/symbols')
+
+    args = parser.parse_args()
+
+    bcg = BannerCacheGenerator(args.path, args.urlprefix)
+    bcg.run()

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -165,6 +165,10 @@ class CommandLine:
                             help = f"Change the default path ({constants.CACHE_PATH}) used to store the cache",
                             default = constants.CACHE_PATH,
                             type = str)
+        parser.add_argument("--offline",
+                            help = "Do not search online for additional JSON files",
+                            default = False,
+                            action = 'store_true')
 
         # We have to filter out help, otherwise parse_known_args will trigger the help message before having
         # processed the plugin choice or had the plugin subparser added.
@@ -215,6 +219,9 @@ class CommandLine:
 
         if partial_args.clear_cache:
             framework.clear_cache()
+
+        if partial_args.offline:
+            constants.OFFLINE = partial_args.offline
 
         # Do the initialization
         ctx = contexts.Context()  # Construct a blank context

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -10,7 +10,6 @@ import pickle
 import urllib
 import urllib.parse
 import urllib.request
-import zipfile
 from typing import Dict, List, Optional
 
 from volatility3.framework import constants, exceptions, interfaces
@@ -165,7 +164,7 @@ class SymbolBannerCache(interfaces.automagic.AutomagicInterface):
         if banner_location is None:
             banner_location = constants.REMOTE_ISF_URL
 
-        if not constants.OFFLINE:
+        if not constants.OFFLINE and banner_location is not None:
             try:
                 rbf = RemoteBannerFormat(banner_location)
                 rbf.process(banners, operating_system)

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -166,8 +166,11 @@ class SymbolBannerCache(interfaces.automagic.AutomagicInterface):
             banner_location = constants.REMOTE_ISF_URL
 
         if not constants.OFFLINE:
-            rbf = RemoteBannerFormat(banner_location)
-            rbf.process(banners, operating_system)
+            try:
+                rbf = RemoteBannerFormat(banner_location)
+                rbf.process(banners, operating_system)
+            except urllib.error.URLError:
+                vollog.debug(f"Unable to download remote banner list from {banner_location}")
 
 
 class RemoteBannerFormat:

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -10,6 +10,7 @@ import pickle
 import urllib
 import urllib.parse
 import urllib.request
+import zipfile
 from typing import Dict, List, Optional
 
 from volatility3.framework import constants, exceptions, interfaces
@@ -53,13 +54,13 @@ class SymbolBannerCache(interfaces.automagic.AutomagicInterface):
                             path, str(banner or b'', 'latin-1')))
                     banners[banner].remove(path)
                 # This is probably excessive, but it's here if we need it
-                # if url.scheme == 'jar':
-                #     zip_file, zip_path = url.path.split("!")
-                #     zip_file = urllib.parse.urlparse(zip_file).path
-                #     if ((not os.path.exists(zip_file)) or (zip_path not in zipfile.ZipFile(zip_file).namelist())):
-                #         vollog.log(constants.LOGLEVEL_VV,
-                #                    "Removing cached path {} for banner {}: file does not exist".format(path, banner))
-                #         banners[banner].remove(path)
+                if url.scheme == 'jar':
+                    zip_file, zip_path = url.path.split("!")
+                    zip_file = urllib.parse.urlparse(zip_file).path
+                    if ((not os.path.exists(zip_file)) or (zip_path not in zipfile.ZipFile(zip_file).namelist())):
+                        vollog.log(constants.LOGLEVEL_VV,
+                                   "Removing cached path {} for banner {}: file does not exist".format(path, banner))
+                        banners[banner].remove(path)
 
             if not banners[banner]:
                 remove_banners.append(banner)
@@ -100,7 +101,7 @@ class SymbolBannerCache(interfaces.automagic.AutomagicInterface):
         self.save_banners(banners)
 
         if progress_callback is not None:
-            progress_callback(100, "Built {} caches".format(self.os))
+            progress_callback(100, f"Built {self.os} caches")
 
     @classmethod
     def read_new_banners(cls, context: interfaces.context.ContextInterface, config_path: str, new_urls: List[str],
@@ -114,10 +115,10 @@ class SymbolBannerCache(interfaces.automagic.AutomagicInterface):
 
         total = len(new_urls)
         if total > 0:
-            vollog.info(f"Building {self.os} caches...")
+            vollog.info(f"Building {operating_system} caches...")
         for current in range(total):
             if progress_callback is not None:
-                progress_callback(current * 100 / total, f"Building {self.os} caches")
+                progress_callback(current * 100 / total, f"Building {operating_system} caches")
             isf_url = new_urls[current]
 
             isf = None

--- a/volatility3/framework/automagic/symbol_finder.py
+++ b/volatility3/framework/automagic/symbol_finder.py
@@ -94,7 +94,8 @@ class SymbolFinder(interfaces.automagic.AutomagicInterface):
         else:
             # Swap to the physical layer for scanning
             # TODO: Fix this so it works for layers other than just Intel
-            layer = context.layers[layer.config['memory_layer']]
+            if isinstance(layer, layers.intel.Intel):
+                layer = context.layers[layer.config['memory_layer']]
             banner_list = layer.scan(context = context, scanner = mss, progress_callback = progress_callback)
 
         for _, banner in banner_list:

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -94,3 +94,9 @@ ISF_MINIMUM_SUPPORTED = (2, 0, 0)
 """The minimum supported version of the Intermediate Symbol Format"""
 ISF_MINIMUM_DEPRECATED = (3, 9, 9)
 """The highest version of the ISF that's deprecated (usually higher than supported)"""
+
+OFFLINE = False
+"""Whether to go online to retrieve missing/necessary JSON files"""
+
+REMOTE_ISF_URL = 'http://localhost:8000/banners.json'
+"""Remote URL to query for a list of ISF addresses"""

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -40,7 +40,7 @@ BANG = "!"
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 1  # Number of releases of the library with a breaking change
 VERSION_MINOR = 2  # Number of changes that only add to the interface
-VERSION_PATCH = 0  # Number of changes that do not change the interface
+VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 # TODO: At version 2.0.0, remove the symbol_shift feature

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -98,5 +98,5 @@ ISF_MINIMUM_DEPRECATED = (3, 9, 9)
 OFFLINE = False
 """Whether to go online to retrieve missing/necessary JSON files"""
 
-REMOTE_ISF_URL = 'http://localhost:8000/banners.json'
+REMOTE_ISF_URL = None  # 'http://localhost:8000/banners.json'
 """Remote URL to query for a list of ISF addresses"""

--- a/volatility3/framework/exceptions.py
+++ b/volatility3/framework/exceptions.py
@@ -99,3 +99,14 @@ class MissingModuleException(VolatilityException):
     def __init__(self, module: str, *args) -> None:
         super().__init__(*args)
         self.module = module
+
+
+class OfflineException(VolatilityException):
+    """Throw when a remote resource is requested but Volatility is in offline mode"""
+
+    def __init__(self, url: str, *args) -> None:
+        super().__init__(*args)
+        self._url = url
+
+    def __str__(self):
+        return f'Volatility 3 is offline: unable to access {self._url}'


### PR DESCRIPTION
Add in support for offline mode (defaults to false) and for remote linux/mac banner repositories.  The code for generating a repo is pretty crude, and mostly proof of concept, but it should generate the appropriate JSON file to be downloaded from a server such that the banner list can be split into multiple lists if wanted and there's a version in the file format to allow it to be extended/altered in the future.  I haven't written a JSON schema for it yet, but it should be pretty easy to do.

Essentially this JSON file contains base64 encoded banners and for each, a list of JSON ISF files that can fulfill that banner.  This list is pulled down and added to the existing cache list (currently every time, but we can add in a cache age system in the future), and the URLs added to the list of JSON locations.  Since these are remote, and we can't easily check for their existence each time, they'll stay in the cache list until it's clearer or forever.  If the file stops existing at the URL, it *shouldn't* cause big problems, it should just move to the next URL (still need to test this).

Then it's just part of the normal cache mechanism.  The banners are scanned for, and if one is found it's loaded (which will pull the file down from the internet if it hasn't been cached and --offline isn't in use) and then use it (and cache it).  So there's not a huge amount of new code luckily, just enough to manage the cacheing list.

Things to watch out for when reviewing are various combinations of the remote server being up, being down, files being removed from the remote server all in various combinations with the same file existing/not existing locally.