### PR TITLE
Feature/better modules support

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -1,0 +1,19 @@
+API Changes
+===========
+
+When an addition to the existing API is made, the minor version is bumped.
+When an API feature or function is removed or changed, the major version is bumped.
+
+
+1.2.0
+=====
+* Added support for module collections
+* Added context.modules
+* Added ModuleRequirement
+* Added get\_symbols\_by\_absolute\_location
+
+* Remove support for symbol\_shift and symbol\_mask from symbol tables
+  Symbols should be the data values from the JSON, and if they need modifying,
+  a module wrappr, or similar, should be used
+
+

--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -12,8 +12,4 @@ When an API feature or function is removed or changed, the major version is bump
 * Added ModuleRequirement
 * Added get\_symbols\_by\_absolute\_location
 
-* Remove support for symbol\_shift and symbol\_mask from symbol tables
-  Symbols should be the data values from the JSON, and if they need modifying,
-  a module wrappr, or similar, should be used
-
 

--- a/volatility3/framework/automagic/__init__.py
+++ b/volatility3/framework/automagic/__init__.py
@@ -21,11 +21,13 @@ from volatility3.framework.configuration import requirements
 
 vollog = logging.getLogger(__name__)
 
-windows_automagic = ['ConstructionMagic', 'LayerStacker', 'WintelHelper', 'KernelPDBScanner', 'WinSwapLayers']
+windows_automagic = [
+    'ConstructionMagic', 'LayerStacker', 'WintelHelper', 'KernelPDBScanner', 'WinSwapLayers', 'KernelModule'
+]
 
-linux_automagic = ['ConstructionMagic', 'LayerStacker', 'LinuxBannerCache', 'LinuxSymbolFinder']
+linux_automagic = ['ConstructionMagic', 'LayerStacker', 'LinuxBannerCache', 'LinuxSymbolFinder', 'KernelModule']
 
-mac_automagic = ['ConstructionMagic', 'LayerStacker', 'MacBannerCache', 'MacSymbolFinder']
+mac_automagic = ['ConstructionMagic', 'LayerStacker', 'MacBannerCache', 'MacSymbolFinder', 'KernelModule']
 
 
 def available(context: interfaces.context.ContextInterface) -> List[interfaces.automagic.AutomagicInterface]:

--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -79,7 +79,8 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
                 layer = layer_class(context,
                                     config_path = config_path,
                                     name = new_layer_name,
-                                    metadata = {'kaslr_value': aslr_shift, 'os': 'Linux'})
+                                    metadata = {'os': 'Linux'})
+                layer.config['kernel_virtual_offset'] = aslr_shift
 
             if layer and dtb:
                 vollog.debug(f"DTB was found at: 0x{dtb:0x}")

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -105,7 +105,8 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
                 new_layer = intel.Intel32e(context,
                                            config_path = config_path,
                                            name = new_layer_name,
-                                           metadata = {'kaslr_value': kaslr_shift})
+                                           metadata = {'os': 'mac'})
+                new_layer.config['kernel_virtual_offset'] = kaslr_shift
 
             if new_layer and dtb:
                 vollog.debug(f"DTB was found at: 0x{dtb:0x}")

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -39,9 +39,11 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 1  # Number of releases of the library with a breaking change
-VERSION_MINOR = 1  # Number of changes that only add to the interface
-VERSION_PATCH = 1  # Number of changes that do not change the interface
+VERSION_MINOR = 2  # Number of changes that only add to the interface
+VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
+
+# TODO: At version 2.0.0, remove the symbol_shift feature
 
 PACKAGE_VERSION = ".".join([str(x) for x in [VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH]]) + VERSION_SUFFIX
 """The canonical version of the volatility3 package"""

--- a/volatility3/framework/interfaces/configuration.py
+++ b/volatility3/framework/interfaces/configuration.py
@@ -25,7 +25,7 @@ import sys
 from abc import ABCMeta, abstractmethod
 from typing import Any, ClassVar, Dict, Generator, Iterator, List, Optional, Type, Union, Tuple, Set
 
-from volatility3 import classproperty
+from volatility3 import classproperty, framework
 from volatility3.framework import constants, interfaces
 
 CONFIG_SEPARATOR = "."
@@ -730,6 +730,11 @@ class VersionableInterface:
     All version number should use semantic versioning
     """
     _version: Tuple[int, int, int] = (0, 0, 0)
+    _required_framework_version: Tuple[int, int, int] = (0, 0, 0)
+
+    def __init__(self, *args, **kwargs):
+        framework.require_interface_version(*self._required_framework_version)
+        super().__init__(*args, **kwargs)
 
     @classproperty
     def version(cls) -> Tuple[int, int, int]:

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -54,6 +54,8 @@ class ScannerInterface(interfaces.configuration.VersionableInterface, metaclass 
     """
     thread_safe = False
 
+    _required_framework_version = (1, 0, 0)
+
     def __init__(self) -> None:
         super().__init__()
         self.chunk_size = 0x1000000  # Default to 16Mb chunks

--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -14,7 +14,6 @@ import os
 from abc import ABCMeta, abstractmethod
 from typing import List, Tuple, Type
 
-from volatility3 import framework
 from volatility3.framework import exceptions, constants, interfaces
 
 vollog = logging.getLogger(__name__)
