### PR TITLE
Windows: Update to kernel ModuleRequirement for ease of config

### DIFF
--- a/volatility3/framework/plugins/windows/bigpools.py
+++ b/volatility3/framework/plugins/windows/bigpools.py
@@ -20,17 +20,15 @@ vollog = logging.getLogger(__name__)
 class BigPools(interfaces.plugins.PluginInterface):
     """List big page pools."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.StringRequirement(name = 'tags',
                                            description = "Comma separated list of pool tags to filter pools returned",
                                            optional = True,
@@ -108,9 +106,11 @@ class BigPools(interfaces.plugins.PluginInterface):
         else:
             tags = None
 
+        kernel = self.context.modules[self.config['kernel']]
+
         for big_pool in self.list_big_pools(context = self.context,
-                                            layer_name = self.config["primary"],
-                                            symbol_table = self.config["nt_symbols"],
+                                            layer_name = kernel.layer_name,
+                                            symbol_table = kernel.symbol_table_name,
                                             tags = tags):
 
             num_bytes = big_pool.get_number_of_bytes()

--- a/volatility3/framework/plugins/windows/cachedump.py
+++ b/volatility3/framework/plugins/windows/cachedump.py
@@ -21,16 +21,14 @@ vollog = logging.getLogger(__name__)
 class Cachedump(interfaces.plugins.PluginInterface):
     """Dumps lsa secrets from memory"""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'hivelist', plugin = hivelist.HiveList, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsadump', plugin = lsadump.Lsadump, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'hashdump', plugin = hashdump.Hashdump, version = (1, 1, 0))
@@ -46,7 +44,7 @@ class Cachedump(interfaces.plugins.PluginInterface):
             hmac_md5 = HMAC.new(nlkm, ch)
             rc4key = hmac_md5.digest()
             rc4 = ARC4.new(rc4key)
-            data = rc4.encrypt(edata) # lgtm [py/weak-cryptographic-algorithm]
+            data = rc4.encrypt(edata)  # lgtm [py/weak-cryptographic-algorithm]
         else:
             # based on  Based on code from http://lab.mediaservice.net/code/cachedump.rb
             aes = AES.new(nlkm[16:32], AES.MODE_CBC, ch)
@@ -90,7 +88,10 @@ class Cachedump(interfaces.plugins.PluginInterface):
             vollog.warning('Unable to find bootkey')
             return
 
-        vista_or_later = versions.is_vista_or_later(context = self.context, symbol_table = self.config['nt_symbols'])
+        kernel = self.context.modules[self.config['kernel']]
+
+        vista_or_later = versions.is_vista_or_later(context = self.context,
+                                                    symbol_table = kernel.symbol_table_name)
 
         lsakey = lsadump.Lsadump.get_lsa_key(sechive, bootkey, vista_or_later)
         if not lsakey:
@@ -129,10 +130,12 @@ class Cachedump(interfaces.plugins.PluginInterface):
 
         syshive = sechive = None
 
+        kernel = self.context.modules[self.config['kernel']]
+
         for hive in hivelist.HiveList.list_hives(self.context,
                                                  self.config_path,
-                                                 self.config['primary'],
-                                                 self.config['nt_symbols'],
+                                                 kernel.layer_name,
+                                                 kernel.symbol_table_name,
                                                  hive_offsets = None if offset is None else [offset]):
 
             if hive.get_name().split('\\')[-1].upper() == 'SYSTEM':
@@ -147,5 +150,5 @@ class Cachedump(interfaces.plugins.PluginInterface):
                 vollog.warning('Unable to locate SECURITY hive')
             return
 
-        return renderers.TreeGrid([("Username", str), ("Domain", str), ("Domain name", str), ('Hashh', bytes)],
+        return renderers.TreeGrid([("Username", str), ("Domain", str), ("Domain name", str), ('Hash', bytes)],
                                   self._generator(syshive, sechive))

--- a/volatility3/framework/plugins/windows/cmdline.py
+++ b/volatility3/framework/plugins/windows/cmdline.py
@@ -15,17 +15,15 @@ vollog = logging.getLogger(__name__)
 class CmdLine(interfaces.plugins.PluginInterface):
     """Lists process command line arguments."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          element_type = int,
@@ -57,13 +55,15 @@ class CmdLine(interfaces.plugins.PluginInterface):
 
     def _generator(self, procs):
 
+        kernel = self.context.modules[self.config['kernel']]
+
         for proc in procs:
             process_name = utility.array_to_string(proc.ImageFileName)
             proc_id = "Unknown"
 
             try:
                 proc_id = proc.UniqueProcessId
-                result_text = self.get_cmdline(self.context, self.config["nt_symbols"], proc)
+                result_text = self.get_cmdline(self.context, kernel.symbol_table_name, proc)
 
             except exceptions.SwappedInvalidAddressException as exp:
                 result_text = f"Required memory at {exp.invalid_address:#x} is inaccessible (swapped)"
@@ -78,11 +78,14 @@ class CmdLine(interfaces.plugins.PluginInterface):
             yield (0, (proc.UniqueProcessId, process_name, result_text))
 
     def run(self):
+
+        kernel = self.context.modules[self.config['kernel']]
+
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
 
         return renderers.TreeGrid([("PID", int), ("Process", str), ("Args", str)],
                                   self._generator(
                                       pslist.PsList.list_processes(context = self.context,
-                                                                   layer_name = self.config['primary'],
-                                                                   symbol_table = self.config['nt_symbols'],
+                                                                   layer_name = kernel.layer_name,
+                                                                   symbol_table = kernel.symbol_table_name,
                                                                    filter_func = filter_func)))

