### PR TITLE
Feature/pdbconv vs19

### DIFF
--- a/volatility3/framework/symbols/windows/pdb.json
+++ b/volatility3/framework/symbols/windows/pdb.json
@@ -1295,6 +1295,54 @@
       "kind": "struct",
       "size": 18
     },
+    "LF_STRUCTURE_VS19": {
+      "fields": {
+        "properties": {
+          "offset": 0,
+          "type": {
+            "kind": "struct",
+            "name": "Type_Properties"
+          }
+        },
+        "fields": {
+          "offset": 4,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "derived_from": {
+          "offset": 8,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "vtable_shape": {
+          "offset": 12,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "size": {
+          "offset": 18,
+          "type": {
+            "kind": "base",
+            "name": "unsigned short"
+          }
+        },
+        "name": {
+          "offset": 20,
+          "type": {
+            "kind": "base",
+            "name": "string"
+          }
+        }
+      },
+      "kind": "struct",
+      "size": 20
+    },
     "LF_UDT_SRC_LINE": {
       "fields": {
         "udt": {
@@ -1626,6 +1674,8 @@
         "LF_STRING_ID": 5637,
         "LF_UDT_SRC_LINE": 5638,
         "LF_UDT_MOD_SRC_LINE": 5639,
+        "LF_CLASS_VS19": 5640,
+        "LF_STRUCTURE_VS19": 5641,
         "LF_CHAR": 32768,
         "LF_SHORT": 32769,
         "LF_USHORT": 32770,

--- a/volatility3/framework/symbols/windows/pdbconv.py
+++ b/volatility3/framework/symbols/windows/pdbconv.py
@@ -770,7 +770,8 @@ class PdbReader:
         consumed = leaf_type.vol.base_type.size
         remaining = length - consumed
 
-        type_handler, has_name, value_attribute = self.type_handlers.get(leaf_type.lookup(), 'LF_UNKNOWN')
+        type_handler, has_name, value_attribute = self.type_handlers.get(leaf_type.lookup(),
+                                                                         ('LF_UNKNOWN', False, None))
 
         if type_handler in ['LF_FIELDLIST']:
             sub_length = remaining

--- a/volatility3/framework/symbols/windows/pdbconv.py
+++ b/volatility3/framework/symbols/windows/pdbconv.py
@@ -695,7 +695,7 @@ class PdbReader:
             leaf_type, name, value = self.types[index]
             if leaf_type in [
                 leaf_type.LF_CLASS, leaf_type.LF_CLASS_ST, leaf_type.LF_STRUCTURE, leaf_type.LF_STRUCTURE_ST,
-                leaf_type.LF_INTERFACE
+                leaf_type.LF_INTERFACE, leaf_type.LF_CLASS_VS19, leaf_type.LF_STRUCTURE_VS19
             ]:
                 if not value.properties.forward_reference and name:
                     self.user_types[name] = {


### PR DESCRIPTION
Microsoft changed what was otherwise a stable format (and didn't bump the format number), so very recent kernels may cause pdbconv to file (for example ntkrnlmp.pdb with the GUID D06948C5F5258EFB9CF74852D40682A5 and age 1).

This adds the two new structures (class and structure) which appear to have been added for recent compilers.  The refactoring should produce identical files to previous versions (save for the timestamp).  Without a sample for the image, it's not easy to test whether the generated structures are correct, but it looks reasonable from what's generated?  This won't go in without a review...

Closes #516.