@@ -122,8 +121,6 @@ class PluginInterface(interfaces.configuration.ConfigurableInterface,
                 self.config[requirement.name] = requirement.default
 
         self._file_handler: Type[FileHandlerInterface] = FileHandlerInterface
-
-        framework.require_interface_version(*self._required_framework_version)
 
     @property
     def open(self):

--- a/volatility3/framework/layers/scanners/__init__.py
+++ b/volatility3/framework/layers/scanners/__init__.py
@@ -2,7 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import re
-from typing import Generator, List, Tuple, Dict, Union, Optional
+from typing import Generator, List, Tuple, Dict, Optional
 
 from volatility3.framework.interfaces import layers
 from volatility3.framework.layers.scanners import multiregexp
@@ -10,6 +10,8 @@ from volatility3.framework.layers.scanners import multiregexp
 
 class BytesScanner(layers.ScannerInterface):
     thread_safe = True
+
+    _required_framework_version = (1, 0, 0)
 
     def __init__(self, needle: bytes) -> None:
         super().__init__()
@@ -30,6 +32,8 @@ class BytesScanner(layers.ScannerInterface):
 class RegExScanner(layers.ScannerInterface):
     thread_safe = True
 
+    _required_framework_version = (1, 0, 0)
+
     def __init__(self, pattern: bytes, flags: int = 0) -> None:
         super().__init__()
         self.regex = re.compile(pattern, flags)
@@ -43,8 +47,11 @@ class RegExScanner(layers.ScannerInterface):
             if offset < self.chunk_size:
                 yield offset + data_offset
 
+
 class MultiStringScanner(layers.ScannerInterface):
     thread_safe = True
+
+    _required_framework_version = (1, 0, 0)
 
     def __init__(self, patterns: List[bytes]) -> None:
         super().__init__()

--- a/volatility3/framework/plugins/linux/check_afinfo.py
+++ b/volatility3/framework/plugins/linux/check_afinfo.py
@@ -6,7 +6,7 @@ found in Linux's /proc file system."""
 import logging
 from typing import List
 
-from volatility3.framework import exceptions, interfaces, contexts
+from volatility3.framework import exceptions, interfaces
 from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
@@ -18,15 +18,12 @@ vollog = logging.getLogger(__name__)
 class Check_afinfo(plugins.PluginInterface):
     """Verifies the operation function pointers of network protocols."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols")
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
         ]
 
     # returns whether the symbol is found within the kernel (system.map) or not
@@ -63,7 +60,8 @@ class Check_afinfo(plugins.PluginInterface):
             yield var_name, "show", var.seq_show
 
     def _generator(self):
-        vmlinux = contexts.Module(self.context, self.config['vmlinux'], self.config['primary'], 0)
+
+        vmlinux = self.context.modules[self.config['vmlinux']]
 
         op_members = vmlinux.get_type('file_operations').members
         seq_members = vmlinux.get_type('seq_operations').members

--- a/volatility3/framework/plugins/linux/check_creds.py
+++ b/volatility3/framework/plugins/linux/check_creds.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from volatility3.framework import interfaces, renderers, constants
+from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.plugins.linux import pslist
 
@@ -14,22 +14,19 @@ vollog = logging.getLogger(__name__)
 class Check_creds(interfaces.plugins.PluginInterface):
     """Checks if any processes are sharing credential structures"""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (1, 0, 0))
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        # vmlinux = contexts.Module(self.context, self.config['vmlinux'], self.config['primary'], 0)
+        vmlinux = self.context.modules[self.config['vmlinux']]
 
-        type_task = self.context.symbol_space.get_type(self.config['vmlinux'] + constants.BANG + "task_struct")
+        type_task = vmlinux.get_type("task_struct")
 
         if not type_task.has_member("cred"):
             raise TypeError(
@@ -40,7 +37,7 @@ class Check_creds(interfaces.plugins.PluginInterface):
 
         creds = {}
 
-        tasks = pslist.PsList.list_tasks(self.context, self.config['primary'], self.config['vmlinux'])
+        tasks = pslist.PsList.list_tasks(self.context, vmlinux.name)
 
         for task in tasks:
 

--- a/volatility3/framework/plugins/linux/check_modules.py
+++ b/volatility3/framework/plugins/linux/check_modules.py
@@ -5,7 +5,7 @@
 import logging
 from typing import List
 
-from volatility3.framework import interfaces, renderers, exceptions, constants, contexts
+from volatility3.framework import interfaces, renderers, exceptions, constants
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
@@ -18,19 +18,19 @@ vollog = logging.getLogger(__name__)
 class Check_modules(plugins.PluginInterface):
     """Compares module list to sysfs info, if available"""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
-    def get_kset_modules(self, vmlinux):
+    @classmethod
+    def get_kset_modules(self, context: interfaces.context.ContextInterface, vmlinux_name: str):
+
+        vmlinux = context.modules[vmlinux_name]
 
         try:
             module_kset = vmlinux.object_from_symbol("module_kset")
@@ -44,12 +44,12 @@ class Check_modules(plugins.PluginInterface):
 
         ret = {}
 
-        kobj_off = self.context.symbol_space.get_type(self.config['vmlinux'] + constants.BANG +
-                                                      'module_kobject').relative_child_offset('kobj')
+        kobj_off = vmlinux.get_type('module_kobject').relative_child_offset('kobj')
 
-        for kobj in module_kset.list.to_list(vmlinux.name + constants.BANG + "kobject", "entry"):
+        for kobj in module_kset.list.to_list(vmlinux.symbol_table_name + constants.BANG + "kobject", "entry"):
 
-            mod_kobj = vmlinux.object(object_type = "module_kobject", offset = kobj.vol.offset - kobj_off)
+            mod_kobj = vmlinux.object(object_type = "module_kobject", offset = kobj.vol.offset - kobj_off,
+                                      absolute = True)
 
             mod = mod_kobj.mod
 
@@ -60,13 +60,11 @@ class Check_modules(plugins.PluginInterface):
         return ret
 
     def _generator(self):
-        vmlinux = contexts.Module(self.context, self.config['vmlinux'], self.config['primary'], 0)
-
-        kset_modules = self.get_kset_modules(vmlinux)
+        kset_modules = self.get_kset_modules(self.context, self.config['vmlinux'])
 
         lsmod_modules = set(
             str(utility.array_to_string(modules.name))
-            for modules in lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['vmlinux']))
+            for modules in lsmod.Lsmod.list_modules(self.context, self.config['vmlinux']))
 
         for mod_name in set(kset_modules.keys()).difference(lsmod_modules):
             yield (0, (format_hints.Hex(kset_modules[mod_name]), str(mod_name)))

--- a/volatility3/framework/plugins/linux/check_syscall.py
+++ b/volatility3/framework/plugins/linux/check_syscall.py
@@ -6,7 +6,7 @@ found in Linux's /proc file system."""
 import logging
 from typing import List
 
-from volatility3.framework import exceptions, interfaces, contexts
+from volatility3.framework import exceptions, interfaces
 from volatility3.framework import renderers, constants
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
@@ -25,24 +25,26 @@ except ImportError:
 class Check_syscall(plugins.PluginInterface):
     """Check system call table for hooks."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols")
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
         ]
 
     def _get_table_size_next_symbol(self, table_addr, ptr_sz, vmlinux):
         """Returns the size of the table based on the next symbol."""
         ret = 0
 
-        sym_table = self.context.symbol_space[vmlinux.name]
-
-        sorted_symbols = sorted([(sym_table.get_symbol(sn).address, sn) for sn in sym_table.symbols])
+        symbol_list = []
+        for sn in vmlinux.symbols:
+            try:
+                # When requesting the symbol from the module, a full resolve is performed
+                symbol_list.append((vmlinux.get_symbol(sn).address, sn))
+            except exceptions.SymbolError:
+                pass
+        sorted_symbols = sorted(symbol_list)
 
         sym_address = 0
 
@@ -62,7 +64,8 @@ class Check_syscall(plugins.PluginInterface):
         accurate."""
 
         return len(
-            [sym for sym in self.context.symbol_space[vmlinux.name].symbols if sym.startswith("__syscall_meta__")])
+            [sym for sym in self.context.symbol_space[vmlinux.symbol_table_name].symbols if
+             sym.startswith("__syscall_meta__")])
 
     def _get_table_info_other(self, table_addr, ptr_sz, vmlinux):
         table_size_meta = self._get_table_size_meta(vmlinux)
