### PR TITLE
Core: Change pointer caching

### DIFF
--- a/API_CHANGES
+++ b/API_CHANGES
@@ -1,0 +1,4 @@
+Lists of changes made to API in each version
+============================================
+
+1.2.1  Added new_instance flag to pointer.dereference call

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -39,7 +39,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 1  # Number of releases of the library with a breaking change
-VERSION_MINOR = 1  # Number of changes that only add to the interface
+VERSION_MINOR = 2  # Number of changes that only add to the interface
 VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 


### PR DESCRIPTION
Fixes #532 by caching pointer dereferences explicitly, since we found an instance where a pointer was reused with a different vol subtype dict and so was returning the cached object from a new pointer.  Now, rather than the class hanging onto the cache and indexing it on self and layer_name, the instance itself keep a copy of its own dereference keyed by layer_name.  A new parameter `new_instance` was added to the dereference call to allow new instances to be created if wanted.  This now means that once a pointer is referenced it will be maintained by the object's calling stack, so may create the memory usage in certain conditions.

I don't think this will have a knock on effect because multiple context references, etc are being stored, but this is all deep low level stuff, which is why I wanted a review of it before commiting it directly...

@japhlange if you could check it over too, that'd be much appreciated.  The more eyes the better on something like this...  5;)