### PR TITLE
Windows: Fix up pdb.json for LF_UDT_MOD_SRC_LINE

### DIFF
--- a/volatility3/framework/symbols/windows/pdb.json
+++ b/volatility3/framework/symbols/windows/pdb.json
@@ -1349,12 +1349,12 @@
           "offset": 12,
           "type": {
             "kind": "base",
-            "name": "string"
+            "name": "unsigned short"
           }
         }
       },
       "kind": "struct",
-      "size": 16
+      "size": 14
     },
     "LF_UNION": {
       "fields": {


### PR DESCRIPTION
The `module` field in `LF_UDT_MOD_SRC_LINE` should be `unsigned short` instead of `string` as per:
```
typedef struct lfUdtModSrcLine {
    unsigned short leaf;        // LF_UDT_MOD_SRC_LINE
    CV_typ_t       type;        // UDT's type index
    CV_ItemId      src;         // index into string table where source file name is saved
    unsigned long  line;        // line number
    unsigned short imod;        // module that contributes this UDT definition 
} lfUdtModSrcLine;
```
([source](https://github.com/microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L1707))

This also changes the size of the struct from 16 to 14.