@@ -93,12 +96,12 @@ class Check_syscall(plugins.PluginInterface):
         md = capstone.Cs(capstone.CS_ARCH_X86, mode)
 
         try:
-            func_addr = self.context.symbol_space.get_symbol(vmlinux.name + constants.BANG + syscall_entry_func).address
+            func_addr = vmlinux.get_symbol(syscall_entry_func).address
         except exceptions.SymbolError as e:
             # if we can't find the disassemble function then bail and rely on a different method
             return 0
 
-        data = self.context.layers.read(self.config['primary'], func_addr, 6)
+        data = self.context.layers.read(self.config['vmlinux.layer_name'], func_addr, 6)
 
         for (address, size, mnemonic, op_str) in md.disasm_lite(data, func_addr):
             if mnemonic == 'CMP':
@@ -108,7 +111,7 @@ class Check_syscall(plugins.PluginInterface):
         return table_size
 
     def _get_table_info(self, vmlinux, table_name, ptr_sz):
-        table_sym = self.context.symbol_space.get_symbol(vmlinux.name + constants.BANG + table_name)
+        table_sym = vmlinux.get_symbol(table_name)
 
         table_size = self._get_table_info_disassembly(ptr_sz, vmlinux)
 
@@ -123,7 +126,7 @@ class Check_syscall(plugins.PluginInterface):
 
     # TODO - add finding and parsing unistd.h once cached file enumeration is added
     def _generator(self):
-        vmlinux = contexts.Module(self.context, self.config['vmlinux'], self.config['primary'], 0)
+        vmlinux = self.context.modules[self.config['vmlinux']]
 
         ptr_sz = vmlinux.get_type("pointer").size
         if ptr_sz == 4:
@@ -143,7 +146,7 @@ class Check_syscall(plugins.PluginInterface):
         # enabled in order to support 32 bit programs and libraries
         # if the symbol isn't there then the support isn't in the kernel and so we skip it
         try:
-            ia32_symbol = self.context.symbol_space.get_symbol(vmlinux.name + constants.BANG + "ia32_sys_call_table")
+            ia32_symbol = vmlinux.get_symbol("ia32_sys_call_table")
         except exceptions.SymbolError:
             ia32_symbol = None
 
@@ -161,7 +164,7 @@ class Check_syscall(plugins.PluginInterface):
                 if not call_addr:
                     continue
 
-                symbols = list(self.context.symbol_space.get_symbols_by_location(call_addr))
+                symbols = list(vmlinux.get_symbols_by_absolute_location(call_addr))
 
                 if len(symbols) > 0:
                     sym_name = str(symbols[0].split(constants.BANG)[1]) if constants.BANG in symbols[0] else \

--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -17,16 +17,13 @@ from volatility3.plugins.linux import pslist
 class Elfs(plugins.PluginInterface):
     """Lists all memory mapped ELF files for all processes."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (1, 0, 0)),
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -59,6 +56,5 @@ class Elfs(plugins.PluginInterface):
                                    ("End", format_hints.Hex), ("File Path", str)],
                                   self._generator(
                                       pslist.PsList.list_tasks(self.context,
-                                                               self.config['primary'],
                                                                self.config['vmlinux'],
                                                                filter_func = filter_func)))

--- a/volatility3/framework/plugins/linux/keyboard_notifiers.py
+++ b/volatility3/framework/plugins/linux/keyboard_notifiers.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from volatility3.framework import interfaces, renderers, contexts, exceptions
+from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import linux
@@ -16,26 +16,22 @@ vollog = logging.getLogger(__name__)
 class Keyboard_notifiers(interfaces.plugins.PluginInterface):
     """Parses the keyboard notifier call chain"""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0)),
-            requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (1, 0, 0))
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0)),
+            requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        vmlinux = contexts.Module(self.context, self.config['vmlinux'], self.config['primary'], 0)
+        vmlinux = self.context.modules[self.config['vmlinux']]
 
-        modules = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['vmlinux'])
+        modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
 
-        handlers = linux.LinuxUtilities.generate_kernel_handler_info(self.context, self.config['primary'],
-                                                                     self.config['vmlinux'], modules)
+        handlers = linux.LinuxUtilities.generate_kernel_handler_info(self.context, vmlinux.name, modules)
 
         try:
             knl_addr = vmlinux.object_from_symbol("keyboard_notifier_list")
@@ -49,12 +45,12 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
                 "This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt."
             )
 
-        knl = vmlinux.object(object_type = "atomic_notifier_head", offset = knl_addr.vol.offset)
+        knl = vmlinux.object(object_type = "atomic_notifier_head", offset = knl_addr.vol.offset, absolute = True)
 
         for call_back in linux.LinuxUtilities.walk_internal_list(vmlinux, "notifier_block", "next", knl.head):
             call_addr = call_back.notifier_call
 
-            module_name, symbol_name = linux.LinuxUtilities.lookup_module_address(self.context, handlers, call_addr)
+            module_name, symbol_name = linux.LinuxUtilities.lookup_module_address(vmlinux, handlers, call_addr)
 
             yield (0, [format_hints.Hex(call_addr), module_name, symbol_name])
 

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -15,16 +15,13 @@ from volatility3.plugins.linux import pslist
 class Malfind(interfaces.plugins.PluginInterface):
     """Lists process memory ranges that potentially contain injected code."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (1, 0, 0)),
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -48,7 +45,8 @@ class Malfind(interfaces.plugins.PluginInterface):
 
     def _generator(self, tasks):
         # determine if we're on a 32 or 64 bit kernel