--- a/volatility3/framework/plugins/windows/envars.py
+++ b/volatility3/framework/plugins/windows/envars.py
@@ -15,17 +15,15 @@ vollog = logging.getLogger(__name__)
 class Envars(interfaces.plugins.PluginInterface):
     "Display process environment variables"
 
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
-    _required_framework_version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -48,11 +46,12 @@ class Envars(interfaces.plugins.PluginInterface):
         """
 
         values = []
+        kernel = self.context.modules[self.config['kernel']]
 
         for hive in hivelist.HiveList.list_hives(context = self.context,
                                                  base_config_path = self.config_path,
-                                                 layer_name = self.config['primary'],
-                                                 symbol_table = self.config['nt_symbols'],
+                                                 layer_name = kernel.layer_name,
+                                                 symbol_table = kernel.symbol_table_name,
                                                  hive_offsets = None):
             sys = False
             ntuser = False
@@ -192,10 +191,11 @@ class Envars(interfaces.plugins.PluginInterface):
     def run(self):
 
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
+        kernel = self.context.modules[self.config['kernel']]
 
         return renderers.TreeGrid([("PID", int), ("Process", str), ("Block", str), ("Variable", str), ("Value", str)],
                                   self._generator(
                                       pslist.PsList.list_processes(context = self.context,
-                                                                   layer_name = self.config['primary'],
-                                                                   symbol_table = self.config['nt_symbols'],
+                                                                   layer_name = kernel.layer_name,
+                                                                   symbol_table = kernel.symbol_table_name,
                                                                    filter_func = filter_func)))

--- a/volatility3/framework/plugins/windows/filescan.py
+++ b/volatility3/framework/plugins/windows/filescan.py
@@ -13,15 +13,13 @@ from volatility3.plugins.windows import poolscanner
 class FileScan(interfaces.plugins.PluginInterface):
     """Scans for file objects present in a particular windows memory image."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'poolscanner', plugin = poolscanner.PoolScanner, version = (1, 0, 0)),
         ]
 
@@ -50,7 +48,9 @@ class FileScan(interfaces.plugins.PluginInterface):
             yield mem_object
 
     def _generator(self):
-        for fileobj in self.scan_files(self.context, self.config['primary'], self.config['nt_symbols']):
+        kernel = self.context.modules[self.config['kernel']]
+
+        for fileobj in self.scan_files(self.context, kernel.layer_name, kernel.symbol_table_name):
 
             try:
                 file_name = fileobj.FileName.String

--- a/volatility3/framework/plugins/windows/getservicesids.py
+++ b/volatility3/framework/plugins/windows/getservicesids.py
@@ -30,8 +30,8 @@ def createservicesid(svc) -> str:
 class GetServiceSIDs(interfaces.plugins.PluginInterface):
     """Lists process token sids."""
 
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
-    _required_framework_version = (1, 0, 0)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -53,20 +53,18 @@ class GetServiceSIDs(interfaces.plugins.PluginInterface):
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'hivelist', plugin = hivelist.HiveList, version = (1, 0, 0))
         ]
 
     def _generator(self):
-
+        kernel = self.context.modules[self.config['kernel']]
         # Get the system hive
         for hive in hivelist.HiveList.list_hives(context = self.context,
                                                  base_config_path = self.config_path,
-                                                 layer_name = self.config['primary'],
-                                                 symbol_table = self.config['nt_symbols'],
+                                                 layer_name = kernel.layer_name,
+                                                 symbol_table = kernel.symbol_table_name,
                                                  filter_string = 'machine\\system',
                                                  hive_offsets = None):
             # Get ControlSet\Services.

