### PR TITLE
issue #528 - change how registry enum members are accessed

### DIFF
--- a/volatility3/framework/plugins/windows/getsids.py
+++ b/volatility3/framework/plugins/windows/getsids.py
@@ -96,9 +96,9 @@ class GetSIDs(interfaces.plugins.PluginInterface):
                             value_data = node.decode_data()
                             if isinstance(value_data, int):
                                 value_data = format_hints.MultiTypeData(value_data, encoding = 'utf-8')
-                            elif registry.RegValueTypes.get(node.Type) == registry.RegValueTypes.REG_BINARY:
+                            elif registry.RegValueTypes[node.Type] == registry.RegValueTypes.REG_BINARY:
                                 value_data = format_hints.MultiTypeData(value_data, show_hex = True)
-                            elif registry.RegValueTypes.get(node.Type) == registry.RegValueTypes.REG_MULTI_SZ:
+                            elif registry.RegValueTypes[node.Type] == registry.RegValueTypes.REG_MULTI_SZ:
                                 value_data = format_hints.MultiTypeData(value_data,
                                                                         encoding = 'utf-16-le',
                                                                         split_nulls = True)

--- a/volatility3/framework/plugins/windows/registry/printkey.py
+++ b/volatility3/framework/plugins/windows/registry/printkey.py
@@ -123,7 +123,7 @@ class PrintKey(interfaces.plugins.PluginInterface):
                     value_node_name = renderers.UnreadableValue()
 
                 try:
-                    value_type = RegValueTypes.get(node.Type).name
+                    value_type = RegValueTypes[node.Type].name
                 except (exceptions.InvalidAddressException, RegistryFormatException) as excp:
                     vollog.debug(excp)
                     value_type = renderers.UnreadableValue()
@@ -137,9 +137,9 @@ class PrintKey(interfaces.plugins.PluginInterface):
 
                         if isinstance(value_data, int):
                             value_data = format_hints.MultiTypeData(value_data, encoding = 'utf-8')
-                        elif RegValueTypes.get(node.Type) == RegValueTypes.REG_BINARY:
+                        elif RegValueTypes[node.Type] == RegValueTypes.REG_BINARY:
                             value_data = format_hints.MultiTypeData(value_data, show_hex = True)
-                        elif RegValueTypes.get(node.Type) == RegValueTypes.REG_MULTI_SZ:
+                        elif RegValueTypes[node.Type] == RegValueTypes.REG_MULTI_SZ:
                             value_data = format_hints.MultiTypeData(value_data,
                                                                     encoding = 'utf-16-le',
                                                                     split_nulls = True)

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -50,7 +50,7 @@ class Certificates(interfaces.plugins.PluginInterface):
                     node_path = hive.get_key(top_key, return_list = True)
                     for (depth, is_key, last_write_time, key_path, volatility,
                          node) in printkey.PrintKey.key_iterator(hive, node_path, recurse = True):
-                        if not is_key and RegValueTypes.get(node.Type).name == "REG_BINARY":
+                        if not is_key and RegValueTypes[node.Type].name == "REG_BINARY":
                             name, certificate_data = self.parse_data(node.decode_data())
                             unique_key_offset = key_path.index(top_key) + len(top_key) + 1
                             reg_section = key_path[unique_key_offset:key_path.index("\\", unique_key_offset)]


### PR DESCRIPTION
Closes #528.  With removing the get() classmethod for the enum, accessing enum members needed to change as well.