-        if self.context.symbol_space.get_type(self.config["vmlinux"] + constants.BANG + "pointer").size == 4:
+        if self.context.symbol_space.get_type(
+                self.config["vmlinux.symbol_table_name"] + constants.BANG + "pointer").size == 4:
             is_32bit_arch = True
         else:
             is_32bit_arch = False
@@ -75,6 +73,5 @@ class Malfind(interfaces.plugins.PluginInterface):
                                    ("Disasm", interfaces.renderers.Disassembly)],
                                   self._generator(
                                       pslist.PsList.list_tasks(self.context,
-                                                               self.config['primary'],
                                                                self.config['vmlinux'],
                                                                filter_func = filter_func)))

--- a/volatility3/framework/plugins/linux/proc.py
+++ b/volatility3/framework/plugins/linux/proc.py
@@ -15,17 +15,14 @@ from volatility3.plugins.linux import pslist
 class Maps(plugins.PluginInterface):
     """Lists all memory maps for all processes."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (1, 0, 0)),
+            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -68,6 +65,5 @@ class Maps(plugins.PluginInterface):
                                    ("File Path", str)],
                                   self._generator(
                                       pslist.PsList.list_tasks(self.context,
-                                                               self.config['primary'],
                                                                self.config['vmlinux'],
                                                                filter_func = filter_func)))

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -1,10 +1,9 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-
 from typing import Callable, Iterable, List, Any
 
-from volatility3.framework import renderers, interfaces, contexts
+from volatility3.framework import renderers, interfaces
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 
@@ -12,17 +11,14 @@ from volatility3.framework.objects import utility
 class PsList(interfaces.plugins.PluginInterface):
     """Lists the processes present in a particular linux memory image."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
-    _version = (1, 0, 0)
+    _version = (2, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "vmlinux", description = "Linux kernel symbols"),
+            requirements.ModuleRequirement(name = 'vmlinux'),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -53,7 +49,6 @@ class PsList(interfaces.plugins.PluginInterface):
 
     def _generator(self):
         for task in self.list_tasks(self.context,
-                                    self.config['primary'],
                                     self.config['vmlinux'],
                                     filter_func = self.create_pid_filter(self.config.get('pid', None))):
             pid = task.pid
@@ -67,20 +62,18 @@ class PsList(interfaces.plugins.PluginInterface):
     def list_tasks(
             cls,
             context: interfaces.context.ContextInterface,
-            layer_name: str,
-            vmlinux_symbols: str,
+            vmlinux_module_name: str,
             filter_func: Callable[[int], bool] = lambda _: False) -> Iterable[interfaces.objects.ObjectInterface]:
         """Lists all the tasks in the primary layer.
 
         Args:
             context: The context to retrieve required elements (layers, symbol tables) from
-            layer_name: The name of the layer on which to operate
-            vmlinux_symbols: The name of the table containing the kernel symbols
+            vmlinux_module_name: The name of the kernel module on which to operate
 
         Yields:
             Process objects
         """
-        vmlinux = contexts.Module(context, vmlinux_symbols, layer_name, 0)
+        vmlinux = context.modules[vmlinux_module_name]
 
         init_task = vmlinux.object_from_symbol(symbol_name = "init_task")
 

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -10,8 +10,6 @@ class PsTree(pslist.PsList):
     """Plugin for listing processes in a tree based on their parent process
     ID."""
 
-    _required_framework_version = (1, 0, 0)
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._processes = {}
@@ -36,7 +34,8 @@ class PsTree(pslist.PsList):
 
     def _generator(self):
         """Generates the."""
-        for proc in self.list_tasks(self.context, self.config['primary'], self.config['vmlinux']):
+        for proc in self.list_tasks(self.context, self.config['vmlinux.layer_name'],
+                                    self.config['vmlinux.symbol_table_name']):
             self._processes[proc.pid] = proc
 
         # Build the child/level maps

--- a/volatility3/framework/plugins/mac/check_syscall.py
+++ b/volatility3/framework/plugins/mac/check_syscall.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 from volatility3.framework import exceptions, interfaces
-from volatility3.framework import renderers, contexts
+from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.renderers import format_hints
@@ -18,25 +18,23 @@ vollog = logging.getLogger(__name__)
 class Check_syscall(plugins.PluginInterface):
     """Check system call table for hooks."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        kernel = contexts.Module(self._context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
         nsysent = kernel.object_from_symbol(symbol_name = "nsysent")
         table = kernel.object_from_symbol(symbol_name = "sysent")
@@ -55,7 +53,8 @@ class Check_syscall(plugins.PluginInterface):
             if not call_addr or call_addr == 0:
                 continue
 
-            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, call_addr)
+            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers,
+                                                                              call_addr, self.config['darwin'])
 
             yield (0, (format_hints.Hex(table.vol.offset), "SysCall", i, format_hints.Hex(call_addr), module_name,
                        symbol_name))

--- a/volatility3/framework/plugins/mac/check_sysctl.py
+++ b/volatility3/framework/plugins/mac/check_sysctl.py
@@ -6,7 +6,7 @@ from typing import List
 
 import volatility3
 from volatility3.framework import exceptions, interfaces
-from volatility3.framework import renderers, contexts
+from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
@@ -20,17 +20,14 @@ vollog = logging.getLogger(__name__)
 class Check_sysctl(plugins.PluginInterface):
     """Check sysctl handlers for hooks."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS'),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _parse_global_variable_sysctls(self, kernel, name):