--- a/volatility3/framework/plugins/windows/getsids.py
+++ b/volatility3/framework/plugins/windows/getsids.py
@@ -28,8 +28,8 @@ def find_sid_re(sid_string, sid_re_list) -> Union[str, interfaces.renderers.Base
 class GetSIDs(interfaces.plugins.PluginInterface):
     """Print the SIDs owning each process"""
 
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
-    _required_framework_version = (1, 0, 0)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -53,10 +53,8 @@ class GetSIDs(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -75,12 +73,13 @@ class GetSIDs(interfaces.plugins.PluginInterface):
 
         key = "Microsoft\\Windows NT\\CurrentVersion\\ProfileList"
         val = "ProfileImagePath"
+        kernel = self.context.modules[self.config['kernel']]
 
         sids = {}
         for hive in hivelist.HiveList.list_hives(context = self.context,
                                                  base_config_path = self.config_path,
-                                                 layer_name = self.config['primary'],
-                                                 symbol_table = self.config['nt_symbols'],
+                                                 layer_name = kernel.layer_name,
+                                                 symbol_table = kernel.symbol_table_name,
                                                  filter_string = 'config\\software',
                                                  hive_offsets = None):
 
@@ -154,10 +153,11 @@ class GetSIDs(interfaces.plugins.PluginInterface):
     def run(self):
 
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
+        kernel = self.context.modules[self.config['kernel']]
 
         return renderers.TreeGrid([("PID", int), ("Process", str), ("SID", str), ("Name", str)],
                                   self._generator(
                                       pslist.PsList.list_processes(context = self.context,
-                                                                   layer_name = self.config['primary'],
-                                                                   symbol_table = self.config['nt_symbols'],
+                                                                   layer_name = kernel.layer_name,
+                                                                   symbol_table = kernel.symbol_table_name,
                                                                    filter_func = filter_func)))

--- a/volatility3/framework/plugins/windows/info.py
+++ b/volatility3/framework/plugins/windows/info.py
@@ -16,16 +16,14 @@ from volatility3.framework.symbols.windows import extensions
 class Info(plugins.PluginInterface):
     """Show OS & kernel details of the memory sample being analyzed."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols")
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
         ]
 
     @classmethod
@@ -150,18 +148,22 @@ class Info(plugins.PluginInterface):
 
     def _generator(self):
 
-        layer_name = self.config['primary']
-        symbol_table = self.config['nt_symbols']
+        kernel = self.context.modules[self.config['kernel']]
+
+        layer_name = kernel.layer_name
+        symbol_table = kernel.symbol_table_name
+        layer = self.context.layers[layer_name]
+        table = self.context.symbol_space[symbol_table]
 
         kdbg = self.get_kdbg_structure(self.context, self.config_path, layer_name, symbol_table)
 
-        yield (0, ("Kernel Base", hex(self.config["primary.kernel_virtual_offset"])))
-        yield (0, ("DTB", hex(self.config["primary.page_map_offset"])))
-        yield (0, ("Symbols", self.config["nt_symbols.isf_url"]))
+        yield (0, ("Kernel Base", hex(layer.config["kernel_virtual_offset"])))
+        yield (0, ("DTB", hex(layer.config["page_map_offset"])))
+        yield (0, ("Symbols", table.config["isf_url"]))
         yield (0, ("Is64Bit", str(symbols.symbol_table_is_64bit(self.context, symbol_table))))
         yield (0, ("IsPAE", str(self.context.layers[layer_name].metadata.get("pae", False))))
 
-        for i, layer in self.get_depends(self.context, "primary"):
+        for i, layer in self.get_depends(self.context, layer_name):
             yield (0, (layer.name, f"{i} {layer.__class__.__name__}"))
 
         if kdbg.Header.OwnerTag == 0x4742444B:

--- a/volatility3/framework/plugins/windows/memmap.py
+++ b/volatility3/framework/plugins/windows/memmap.py
@@ -16,16 +16,14 @@ vollog = logging.getLogger(__name__)
 class Memmap(interfaces.plugins.PluginInterface):
     """Prints the memory map"""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.BooleanRequirement(name = 'coalesce', description = 'Clump output where possible',
                                             default = False, optional = True),
@@ -108,12 +106,13 @@ class Memmap(interfaces.plugins.PluginInterface):
 
     def run(self):
         filter_func = pslist.PsList.create_pid_filter([self.config.get('pid', None)])
+        kernel = self.context.modules[self.config['kernel']]
 
         return renderers.TreeGrid([("Virtual", format_hints.Hex), ("Physical", format_hints.Hex),
                                    ("Size", format_hints.Hex), ("Offset in File", format_hints.Hex),
                                    ("File output", str)],
                                   self._generator(
                                       pslist.PsList.list_processes(context = self.context,
-                                                                   layer_name = self.config['primary'],
-                                                                   symbol_table = self.config['nt_symbols'],
+                                                                   layer_name = kernel.layer_name,
+                                                                   symbol_table = kernel.symbol_table_name,
                                                                    filter_func = filter_func)))

--- a/volatility3/framework/plugins/windows/modscan.py
+++ b/volatility3/framework/plugins/windows/modscan.py
@@ -17,16 +17,14 @@ vollog = logging.getLogger(__name__)
 class ModScan(interfaces.plugins.PluginInterface):
     """Scans for modules present in a particular windows memory image."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'poolerscanner',
                                             component = poolscanner.PoolScanner,
                                             version = (1, 0, 0)),
@@ -137,14 +135,16 @@ class ModScan(interfaces.plugins.PluginInterface):
         return None
 
     def _generator(self):
-        session_layers = list(self.get_session_layers(self.context, self.config['primary'], self.config['nt_symbols']))
+        kernel = self.context.modules[self.config['kernel']]
+
+        session_layers = list(self.get_session_layers(self.context, kernel.layer_name, kernel.symbol_table_name))
         pe_table_name = intermed.IntermediateSymbolTable.create(self.context,
                                                                 self.config_path,
                                                                 "windows",
                                                                 "pe",
                                                                 class_types = pe.class_types)
 
-        for mod in self.scan_modules(self.context, self.config['primary'], self.config['nt_symbols']):
+        for mod in self.scan_modules(self.context, kernel.layer_name, kernel.symbol_table_name):
 
             try:
                 BaseDllName = mod.BaseDllName.get_string()

--- a/volatility3/framework/plugins/windows/mutantscan.py
+++ b/volatility3/framework/plugins/windows/mutantscan.py
@@ -13,15 +13,13 @@ from volatility3.plugins.windows import poolscanner
 class MutantScan(interfaces.plugins.PluginInterface):
     """Scans for mutexes present in a particular windows memory image."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'poolscanner', plugin = poolscanner.PoolScanner, version = (1, 0, 0)),
         ]
 
@@ -50,7 +48,9 @@ class MutantScan(interfaces.plugins.PluginInterface):
             yield mem_object
 
     def _generator(self):
-        for mutant in self.scan_mutants(self.context, self.config['primary'], self.config['nt_symbols']):
+        kernel = self.context.modules[self.config['kernel']]
+
+        for mutant in self.scan_mutants(self.context, kernel.layer_name, kernel.symbol_table_name):
 
             try:
                 name = mutant.get_name()

--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -20,16 +20,14 @@ vollog = logging.getLogger(__name__)
 class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Traverses network tracking structures present in a particular windows memory image."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'netscan', component = netscan.NetScan, version = (1, 0, 0)),
             requirements.VersionRequirement(name = 'modules', component = modules.Modules, version = (1, 0, 0)),
             requirements.VersionRequirement(name = 'pdbutil', component = pdbutil.PDBUtility, version = (1, 0, 0)),
@@ -419,19 +417,23 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     def _generator(self, show_corrupt_results: Optional[bool] = None):
         """ Generates the network objects for use in rendering. """
 
-        netscan_symbol_table = netscan.NetScan.create_netscan_symbol_table(self.context, self.config["primary"],
-                                                                           self.config["nt_symbols"], self.config_path)
+        kernel = self.context.modules[self.config['kernel']]
 
-        tcpip_module = self.get_tcpip_module(self.context, self.config["primary"], self.config["nt_symbols"])
+        netscan_symbol_table = netscan.NetScan.create_netscan_symbol_table(self.context,
+                                                                           kernel.layer_name,
+                                                                           kernel.symbol_table_name,
+                                                                           self.config_path)
+
+        tcpip_module = self.get_tcpip_module(self.context, kernel.layer_name, kernel.symbol_table_name)
 
         try:
             tcpip_symbol_table = pdbutil.PDBUtility.symbol_table_from_pdb(
-                self.context, interfaces.configuration.path_join(self.config_path, 'tcpip'), self.config["primary"],
-                "tcpip.pdb", tcpip_module.DllBase, tcpip_module.SizeOfImage)
+                self.context, interfaces.configuration.path_join(self.config_path, 'tcpip'),
+                kernel.layer_name, "tcpip.pdb", tcpip_module.DllBase, tcpip_module.SizeOfImage)
         except exceptions.VolatilityException:
             vollog.warning("Unable to locate symbols for the memory image's tcpip module")
 
-        for netw_obj in self.list_sockets(self.context, self.config['primary'], self.config['nt_symbols'],
+        for netw_obj in self.list_sockets(self.context, kernel.layer_name, kernel.symbol_table_name,
                                           netscan_symbol_table, tcpip_module.DllBase, tcpip_symbol_table):
 
             # objects passed pool header constraints. check for additional constraints if strict flag is set.

--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -112,25 +112,25 @@ class PoolHeaderScanner(interfaces.layers.ScannerInterface):
 class PoolScanner(plugins.PluginInterface):
     """A generic pool scanner plugin."""
 
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
-    _required_framework_version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'handles', plugin = handles.Handles, version = (1, 0, 0)),
         ]
 
     def _generator(self):
 
-        symbol_table = self.config["nt_symbols"]
+        kernel = self.context.modules[self.config['kernel']]
+
+        symbol_table = kernel.symbol_table_name
         constraints = self.builtin_constraints(symbol_table)
 
-        for constraint, mem_object, header in self.generate_pool_scan(self.context, self.config["primary"],
+        for constraint, mem_object, header in self.generate_pool_scan(self.context, kernel.layer_name,
                                                                       symbol_table, constraints):
             # generate some type-specific info for sanity checking
             if constraint.object_type == "Process":

--- a/volatility3/framework/plugins/windows/skeleton_key_check.py
+++ b/volatility3/framework/plugins/windows/skeleton_key_check.py
@@ -6,50 +6,49 @@
 # It does this by locating the CSystems array through a variety of methods,
 # and then validating the entry for RC4 HMAC (0x17 / 23)
 #
-# For a thorough walkthrough on how the R&D was performed to develop this plugin, 
+# For a thorough walkthrough on how the R&D was performed to develop this plugin,
 # please see our blogpost here:
 #
 # <insert blog URL once published>
 
-import logging, io
-
+import io
+import logging
 from typing import Iterable, Tuple, List, Optional
-
-from volatility3.framework.symbols.windows import pdbutil
-from volatility3.framework import interfaces, symbols, exceptions
-from volatility3.framework import renderers, constants
-from volatility3.framework.layers import scanners
-from volatility3.framework.configuration import requirements
-from volatility3.framework.objects import utility
-from volatility3.framework.symbols import intermed
-from volatility3.framework.renderers import format_hints
-from volatility3.plugins.windows import pslist, vadinfo
-
-from volatility3.framework.symbols.windows.extensions import pe
 
 import pefile
 
+from volatility3.framework import interfaces, symbols, exceptions
+from volatility3.framework import renderers, constants
+from volatility3.framework.configuration import requirements
+from volatility3.framework.layers import scanners
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.symbols import intermed
+from volatility3.framework.symbols.windows import pdbutil
+from volatility3.framework.symbols.windows.extensions import pe
+from volatility3.plugins.windows import pslist, vadinfo
+
 try:
     import capstone
+
     has_capstone = True
 except ImportError:
     has_capstone = False
 
 vollog = logging.getLogger(__name__)
 
+
 class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
     """ Looks for signs of Skeleton Key malware """
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'pslist', component = pslist.PsList, version = (2, 0, 0)),
             requirements.VersionRequirement(name = 'vadinfo', component = vadinfo.VadInfo, version = (2, 0, 0)),
             requirements.VersionRequirement(name = 'pdbutil', component = pdbutil.PDBUtility, version = (1, 0, 0)),
@@ -71,26 +70,26 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
 
         try:
             dos_header = self.context.object(pe_table_name + constants.BANG + "_IMAGE_DOS_HEADER",
-                                    offset = base_address,
-                                    layer_name = layer_name)
+                                             offset = base_address,
+                                             layer_name = layer_name)
 
             for offset, data in dos_header.reconstruct():
                 pe_data.seek(offset)
                 pe_data.write(data)
-        
+
             pe_ret = pefile.PE(data = pe_data.getvalue(), fast_load = True)
-        
+
         except exceptions.InvalidAddressException:
             vollog.debug("Unable to reconstruct cryptdll.dll in memory")
             pe_ret = None
 
         return pe_ret
 
-    def _check_for_skeleton_key_vad(self, csystem: interfaces.objects.ObjectInterface, 
-                                          cryptdll_base: int, 
-                                          cryptdll_size: int) -> bool:
+    def _check_for_skeleton_key_vad(self, csystem: interfaces.objects.ObjectInterface,
+                                    cryptdll_base: int,
+                                    cryptdll_size: int) -> bool:
         """
-        Checks if Initialize and/or Decrypt is hooked by determining if 
+        Checks if Initialize and/or Decrypt is hooked by determining if
         these function pointers reference addresses inside of the cryptdll VAD
 
         Args:
@@ -101,11 +100,11 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
             bool: if a skeleton key hook is present
         """
         return not ((cryptdll_base <= csystem.Initialize <= cryptdll_base + cryptdll_size) and \
-                  (cryptdll_base <= csystem.Decrypt <= cryptdll_base + cryptdll_size))
+                    (cryptdll_base <= csystem.Decrypt <= cryptdll_base + cryptdll_size))
 
-    def _check_for_skeleton_key_symbols(self, csystem: interfaces.objects.ObjectInterface, 
-                                              rc4HmacInitialize: int, 
-                                              rc4HmacDecrypt: int) -> bool:
+    def _check_for_skeleton_key_symbols(self, csystem: interfaces.objects.ObjectInterface,
+                                        rc4HmacInitialize: int,
+                                        rc4HmacDecrypt: int) -> bool:
         """
         Uses the PDB information to specifically check if the csystem for RC4HMAC
         has an initialization pointer to rc4HmacInitialize and a decryption pointer
@@ -113,12 +112,12 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
 
         Args:
             csystem: The RC4HMAC KERB_ECRYPT instance
-            rc4HmacInitialize: The expected address of csystem Initialization function 
+            rc4HmacInitialize: The expected address of csystem Initialization function
             rc4HmacDecrypt: The expected address of the csystem Decryption function
-        
+
         Returns:
             bool: if a skeleton key hook was found
-        """ 
+        """
         return csystem.Initialize != rc4HmacInitialize or csystem.Decrypt != rc4HmacDecrypt
 
     def _construct_ecrypt_array(self, array_start: int, count: int, \
@@ -137,21 +136,21 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
 
         try:
             array = cryptdll_types.object(object_type = "array",
-                                      offset = array_start,
-                                      subtype = cryptdll_types.get_type("_KERB_ECRYPT"),
-                                      count = count,
-                                      absolute = True)
+                                          offset = array_start,
+                                          subtype = cryptdll_types.get_type("_KERB_ECRYPT"),
+                                          count = count,
+                                          absolute = True)
 
         except exceptions.InvalidAddressException:
             vollog.debug("Unable to construct cSystems array at given offset: {:x}".format(array_start))
             array = None
-            
+
         return array
 
-    def _find_array_with_pdb_symbols(self, cryptdll_symbols: str, 
-                                           cryptdll_types: interfaces.context.ModuleInterface, 
-                                           proc_layer_name: str, 
-                                           cryptdll_base: int) -> Tuple[interfaces.objects.ObjectInterface, int, int, int]:
+    def _find_array_with_pdb_symbols(self, cryptdll_symbols: str,
+                                     cryptdll_types: interfaces.context.ModuleInterface,
+                                     proc_layer_name: str,
+                                     cryptdll_base: int) -> Tuple[interfaces.objects.ObjectInterface, int, int, int]:
 
         """
         Finds the CSystems array through use of PDB symbols
@@ -177,7 +176,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         count_address = cryptdll_module.get_symbol("cCSystems").address
 
         # we do not want to fail just because the count is not in memory
-        # 16 was the size on samples I tested, so I chose it as the default         
+        # 16 was the size on samples I tested, so I chose it as the default
         try:
             count = cryptdll_types.object(object_type = "unsigned long", offset = count_address)
         except exceptions.InvalidAddressException:
@@ -186,30 +185,31 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         array_start = cryptdll_module.get_absolute_symbol_address("CSystems")
 
         array = self._construct_ecrypt_array(array_start, count, cryptdll_types)
-        
+
         if array is None:
             vollog.debug("The CSystem array is not present in memory. Stopping PDB based analysis.")
 
         return array, rc4HmacInitialize, rc4HmacDecrypt
 
-    def _get_cryptdll_types(self, context: interfaces.context.ContextInterface, 
-                                  config, 
-                                  config_path: str, 
-                                  proc_layer_name: str, 
-                                  cryptdll_base: int):
+    def _get_cryptdll_types(self, context: interfaces.context.ContextInterface,
+                            config,
+                            config_path: str,
+                            proc_layer_name: str,
+                            cryptdll_base: int):
         """
         Builds a symbol table from the cryptdll types generated after binary analysis
 
         Args:
             context: the context to operate upon
-            config: 
+            config:
             config_path:
             proc_layer_name: name of the lsass.exe process layer
             cryptdll_base: base address of cryptdll.dll inside of lsass.exe
         """
-        table_mapping = {"nt_symbols":  config["nt_symbols"]}
+        kernel = self.context.modules[self.config['kernel']]
+        table_mapping = {"nt_symbols": kernel.symbol_table_name}
 
-        cryptdll_symbol_table = intermed.IntermediateSymbolTable.create(context = context, 
+        cryptdll_symbol_table = intermed.IntermediateSymbolTable.create(context = context,
                                                                         config_path = config_path,
                                                                         sub_path = "windows",
                                                                         filename = "kerb_ecrypt",
@@ -218,7 +218,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         return context.module(cryptdll_symbol_table, proc_layer_name, offset = cryptdll_base)
 
     def _find_lsass_proc(self, proc_list: Iterable) -> \
-                               Tuple[interfaces.context.ContextInterface, str]:
+            Tuple[interfaces.context.ContextInterface, str]:
         """
         Walks the process list and returns the first valid lsass instances.
         There should be only one lsass process, but malware will often use the
@@ -242,11 +242,10 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
                 vollog.debug("Process {}: invalid address {} in layer {}".format(proc_id, excp.invalid_address,
                                                                                  excp.layer_name))
 
-            
         return None, None
 
     def _find_cryptdll(self, lsass_proc: interfaces.context.ContextInterface) -> \
-                                Tuple[int, int]:  
+            Tuple[int, int]:
         """
         Finds the base address of cryptdll.dll inside of lsass.exe
 
@@ -260,18 +259,18 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         """
         for vad in lsass_proc.get_vad_root().traverse():
             filename = vad.get_file_name()
-            
+
             if isinstance(filename, str) and filename.lower().endswith("cryptdll.dll"):
                 base = vad.get_start()
                 return base, vad.get_end() - base
 
         return None, None
 
-    def _find_csystems_with_symbols(self, proc_layer_name: str, 
-                                          cryptdll_types: interfaces.context.ModuleInterface, 
-                                          cryptdll_base: int, 
-                                          cryptdll_size: int) -> \
-                                          Tuple[interfaces.objects.ObjectInterface, int, int]:
+    def _find_csystems_with_symbols(self, proc_layer_name: str,
+                                    cryptdll_types: interfaces.context.ModuleInterface,
+                                    cryptdll_base: int,
+                                    cryptdll_size: int) -> \
+            Tuple[interfaces.objects.ObjectInterface, int, int]:
         """
         Attempts to find CSystems and the expected address of the handlers.
         Relies on downloading and parsing of the cryptdll PDB file.
@@ -281,27 +280,28 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
             cryptdll_types: The types from cryptdll binary analysis
             cryptdll_base: the base address of cryptdll.dll
             crytpdll_size: the size of the VAD for cryptdll.dll
-        
+
         Returns:
             A tuple of:
             array: An initialized Volatility array of _KERB_ECRYPT structures
-            rc4HmacInitialize: The expected address of csystem Initialization function 
+            rc4HmacInitialize: The expected address of csystem Initialization function
             rc4HmacDecrypt: The expected address of the csystem Decryption function
         """
         try:
-            cryptdll_symbols = pdbutil.PDBUtility.symbol_table_from_pdb(self.context, 
-                                                                    interfaces.configuration.path_join(self.config_path, 'cryptdll'),
-                                                                    proc_layer_name,
-                                                                    "cryptdll.pdb",
-                                                                    cryptdll_base,
-                                                                    cryptdll_size)
+            cryptdll_symbols = pdbutil.PDBUtility.symbol_table_from_pdb(self.context,
+                                                                        interfaces.configuration.path_join(
+                                                                            self.config_path, 'cryptdll'),
+                                                                        proc_layer_name,
+                                                                        "cryptdll.pdb",
+                                                                        cryptdll_base,
+                                                                        cryptdll_size)
         except exceptions.VolatilityException:
             vollog.debug("Unable to use the cryptdll PDB. Stopping PDB symbols based analysis.")
             return None, None, None
 
         array, rc4HmacInitialize, rc4HmacDecrypt = \
-            self._find_array_with_pdb_symbols(cryptdll_symbols, cryptdll_types, proc_layer_name, cryptdll_base) 
-       
+            self._find_array_with_pdb_symbols(cryptdll_symbols, cryptdll_types, proc_layer_name, cryptdll_base)
+
         if array is None:
             vollog.debug("The CSystem array is not present in memory. Stopping PDB symbols based analysis.")
 
@@ -313,7 +313,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
 
         These instructions contain the offset of a target address
         relative to the current instruction pointer.
-        
+
         Args:
             inst: A capstone instruction instance
 
@@ -322,7 +322,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         """
         try:
             opnd = inst.operands[1]
-        except capstone.CsError: 
+        except capstone.CsError:
             return None
 
         if opnd.type != capstone.x86.X86_OP_MEM:
@@ -334,9 +334,9 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         return inst.address + inst.size + opnd.mem.disp
 
     def _analyze_cdlocatecsystem(self, function_bytes: bytes,
-                                       function_start: int,
-                                       cryptdll_types: interfaces.context.ModuleInterface,
-                                       proc_layer_name: str) -> Optional[interfaces.objects.ObjectInterface]:
+                                 function_start: int,
+                                 cryptdll_types: interfaces.context.ModuleInterface,
+                                 proc_layer_name: str) -> Optional[interfaces.objects.ObjectInterface]:
         """
         Performs static analysis on CDLocateCSystem to find the instructions that
         reference CSystems as well as cCsystems
@@ -380,7 +380,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
                 target_address = self._get_rip_relative_target(inst)
 
                 if target_address:
-                   array_start = target_address
+                    array_start = target_address
 
                 # we find the count before, so we can terminate the static analysis here
                 break
@@ -392,10 +392,10 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
 
         return array
 
-    def _find_csystems_with_export(self, proc_layer_name: str, 
-                                         cryptdll_types: interfaces.context.ModuleInterface, 
-                                         cryptdll_base: int, 
-                                         _) -> Optional[interfaces.objects.ObjectInterface]:
+    def _find_csystems_with_export(self, proc_layer_name: str,
+                                   cryptdll_types: interfaces.context.ModuleInterface,
+                                   cryptdll_base: int,
+                                   _) -> Optional[interfaces.objects.ObjectInterface]:
         """
         Uses export table analysis to locate CDLocateCsystem
         This function references CSystems and cCsystems
@@ -420,8 +420,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
                                                                 "windows",
                                                                 "pe",
                                                                 class_types = pe.class_types)
-  
- 
+
         cryptdll = self._get_pefile_obj(pe_table_name, proc_layer_name, cryptdll_base)
         if not cryptdll:
             return None
@@ -440,7 +439,8 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
             try:
                 function_bytes = self.context.layers[proc_layer_name].read(function_start, 0x50)
             except exceptions.InvalidAddressException:
-                vollog.debug("The CDLocateCSystem function is not present in the lsass address space. Stopping export based analysis.")
+                vollog.debug(
+                    "The CDLocateCSystem function is not present in the lsass address space. Stopping export based analysis.")
                 break
 
             array = self._analyze_cdlocatecsystem(function_bytes, function_start, cryptdll_types, proc_layer_name)
@@ -451,15 +451,15 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
 
         return None
 
-    def _find_csystems_with_scanning(self, proc_layer_name: str, 
-                                           cryptdll_types: interfaces.context.ModuleInterface, 
-                                           cryptdll_base: int, 
-                                           cryptdll_size: int) -> List[interfaces.context.ModuleInterface]:
+    def _find_csystems_with_scanning(self, proc_layer_name: str,
+                                     cryptdll_types: interfaces.context.ModuleInterface,
+                                     cryptdll_base: int,
+                                     cryptdll_size: int) -> List[interfaces.context.ModuleInterface]:
         """
         Performs scanning to find potential RC4 HMAC csystem instances
 
         This function may return several values as it cannot validate which is the active one
-        
+
         Args:
             proc_layer_name: the lsass.exe process layer name
             cryptdll_types: the types from cryptdll binary analysis
@@ -468,22 +468,22 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         Returns:
             A list of csystem instances
         """
-     
+
         csystems = []
-       
+
         cryptdll_end = cryptdll_base + cryptdll_size
 
         proc_layer = self.context.layers[proc_layer_name]
-        
+
         ecrypt_size = cryptdll_types.get_type("_KERB_ECRYPT").size
 
         # scan for potential instances of RC4 HMAC
         # the signature is based on the type being 0x17
-        # and the block size member being 1 in all test samples 
+        # and the block size member being 1 in all test samples
         for address in proc_layer.scan(self.context,
                                        scanners.BytesScanner(b"\x17\x00\x00\x00\x01\x00\x00\x00"),
                                        sections = [(cryptdll_base, cryptdll_size)]):
- 
+
             # this occurs across page boundaries
             if not proc_layer.is_valid(address, ecrypt_size):
                 continue
@@ -491,11 +491,11 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
             kerb = cryptdll_types.object("_KERB_ECRYPT",
                                          offset = address,
                                          absolute = True)
-           
+
             # ensure the Encrypt and Finish pointers are inside the VAD
-            # these are not manipulated in the attack 
+            # these are not manipulated in the attack
             if (cryptdll_base < kerb.Encrypt < cryptdll_end) and \
-               (cryptdll_base < kerb.Finish < cryptdll_end):
+                    (cryptdll_base < kerb.Finish < cryptdll_end):
                 csystems.append(kerb)
 
         return csystems
@@ -509,35 +509,36 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         Args:
             procs: the process list filtered to lsass.exe instances
         """
-        
-        if not symbols.symbol_table_is_64bit(self.context, self.config["nt_symbols"]):
+        kernel = self.context.modules[self.config['kernel']]
+
+        if not symbols.symbol_table_is_64bit(self.context, kernel.symbol_table_name):
             vollog.info("This plugin only supports 64bit Windows memory samples")
             return
 
         lsass_proc, proc_layer_name = self._find_lsass_proc(procs)
         if not lsass_proc:
-            vollog.info("Unable to find a valid lsass.exe process in the process list. This should never happen. Analysis cannot proceed.")
+            vollog.info(
+                "Unable to find a valid lsass.exe process in the process list. This should never happen. Analysis cannot proceed.")
             return
 
         cryptdll_base, cryptdll_size = self._find_cryptdll(lsass_proc)
         if not cryptdll_base:
             vollog.info("Unable to find the location of cryptdll.dll inside of lsass.exe. Analysis cannot proceed.")
             return
-        
+
         # the custom type information from binary analysis
-        cryptdll_types = self._get_cryptdll_types(self.context, 
-                                                  self.config, 
+        cryptdll_types = self._get_cryptdll_types(self.context,
+                                                  self.config,
                                                   self.config_path,
                                                   proc_layer_name,
                                                   cryptdll_base)
 
-
         # attempt to find the array and symbols directly from the PDB
         csystems, rc4HmacInitialize, rc4HmacDecrypt = \
-                self._find_csystems_with_symbols(proc_layer_name,
-                                                 cryptdll_types,
-                                                 cryptdll_base,
-                                                 cryptdll_size) 
+            self._find_csystems_with_symbols(proc_layer_name,
+                                             cryptdll_types,
+                                             cryptdll_base,
+                                             cryptdll_size)
 
         csystems = None
 
@@ -550,7 +551,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
                                 self._find_csystems_with_scanning]
 
             for source in fallback_sources:
-                csystems = source(proc_layer_name, 
+                csystems = source(proc_layer_name,
                                   cryptdll_types,
                                   cryptdll_base,
                                   cryptdll_size)
@@ -587,13 +588,17 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
         named processes to blend in or uses lsass.exe as a process hollowing target
         """
         process_name = utility.array_to_string(proc.ImageFileName)
-    
+
         return process_name != "lsass.exe"
 
     def run(self):
-        return renderers.TreeGrid([("PID", int), ("Process", str), ("Skeleton Key Found", bool), ("rc4HmacInitialize", format_hints.Hex), ("rc4HmacDecrypt", format_hints.Hex)], 
-                                  self._generator(
-                                      pslist.PsList.list_processes(context = self.context,
-                                                                   layer_name = self.config['primary'],
-                                                                   symbol_table = self.config['nt_symbols'],
-                                                                   filter_func = self._lsass_proc_filter)))
+        kernel = self.context.modules[self.config['kernel']]
+
+        return renderers.TreeGrid(
+            [("PID", int), ("Process", str), ("Skeleton Key Found", bool), ("rc4HmacInitialize", format_hints.Hex),
+             ("rc4HmacDecrypt", format_hints.Hex)],
+            self._generator(
+                pslist.PsList.list_processes(context = self.context,
+                                             layer_name = kernel.layer_name,
+                                             symbol_table = kernel.symbol_table_name,
+                                             filter_func = self._lsass_proc_filter)))

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -21,17 +21,15 @@ vollog = logging.getLogger(__name__)
 class SvcScan(interfaces.plugins.PluginInterface):
     """Scans for windows services."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
     _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.PluginRequirement(name = 'poolscanner', plugin = poolscanner.PoolScanner, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'vadyarascan', plugin = vadyarascan.VadYaraScan, version = (1, 0, 0))
@@ -94,15 +92,18 @@ class SvcScan(interfaces.plugins.PluginInterface):
                                                        native_types = native_types)
 
     def _generator(self):
+        kernel = self.context.modules[self.config['kernel']]
 
-        service_table_name = self.create_service_table(self.context, self.config["nt_symbols"], self.config_path)
+        service_table_name = self.create_service_table(self.context, kernel.symbol_table_name,
+                                                       self.config_path)
 
         relative_tag_offset = self.context.symbol_space.get_type(service_table_name + constants.BANG +
                                                                  "_SERVICE_RECORD").relative_child_offset("Tag")
 
         filter_func = pslist.PsList.create_name_filter(["services.exe"])
 
-        is_vista_or_later = versions.is_vista_or_later(context = self.context, symbol_table = self.config["nt_symbols"])
+        is_vista_or_later = versions.is_vista_or_later(context = self.context,
+                                                       symbol_table = kernel.symbol_table_name)
 
         if is_vista_or_later:
             service_tag = b"serH"
@@ -112,8 +113,8 @@ class SvcScan(interfaces.plugins.PluginInterface):
         seen = []
 
         for task in pslist.PsList.list_processes(context = self.context,
-                                                 layer_name = self.config['primary'],
-                                                 symbol_table = self.config['nt_symbols'],
+                                                 layer_name = kernel.layer_name,
+                                                 symbol_table = kernel.symbol_table_name,
                                                  filter_func = filter_func):
 
             proc_id = "Unknown"

--- a/volatility3/framework/plugins/windows/symlinkscan.py
+++ b/volatility3/framework/plugins/windows/symlinkscan.py
@@ -15,15 +15,13 @@ from volatility3.plugins.windows import poolscanner
 class SymlinkScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Scans for links present in a particular windows memory image."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"]),
         ]
 
     @classmethod
