### PR TITLE
[API] fix mutantscan (and possibly others)

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/pool.py
+++ b/volatility3/framework/symbols/windows/extensions/pool.py
@@ -59,7 +59,7 @@ class POOL_HEADER(objects.StructType):
                                               layer_name = self.vol.layer_name,
                                               offset = self.vol.offset + pool_header_size,
                                               native_layer_name = native_layer_name)
-            return mem_object
+            yield mem_object
 
         # otherwise we have an executive object in the pool
         else:
@@ -145,7 +145,7 @@ class POOL_HEADER(objects.StructType):
                                                           native_layer_name = native_layer_name)
 
                         if mem_object.is_valid():
-                            return mem_object
+                            yield mem_object
 
                     except (TypeError, exceptions.InvalidAddressException):
                         pass
@@ -168,8 +168,7 @@ class POOL_HEADER(objects.StructType):
                     if mem_object.is_valid():
                         return mem_object
                 except (TypeError, exceptions.InvalidAddressException):
-                    return None
-        return None
+                    pass
 
     @classmethod
     @functools.lru_cache()

--- a/volatility3/framework/symbols/windows/extensions/pool.py
+++ b/volatility3/framework/symbols/windows/extensions/pool.py
@@ -166,7 +166,7 @@ class POOL_HEADER(objects.StructType):
 
                 try:
                     if mem_object.is_valid():
-                        return mem_object
+                        yield mem_object
                 except (TypeError, exceptions.InvalidAddressException):
                     pass
 

--- a/volatility3/framework/symbols/windows/poolheader-x86.json
+++ b/volatility3/framework/symbols/windows/poolheader-x86.json
@@ -55,7 +55,7 @@
         }
       },
       "kind": "struct",
-      "size": 16
+      "size": 8
     }
   },
   "symbols": {

--- a/volatility3/plugins/windows/poolscanner.py
+++ b/volatility3/plugins/windows/poolscanner.py
@@ -121,7 +121,7 @@ class PoolScanner(plugins.PluginInterface):
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
             requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
-                                           architectures = ["Intel32", "Intel64"]),
+                                                     architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'handles', plugin = handles.Handles, version = (1, 0, 0)),
         ]
 


### PR DESCRIPTION
Refs Issue #530 

N.B. This PR requires a major version change which is not currently part of the PR. (Also see #537) 

When `get_object()` uses the "top down" approach, it guesses offsets and accepts the first object that passes the `is_valid()` check. The caller (`generate_pool_scan()`) then checks the object's type and discards the finding if it doesn't match what it expects. In some cases, the first object that passes `is_valid()` does not pass the object type check, so the mutant in that pool allocation is not reported. 

There are two ways to solve this problem. The one I implemented is to turn `get_object()` into a generator. It yields any objects that pass `is_valid()` and lets the caller continue to do the type check. It is possible, but very unlikely, that this could result in more than one mutant being reported, if there happens to be multiple squished into the same pool. The other option is to pass in the variables necessary for validating the object type (`type_map` and `cookie`) to `get_object()` so it only returns objects that pass `is_valid()` AND the type check. 

Ultimately, both checks need to happen. The question is...do we want the caller doing one check and the callee doing the other; or do we want the callee to do both. 

Also, in researching this problem, I stumbled upon an incorrect size for 32-bit `_POOL_HEADER` structures. The JSON said 16, but these are really 8 bytes. 