@@ -115,11 +112,11 @@ class Check_sysctl(plugins.PluginInterface):
                 break
 
     def _generator(self):
-        kernel = contexts.Module(self._context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
         sysctl_list = kernel.object_from_symbol(symbol_name = "sysctl__children")
 
@@ -129,7 +126,8 @@ class Check_sysctl(plugins.PluginInterface):
             except exceptions.InvalidAddressException:
                 continue
 
-            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, check_addr)
+            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, check_addr,
+                                                                              self.config['darwin'])
 
             yield (0, (name, sysctl.oid_number, sysctl.get_perms(), format_hints.Hex(check_addr), val, module_name,
                        symbol_name))

--- a/volatility3/framework/plugins/mac/check_trap_table.py
+++ b/volatility3/framework/plugins/mac/check_trap_table.py
@@ -6,7 +6,7 @@ import logging
 from typing import List
 
 from volatility3.framework import exceptions, interfaces
-from volatility3.framework import renderers, contexts
+from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.renderers import format_hints
@@ -19,25 +19,22 @@ vollog = logging.getLogger(__name__)
 class Check_trap_table(plugins.PluginInterface):
     """Check mach trap table for hooks."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0)),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS'),
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0)),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
         ]
 
     def _generator(self):
-        kernel = contexts.Module(self._context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
         table = kernel.object_from_symbol(symbol_name = "mach_trap_table")
 
@@ -50,7 +47,8 @@ class Check_trap_table(plugins.PluginInterface):
             if not call_addr or call_addr == 0:
                 continue
 
-            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, call_addr)
+            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, call_addr,
+                                                                              self.config['darwin'])
 
             yield (0, (format_hints.Hex(table.vol.offset), "TrapTable", i, format_hints.Hex(call_addr), module_name,
                        symbol_name))

--- a/volatility3/framework/plugins/mac/ifconfig.py
+++ b/volatility3/framework/plugins/mac/ifconfig.py
@@ -1,7 +1,7 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-from volatility3.framework import exceptions, renderers, contexts
+from volatility3.framework import exceptions, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
@@ -11,20 +11,17 @@ from volatility3.framework.symbols import mac
 class Ifconfig(plugins.PluginInterface):
     """Lists loaded kernel modules"""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS'),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0))
         ]
 
     def _generator(self):
-        kernel = contexts.Module(self._context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
         try:
             list_head = kernel.object_from_symbol(symbol_name = "ifnet_head")

--- a/volatility3/framework/plugins/mac/kauth_listeners.py
+++ b/volatility3/framework/plugins/mac/kauth_listeners.py
@@ -2,7 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
-from volatility3.framework import renderers, interfaces, contexts
+from volatility3.framework import renderers, interfaces
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
@@ -13,34 +13,31 @@ from volatility3.plugins.mac import lsmod, kauth_scopes
 class Kauth_listeners(interfaces.plugins.PluginInterface):
     """ Lists kauth listeners and their status """
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel"),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 1, 0)),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0)),
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0)),
             requirements.PluginRequirement(name = 'kauth_scopes',
                                            plugin = kauth_scopes.Kauth_scopes,
-                                           version = (1, 0, 0))
+                                           version = (2, 0, 0))
         ]
 
     def _generator(self):
         """
         Enumerates the listeners for each kauth scope
         """
-        kernel = contexts.Module(self.context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
-        for scope in kauth_scopes.Kauth_scopes.list_kauth_scopes(self.context, self.config['primary'],
-                                                                 self.config['darwin']):
+        for scope in kauth_scopes.Kauth_scopes.list_kauth_scopes(self.context, self.config['darwin']):
 
             scope_name = utility.pointer_to_string(scope.ks_identifier, 128)
 
@@ -49,7 +46,8 @@ class Kauth_listeners(interfaces.plugins.PluginInterface):
                 if callback == 0:
                     continue
 
-                module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, callback)
+                module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, callback,
+                                                                                  self.config['darwin'])
 
                 yield (0, (scope_name, format_hints.Hex(listener.kll_idata), format_hints.Hex(callback), module_name,
                            symbol_name))

--- a/volatility3/framework/plugins/mac/kauth_scopes.py
+++ b/volatility3/framework/plugins/mac/kauth_scopes.py
@@ -1,39 +1,38 @@
 # This file is opyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-
+import logging
 from typing import Iterable, Callable, Tuple
 
-from volatility3.framework import renderers, interfaces, contexts
+from volatility3.framework import renderers, interfaces
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import mac
 from volatility3.plugins.mac import lsmod
 
+vollog = logging.getLogger(__name__)
+
 
 class Kauth_scopes(interfaces.plugins.PluginInterface):
     """ Lists kauth scopes and their status """
 
-    _version = (1, 0, 0)
-    _required_framework_version = (1, 0, 0)
+    _version = (2, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel"),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 1, 0)),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     @classmethod
     def list_kauth_scopes(cls,
                           context: interfaces.context.ContextInterface,
-                          layer_name: str,
-                          darwin_symbols: str,
+                          kernel_module_name: str,
                           filter_func: Callable[[int], bool] = lambda _: False) -> \
             Iterable[Tuple[interfaces.objects.ObjectInterface,
                            interfaces.objects.ObjectInterface,
@@ -42,28 +41,29 @@ class Kauth_scopes(interfaces.plugins.PluginInterface):
         Enumerates the registered kauth scopes and yields each object
         Uses smear-safe enumeration API
         """
-
-        kernel = contexts.Module(context, darwin_symbols, layer_name, 0)
+        kernel = context.modules[kernel_module_name]
 
         scopes = kernel.object_from_symbol("kauth_scopes")
 
         for scope in mac.MacUtilities.walk_tailq(scopes, "ks_link"):
-            yield scope
+            if not filter_func(scope):
+                yield scope
 
     def _generator(self):