@@ -51,7 +49,9 @@ class SymlinkScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfa
             yield mem_object
 
     def _generator(self):
-        for link in self.scan_symlinks(self.context, self.config['primary'], self.config['nt_symbols']):
+        kernel = self.context.modules[self.config['kernel']]
+
+        for link in self.scan_symlinks(self.context, kernel.layer_name, kernel.symbol_table_name):
 
             try:
                 from_name = link.get_link_name()

--- a/volatility3/framework/plugins/windows/virtmap.py
+++ b/volatility3/framework/plugins/windows/virtmap.py
@@ -16,16 +16,14 @@ vollog = logging.getLogger(__name__)
 class VirtMap(interfaces.plugins.PluginInterface):
     """Lists virtual mapped sections."""
 
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.TranslationLayerRequirement(name = 'primary',
-                                                     description = 'Memory layer for the kernel',
-                                                     architectures = ["Intel32", "Intel64"]),
-            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols")
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                           architectures = ["Intel32", "Intel64"])
         ]
 
     def _generator(self, map):
@@ -112,8 +110,10 @@ class VirtMap(interfaces.plugins.PluginInterface):
                     yield value
 
     def run(self):
-        layer = self.context.layers[self.config['primary']]
-        module = self.context.module(self.config['nt_symbols'],
+        kernel = self.context.modules[self.config['kernel']]
+
+        layer = self.context.layers[kernel.layer_name]
+        module = self.context.module(kernel.symbol_table_name,
                                      layer_name = layer.name,
                                      offset = layer.config['kernel_virtual_offset'])
 


### PR DESCRIPTION
Having a mix of kernel and primary config options will make generating config files trickier (the written config won't be easily transferable).  As such probably best to convert all windows plugins over to use the kernel `ModuleRequirement`.  As such, this converts all windows plugins over to the new configuration "standard" (not really a standard).

Unlikely to be a significant change, so committing in a few days if no complaints/comments...