-        kernel = contexts.Module(self.context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
-        for scope in self.list_kauth_scopes(self.context, self.config['primary'], self.config['darwin']):
+        for scope in self.list_kauth_scopes(self.context, self.config['darwin']):
 
             callback = scope.ks_callback
             if callback == 0:
                 continue
 
-            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, callback)
+            module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, callback,
+                                                                              self.config['darwin'])
 
             identifier = utility.pointer_to_string(scope.ks_identifier, 128)
 

--- a/volatility3/framework/plugins/mac/kevents.py
+++ b/volatility3/framework/plugins/mac/kevents.py
@@ -4,7 +4,7 @@
 
 from typing import Iterable, Callable, Tuple
 
-from volatility3.framework import renderers, interfaces, exceptions, contexts
+from volatility3.framework import renderers, interfaces, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols import mac
@@ -14,7 +14,8 @@ from volatility3.plugins.mac import pslist
 class Kevents(interfaces.plugins.PluginInterface):
     """ Lists event handlers registered by processes """
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
+    _version = (1, 0, 0)
 
     event_types = {
         1: "EVFILT_READ",
@@ -47,11 +48,9 @@ class Kevents(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 2, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
@@ -120,8 +119,7 @@ class Kevents(interfaces.plugins.PluginInterface):
     @classmethod
     def list_kernel_events(cls,
                            context: interfaces.context.ContextInterface,
-                           layer_name: str,
-                           darwin_symbols: str,
+                           kernel_module_name: str,
                            filter_func: Callable[[int], bool] = lambda _: False) -> \
             Iterable[Tuple[interfaces.objects.ObjectInterface,
                            interfaces.objects.ObjectInterface,
@@ -135,11 +133,11 @@ class Kevents(interfaces.plugins.PluginInterface):
                 2) The process ID of the process that registered the filter
                 3) The object of the associated kernel event filter
         """
-        kernel = contexts.Module(context, darwin_symbols, layer_name, 0)
+        kernel = context.modules[kernel_module_name]
 
         list_tasks = pslist.PsList.get_list_tasks(pslist.PsList.pslist_methods[0])
 
-        for task in list_tasks(context, layer_name, darwin_symbols, filter_func):
+        for task in list_tasks(context, kernel_module_name, filter_func):
             task_name = utility.array_to_string(task.p_comm)
             pid = task.p_pid
 
@@ -150,7 +148,6 @@ class Kevents(interfaces.plugins.PluginInterface):
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
 
         for task_name, pid, kn in self.list_kernel_events(self.context,
-                                                          self.config['primary'],
                                                           self.config['darwin'],
                                                           filter_func = filter_func):
 

--- a/volatility3/framework/plugins/mac/lsmod.py
+++ b/volatility3/framework/plugins/mac/lsmod.py
@@ -5,7 +5,7 @@
 found in Mac's lsmod command."""
 from typing import Set
 
-from volatility3.framework import renderers, interfaces, contexts, exceptions
+from volatility3.framework import renderers, interfaces, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
@@ -15,21 +15,19 @@ from volatility3.framework.renderers import format_hints
 class Lsmod(plugins.PluginInterface):
     """Lists loaded kernel modules."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
-    _version = (1, 0, 0)
+    _version = (2, 0, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel")
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
         ]
 
     @classmethod
-    def list_modules(cls, context: interfaces.context.ContextInterface, layer_name: str, darwin_symbols: str):
+    def list_modules(cls, context: interfaces.context.ContextInterface, darwin_module_name: str):
         """Lists all the modules in the primary layer.
 
         Args:
@@ -40,8 +38,8 @@ class Lsmod(plugins.PluginInterface):
         Returns:
             A list of modules from the `layer_name` layer
         """
-        kernel = contexts.Module(context, darwin_symbols, layer_name, 0)
-        kernel_layer = context.layers[layer_name]
+        kernel = context.modules[darwin_module_name]
+        kernel_layer = context.layers[kernel.layer_name]
 
         kmod_ptr = kernel.object_from_symbol(symbol_name = "kmod")
 
@@ -78,7 +76,7 @@ class Lsmod(plugins.PluginInterface):
                 return
 
     def _generator(self):
-        for module in self.list_modules(self.context, self.config['primary'], self.config['darwin']):
+        for module in self.list_modules(self.context, self.config['darwin']):
 
             mod_name = utility.array_to_string(module.name)
             mod_size = module.size

--- a/volatility3/framework/plugins/mac/netstat.py
+++ b/volatility3/framework/plugins/mac/netstat.py
@@ -19,16 +19,14 @@ vollog = logging.getLogger(__name__)
 class Netstat(plugins.PluginInterface):
     """Lists all network connections for all processes."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Kernel Address Space',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac Kernel"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
@@ -39,8 +37,7 @@ class Netstat(plugins.PluginInterface):
     @classmethod
     def list_sockets(cls,
                      context: interfaces.context.ContextInterface,
-                     layer_name: str,
-                     darwin_symbols: str,
+                     kernel_module_name: str,
                      filter_func: Callable[[int], bool] = lambda _: False) -> \
             Iterable[Tuple[interfaces.objects.ObjectInterface,
                            interfaces.objects.ObjectInterface,
@@ -56,12 +53,13 @@ class Netstat(plugins.PluginInterface):
         """
         # This is hardcoded, since a change in the default method would change the expected results
         list_tasks = pslist.PsList.get_list_tasks(pslist.PsList.pslist_methods[0])
-        for task in list_tasks(context, layer_name, darwin_symbols, filter_func):
+        for task in list_tasks(context, kernel_module_name, filter_func):
 
             task_name = utility.array_to_string(task.p_comm)
             pid = task.p_pid
 
-            for filp, _, _ in mac.MacUtilities.files_descriptors_for_process(context, darwin_symbols, task):
+            for filp, _, _ in mac.MacUtilities.files_descriptors_for_process(context, context.modules[
+                kernel_module_name].symbol_table_name, task):
                 try:
                     ftype = filp.f_fglob.get_fg_type()
                 except exceptions.InvalidAddressException:
@@ -81,7 +79,6 @@ class Netstat(plugins.PluginInterface):
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
 
         for task_name, pid, socket in self.list_sockets(self.context,
-                                                        self.config['primary'],
                                                         self.config['darwin'],
                                                         filter_func = filter_func):
 

--- a/volatility3/framework/plugins/mac/proc_maps.py
+++ b/volatility3/framework/plugins/mac/proc_maps.py
@@ -12,16 +12,14 @@ from volatility3.plugins.mac import pslist
 class Maps(interfaces.plugins.PluginInterface):
     """Lists process memory ranges that potentially contain injected code."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -34,7 +32,7 @@ class Maps(interfaces.plugins.PluginInterface):
             process_pid = task.p_pid
 
             for vma in task.get_map_iter():
-                path = vma.get_path(self.context, self.config['darwin'])
+                path = vma.get_path(self.context, self.context.modules[self.config['darwin']].symbol_table_name)
                 if path == "":
                     path = vma.get_special_path()
 
@@ -49,6 +47,5 @@ class Maps(interfaces.plugins.PluginInterface):
                                    ("End", format_hints.Hex), ("Protection", str), ("Map Name", str)],
                                   self._generator(
                                       list_tasks(self.context,
-                                                 self.config['primary'],
                                                  self.config['darwin'],
                                                  filter_func = filter_func)))

--- a/volatility3/framework/plugins/mac/psaux.py
+++ b/volatility3/framework/plugins/mac/psaux.py
@@ -14,16 +14,14 @@ from volatility3.plugins.mac import pslist
 class Psaux(plugins.PluginInterface):
     """Recovers program command line arguments."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -98,6 +96,5 @@ class Psaux(plugins.PluginInterface):
         return renderers.TreeGrid([("PID", int), ("Process", str), ("Argc", int), ("Arguments", str)],
                                   self._generator(
                                       list_tasks(self.context,
-                                                 self.config['primary'],
                                                  self.config['darwin'],
                                                  filter_func = filter_func)))

--- a/volatility3/framework/plugins/mac/pstree.py
+++ b/volatility3/framework/plugins/mac/pstree.py
@@ -13,7 +13,7 @@ class PsTree(plugins.PluginInterface):
     """Plugin for listing processes in a tree based on their parent process
     ID."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -24,11 +24,9 @@ class PsTree(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
-            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0))
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0))
         ]
 
     def _find_level(self, pid):
@@ -50,7 +48,7 @@ class PsTree(plugins.PluginInterface):
         """Generates the tree list of processes"""
         list_tasks = pslist.PsList.get_list_tasks(self.config.get('pslist_method', pslist.PsList.pslist_methods[0]))
 
-        for proc in list_tasks(self.context, self.config['primary'], self.config['darwin']):
+        for proc in list_tasks(self.context, self.config['darwin']):
             self._processes[proc.p_pid] = proc
 
         # Build the child/level maps

--- a/volatility3/framework/plugins/mac/socket_filters.py
+++ b/volatility3/framework/plugins/mac/socket_filters.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 from volatility3.framework import exceptions, interfaces
-from volatility3.framework import renderers, contexts
+from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
@@ -19,25 +19,23 @@ vollog = logging.getLogger(__name__)
 class Socket_filters(plugins.PluginInterface):
     """Enumerates kernel socket filters."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        kernel = contexts.Module(self._context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
         members_to_check = [
             "sf_unregistered", "sf_attach", "sf_detach", "sf_notify", "sf_getpeername", "sf_getsockname", "sf_data_in",

--- a/volatility3/framework/plugins/mac/timers.py
+++ b/volatility3/framework/plugins/mac/timers.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 from volatility3.framework import exceptions, interfaces
-from volatility3.framework import renderers, contexts
+from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.renderers import format_hints
@@ -18,36 +18,36 @@ vollog = logging.getLogger(__name__)
 class Timers(plugins.PluginInterface):
     """Check for malicious kernel timers."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
-            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 3, 0)),
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        kernel = contexts.Module(self.context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['primary'], self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
         real_ncpus = kernel.object_from_symbol(symbol_name = "real_ncpus")
 
         cpu_data_ptrs_ptr = kernel.get_symbol("cpu_data_ptr").address
 
+        # Returns the a pointer to the absolute address
         cpu_data_ptrs_addr = kernel.object(object_type = "pointer",
                                            offset = cpu_data_ptrs_ptr,
                                            subtype = kernel.get_type('long unsigned int'))
 
         cpu_data_ptrs = kernel.object(object_type = "array",
                                       offset = cpu_data_ptrs_addr,
+                                      absolute = True,
                                       subtype = kernel.get_type('cpu_data'),
                                       count = real_ncpus)
 
@@ -68,9 +68,10 @@ class Timers(plugins.PluginInterface):
                 else:
                     entry_time = -1
 
-                module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, handler)
+                module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, handler,
+                                                                                  self.config['darwin'])
 
-                yield (0, (format_hints.Hex(handler), format_hints.Hex(timer.param0), format_hints.Hex(timer.param1), \
+                yield (0, (format_hints.Hex(handler), format_hints.Hex(timer.param0), format_hints.Hex(timer.param1),
                            timer.deadline, entry_time, module_name, symbol_name))
 
     def run(self):

--- a/volatility3/framework/plugins/mac/trustedbsd.py
+++ b/volatility3/framework/plugins/mac/trustedbsd.py
@@ -6,7 +6,7 @@ import logging
 from typing import List, Iterator, Any
 
 from volatility3.framework import exceptions, interfaces
-from volatility3.framework import renderers, contexts
+from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
@@ -20,29 +20,28 @@ vollog = logging.getLogger(__name__)
 class Trustedbsd(plugins.PluginInterface):
     """Checks for malicious trustedbsd modules"""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel symbols"),
-            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
-            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (1, 0, 0))
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 3, 0)),
+            requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self, mods: Iterator[Any]):
-        kernel = contexts.Module(self._context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
-        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, self.config['primary'], kernel, mods)
+        handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
         policy_list = kernel.object_from_symbol(symbol_name = "mac_policy_list").cast("mac_policy_list")
 
         entries = kernel.object(object_type = "array",
                                 offset = policy_list.entries.dereference().vol.offset,
                                 subtype = kernel.get_type('mac_policy_list_element'),
+                                absolute = True,
                                 count = policy_list.staticmax + 1)
 
         for i, ent in enumerate(entries):
@@ -65,7 +64,8 @@ class Trustedbsd(plugins.PluginInterface):
                 if call_addr is None or call_addr == 0:
                     continue
 
-                module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, call_addr)
+                module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, call_addr,
+                                                                                  self.config['darwin'])
 
                 yield (0, (check, ent_name, format_hints.Hex(call_addr), module_name, symbol_name))
 
@@ -73,5 +73,4 @@ class Trustedbsd(plugins.PluginInterface):
         return renderers.TreeGrid([("Member", str), ("Policy Name", str), ("Handler Address", format_hints.Hex),
                                    ("Handler Module", str), ("Handler Symbol", str)],
                                   self._generator(
-                                      lsmod.Lsmod.list_modules(self.context, self.config['primary'],
-                                                               self.config['darwin'])))
+                                      lsmod.Lsmod.list_modules(self.context, self.config['darwin'])))

--- a/volatility3/framework/plugins/mac/vfsevents.py
+++ b/volatility3/framework/plugins/mac/vfsevents.py
@@ -2,7 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
-from volatility3.framework import renderers, interfaces, exceptions, contexts
+from volatility3.framework import renderers, interfaces, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 
@@ -10,7 +10,7 @@ from volatility3.framework.objects import utility
 class VFSevents(interfaces.plugins.PluginInterface):
     """ Lists processes that are filtering file system events """
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     event_types = [
         "CREATE_FILE", "DELETE", "STAT_CHANGED", "RENAME", "CONTENT_MODIFIED", "EXCHANGE", "FINDER_INFO_CHANGED",
@@ -20,10 +20,8 @@ class VFSevents(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "darwin", description = "Mac kernel"),
+            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+                                           architectures = ["Intel32", "Intel64"]),
         ]
 
     def _generator(self):
@@ -32,7 +30,7 @@ class VFSevents(interfaces.plugins.PluginInterface):
         Also lists which event(s) a process is registered for
         """
 
-        kernel = contexts.Module(self.context, self.config['darwin'], self.config['primary'], 0)
+        kernel = self.context.modules[self.config['darwin']]
 
         watcher_table = kernel.object_from_symbol("watcher_table")
 
@@ -48,6 +46,7 @@ class VFSevents(interfaces.plugins.PluginInterface):
             try:
                 event_array = kernel.object(object_type = "array",
                                             offset = watcher.event_list,
+                                            absolute = True,
                                             count = 13,
                                             subtype = kernel.get_type("unsigned char"))
 

--- a/volatility3/framework/plugins/windows/strings.py
+++ b/volatility3/framework/plugins/windows/strings.py
@@ -40,9 +40,8 @@ class Strings(interfaces.plugins.PluginInterface):
 
     def run(self):
         return renderers.TreeGrid([("String", str), ("Physical Address", format_hints.Hex), ("Result", str)],
-                                  self._generator)
+                                  self._generator())
 
-    @property
     def _generator(self) -> Generator[Tuple, None, None]:
         """Generates results from a strings file."""
         string_list: List[Tuple[int,bytes]] = []

--- a/volatility3/framework/symbols/intermed.py
+++ b/volatility3/framework/symbols/intermed.py
@@ -135,6 +135,11 @@ class IntermediateSymbolTable(interfaces.symbols.SymbolTableInterface):
 
         # Since we've been created with parameters, ensure our config is populated likewise
         self.config['isf_url'] = isf_url
+
+        if symbol_shift:
+            vollog.warning(
+                "Symbol_shift support has been deprecated and will be removed in the next major release of Volatility 3"
+            )
         self.config['symbol_shift'] = symbol_shift
         self.config['symbol_mask'] = symbol_mask
 

--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -25,6 +25,7 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
     """Class to handle and manage all getting symbols based on MZ header"""
 
     _version = (1, 0, 0)
+    _required_framework_version = (1, 0, 0)
 
     @classmethod
     def symbol_table_from_offset(


### PR DESCRIPTION
This one's pretty big and will need some carefully looking over because it touches so much and what it looks to deprecate is fairly deeply woven in.  Essentially the `symbol_shift` feature (and to some extent the `symbol_mask` feature) change the semantics of a symbol table, meaning each symbol table needs to be loaded per module, and the original data of the symbols is difficult to get to.

This patchset introduces a new means of handling things, a ModuleRequirement which will return a module (that is carried around by and looked up from the context).  These modules are an offset to a location in memory and a symbol table.  This allows for the same library to make use of the same symbol table, even if it is loaded twice at different offsets.  It also doesn't grant the kernel some form of increased privilege, or confuse people that load symbol tables because the kernel ones have been offset by the automagic, but normal symbols aren't.

This predominantly impacts the LinuxUtilties which now needs to be given a module name in some places, rather than a flat symbol table.  There's one chunk of code in particular that's only passed a symbol table and we try to figure out the module from that.  All of this is new and will need reviewing with a careful eye.  It's been tested with a single ASLR linux image and some non-ASLR linux images, and a single Mac image.  These all seemed to work, but the more eyes the better.

Windows plugins haven't been converted except for pslist because a) there isn't really a need since they never used the symbol shift mechanism and b) pslist proves that it can be done and work for windows plugins.  We can convert the rest, but this felt like enough of a change in itself.

Since it's such a big change, I'd like all hands on deck please.  I've managed to avoid significantly changing any of the main API, but the LinuxUtilities class underwent a number of changes and so has been separately versioned.  This will likely mean that all linux plugins will need their versions bumping at a minimum (and a check to make sure they work with the new API), but this also means that this commit itself isn't the right one to roll API breaks into.  There will be another one later on that does carry out the break and removes the symbol_shift functionality, but that's further down the line so we deprecate it and then give people time to remove their reliance on it, before it goes.  We should also consider whether we roll a release before this, after this or after the main break.  We should be coming up on another official release, so we just want to figure out how much potential churn to put developers through...

Any questions, just shout...  5:)