### PR TITLE
Feature/linux mac windows unify config

### DIFF
--- a/volatility3/framework/plugins/linux/bash.py
+++ b/volatility3/framework/plugins/linux/bash.py
@@ -26,7 +26,8 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          element_type = int,
@@ -35,7 +36,8 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
         ]
 
     def _generator(self, tasks):
-        is_32bit = not symbols.symbol_table_is_64bit(self.context, self.config["vmlinux.symbol_table_name"])
+        vmlinux = self.context.modules[self.config["kernel"]]
+        is_32bit = not symbols.symbol_table_is_64bit(self.context, vmlinux.symbol_table_name)
         if is_32bit:
             pack_format = "I"
             bash_json_file = "bash32"
@@ -90,7 +92,7 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
                                    ("Command", str)],
                                   self._generator(
                                       pslist.PsList.list_tasks(self.context,
-                                                               self.config['vmlinux'],
+                                                               self.config['kernel'],
                                                                filter_func = filter_func)))
 
     def generate_timeline(self):
@@ -98,7 +100,7 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
         for row in self._generator(
                 pslist.PsList.list_tasks(self.context,
-                                         self.config['vmlinux'],
+                                         self.config['kernel'],
                                          filter_func = filter_func)):
             _depth, row_data = row
             description = f"{row_data[0]} ({row_data[1]}): \"{row_data[3]}\""

--- a/volatility3/framework/plugins/linux/check_afinfo.py
+++ b/volatility3/framework/plugins/linux/check_afinfo.py
@@ -23,7 +23,8 @@ class Check_afinfo(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
         ]
 
     # returns whether the symbol is found within the kernel (system.map) or not
@@ -61,7 +62,7 @@ class Check_afinfo(plugins.PluginInterface):
 
     def _generator(self):
 
-        vmlinux = self.context.modules[self.config['vmlinux']]
+        vmlinux = self.context.modules[self.config['kernel']]
 
         op_members = vmlinux.get_type('file_operations').members
         seq_members = vmlinux.get_type('seq_operations').members

--- a/volatility3/framework/plugins/linux/check_creds.py
+++ b/volatility3/framework/plugins/linux/check_creds.py
@@ -19,12 +19,13 @@ class Check_creds(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        vmlinux = self.context.modules[self.config['vmlinux']]
+        vmlinux = self.context.modules[self.config['kernel']]
 
         type_task = vmlinux.get_type("task_struct")
 

--- a/volatility3/framework/plugins/linux/check_idt.py
+++ b/volatility3/framework/plugins/linux/check_idt.py
@@ -22,13 +22,14 @@ class Check_idt(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (2, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        vmlinux = self.context.modules[self.config['vmlinux']]
+        vmlinux = self.context.modules[self.config['kernel']]
 
         modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
 

--- a/volatility3/framework/plugins/linux/check_modules.py
+++ b/volatility3/framework/plugins/linux/check_modules.py
@@ -23,7 +23,8 @@ class Check_modules(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
@@ -60,11 +61,11 @@ class Check_modules(plugins.PluginInterface):
         return ret
 
     def _generator(self):
-        kset_modules = self.get_kset_modules(self.context, self.config['vmlinux'])
+        kset_modules = self.get_kset_modules(self.context, self.config['kernel'])
 
         lsmod_modules = set(
             str(utility.array_to_string(modules.name))
-            for modules in lsmod.Lsmod.list_modules(self.context, self.config['vmlinux']))
+            for modules in lsmod.Lsmod.list_modules(self.context, self.config['kernel']))
 
         for mod_name in set(kset_modules.keys()).difference(lsmod_modules):
             yield (0, (format_hints.Hex(kset_modules[mod_name]), str(mod_name)))

--- a/volatility3/framework/plugins/linux/check_syscall.py
+++ b/volatility3/framework/plugins/linux/check_syscall.py
@@ -30,7 +30,8 @@ class Check_syscall(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
         ]
 
     def _get_table_size_next_symbol(self, table_addr, ptr_sz, vmlinux):
@@ -101,7 +102,8 @@ class Check_syscall(plugins.PluginInterface):
             # if we can't find the disassemble function then bail and rely on a different method
             return 0
 
-        data = self.context.layers.read(self.config['vmlinux.layer_name'], func_addr, 6)
+        vmlinux = self.context.modules[self.config['kernel']]
+        data = self.context.layers.read(vmlinux.layer_name, func_addr, 6)
 
         for (address, size, mnemonic, op_str) in md.disasm_lite(data, func_addr):
             if mnemonic == 'CMP':
@@ -126,7 +128,7 @@ class Check_syscall(plugins.PluginInterface):
 
     # TODO - add finding and parsing unistd.h once cached file enumeration is added
     def _generator(self):
-        vmlinux = self.context.modules[self.config['vmlinux']]
+        vmlinux = self.context.modules[self.config['kernel']]
 
         ptr_sz = vmlinux.get_type("pointer").size
         if ptr_sz == 4:

--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -22,7 +22,8 @@ class Elfs(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
@@ -56,5 +57,5 @@ class Elfs(plugins.PluginInterface):
                                    ("End", format_hints.Hex), ("File Path", str)],
                                   self._generator(
                                       pslist.PsList.list_tasks(self.context,
-                                                               self.config['vmlinux'],
+                                                               self.config['kernel'],
                                                                filter_func = filter_func)))

--- a/volatility3/framework/plugins/linux/keyboard_notifiers.py
+++ b/volatility3/framework/plugins/linux/keyboard_notifiers.py
@@ -21,13 +21,14 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0)),
             requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        vmlinux = self.context.modules[self.config['vmlinux']]
+        vmlinux = self.context.modules[self.config['kernel']]
 
         modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
 

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -25,7 +25,8 @@ class Lsmod(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
         ]
 
     @classmethod
@@ -54,7 +55,7 @@ class Lsmod(plugins.PluginInterface):
 
     def _generator(self):
         try:
-            for module in self.list_modules(self.context, self.config['vmlinux']):
+            for module in self.list_modules(self.context, self.config['kernel']):
 
                 mod_size = module.get_init_size() + module.get_core_size()
 

--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -24,7 +24,8 @@ class Lsof(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
@@ -34,7 +35,7 @@ class Lsof(plugins.PluginInterface):
         ]
 
     def _generator(self, tasks):
-        vmlinux = self.context.modules[self.config['vmlinux']]
+        vmlinux = self.context.modules[self.config['kernel']]
 
         symbol_table = None
         for task in tasks:
@@ -56,5 +57,5 @@ class Lsof(plugins.PluginInterface):
         return renderers.TreeGrid([("PID", int), ("Process", str), ("FD", int), ("Path", str)],
                                   self._generator(
                                       pslist.PsList.list_tasks(self.context,
-                                                               self.config['vmlinux'],
+                                                               self.config['kernel'],
                                                                filter_func = filter_func)))

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -20,7 +20,8 @@ class Malfind(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
@@ -45,8 +46,8 @@ class Malfind(interfaces.plugins.PluginInterface):
 
     def _generator(self, tasks):
         # determine if we're on a 32 or 64 bit kernel
-        if self.context.symbol_space.get_type(
-                self.config["vmlinux.symbol_table_name"] + constants.BANG + "pointer").size == 4:
+        vmlinux = self.context.modules[self.config['kernel']]
+        if self.context.symbol_space.get_type(vmlinux.symbol_table_name + constants.BANG + "pointer").size == 4:
             is_32bit_arch = True
         else:
             is_32bit_arch = False

--- a/volatility3/framework/plugins/linux/proc.py
+++ b/volatility3/framework/plugins/linux/proc.py
@@ -21,7 +21,8 @@ class Maps(plugins.PluginInterface):
     def get_requirements(cls):
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
@@ -65,5 +66,5 @@ class Maps(plugins.PluginInterface):
                                    ("File Path", str)],
                                   self._generator(
                                       pslist.PsList.list_tasks(self.context,
-                                                               self.config['vmlinux'],
+                                                               self.config['kernel'],
                                                                filter_func = filter_func)))

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -18,7 +18,8 @@ class PsList(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.ListRequirement(name = 'pid',
                                          description = 'Filter on specific process IDs',
                                          element_type = int,
@@ -49,7 +50,7 @@ class PsList(interfaces.plugins.PluginInterface):
 
     def _generator(self):
         for task in self.list_tasks(self.context,
-                                    self.config['vmlinux'],
+                                    self.config['kernel'],
                                     filter_func = self.create_pid_filter(self.config.get('pid', None))):
             pid = task.pid
             ppid = 0

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -34,8 +34,8 @@ class PsTree(pslist.PsList):
 
     def _generator(self):
         """Generates the."""
-        for proc in self.list_tasks(self.context, self.config['vmlinux.layer_name'],
-                                    self.config['vmlinux.symbol_table_name']):
+        vmlinux = self.context.modules[self.config['kernel']]
+        for proc in self.list_tasks(self.context, vmlinux.layer_name, vmlinux.symbol_table_name):
             self._processes[proc.pid] = proc
 
         # Build the child/level maps

--- a/volatility3/framework/plugins/linux/tty_check.py
+++ b/volatility3/framework/plugins/linux/tty_check.py
@@ -24,13 +24,14 @@ class tty_check(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'vmlinux', architectures = ["Intel32", "Intel64"]),
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0)),
             requirements.VersionRequirement(name = 'linuxutils', component = linux.LinuxUtilities, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        vmlinux = self.context.modules[self.config['vmlinux']]
+        vmlinux = self.context.modules[self.config['kernel']]
 
         modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
 

--- a/volatility3/framework/plugins/mac/check_syscall.py
+++ b/volatility3/framework/plugins/mac/check_syscall.py
@@ -23,16 +23,16 @@ class Check_syscall(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['kernel'])
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
@@ -54,7 +54,7 @@ class Check_syscall(plugins.PluginInterface):
                 continue
 
             module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers,
-                                                                              call_addr, self.config['darwin'])
+                                                                              call_addr, self.config['kernel'])
 
             yield (0, (format_hints.Hex(table.vol.offset), "SysCall", i, format_hints.Hex(call_addr), module_name,
                        symbol_name))

--- a/volatility3/framework/plugins/mac/check_sysctl.py
+++ b/volatility3/framework/plugins/mac/check_sysctl.py
@@ -25,7 +25,7 @@ class Check_sysctl(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
@@ -113,9 +113,9 @@ class Check_sysctl(plugins.PluginInterface):
                 break
 
     def _generator(self):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['kernel'])
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
@@ -128,7 +128,7 @@ class Check_sysctl(plugins.PluginInterface):
                 continue
 
             module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, check_addr,
-                                                                              self.config['darwin'])
+                                                                              self.config['kernel'])
 
             yield (0, (name, sysctl.oid_number, sysctl.get_perms(), format_hints.Hex(check_addr), val, module_name,
                        symbol_name))

--- a/volatility3/framework/plugins/mac/check_trap_table.py
+++ b/volatility3/framework/plugins/mac/check_trap_table.py
@@ -24,16 +24,16 @@ class Check_trap_table(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0)),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
         ]
 
     def _generator(self):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['kernel'])
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
@@ -49,7 +49,7 @@ class Check_trap_table(plugins.PluginInterface):
                 continue
 
             module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, call_addr,
-                                                                              self.config['darwin'])
+                                                                              self.config['kernel'])
 
             yield (0, (format_hints.Hex(table.vol.offset), "TrapTable", i, format_hints.Hex(call_addr), module_name,
                        symbol_name))

--- a/volatility3/framework/plugins/mac/ifconfig.py
+++ b/volatility3/framework/plugins/mac/ifconfig.py
@@ -16,13 +16,13 @@ class Ifconfig(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0))
         ]
 
     def _generator(self):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
         try:
             list_head = kernel.object_from_symbol(symbol_name = "ifnet_head")

--- a/volatility3/framework/plugins/mac/kauth_listeners.py
+++ b/volatility3/framework/plugins/mac/kauth_listeners.py
@@ -18,7 +18,7 @@ class Kauth_listeners(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 1, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0)),
@@ -31,13 +31,13 @@ class Kauth_listeners(interfaces.plugins.PluginInterface):
         """
         Enumerates the listeners for each kauth scope
         """
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['kernel'])
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
-        for scope in kauth_scopes.Kauth_scopes.list_kauth_scopes(self.context, self.config['darwin']):
+        for scope in kauth_scopes.Kauth_scopes.list_kauth_scopes(self.context, self.config['kernel']):
 
             scope_name = utility.pointer_to_string(scope.ks_identifier, 128)
 
@@ -47,7 +47,7 @@ class Kauth_listeners(interfaces.plugins.PluginInterface):
                     continue
 
                 module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, callback,
-                                                                                  self.config['darwin'])
+                                                                                  self.config['kernel'])
 
                 yield (0, (scope_name, format_hints.Hex(listener.kll_idata), format_hints.Hex(callback), module_name,
                            symbol_name))

--- a/volatility3/framework/plugins/mac/kauth_scopes.py
+++ b/volatility3/framework/plugins/mac/kauth_scopes.py
@@ -2,7 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from typing import Iterable, Callable, Tuple
+from typing import Iterable, Callable
 
 from volatility3.framework import renderers, interfaces
 from volatility3.framework.configuration import requirements
@@ -23,7 +23,7 @@ class Kauth_scopes(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 1, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
@@ -34,9 +34,7 @@ class Kauth_scopes(interfaces.plugins.PluginInterface):
                           context: interfaces.context.ContextInterface,
                           kernel_module_name: str,
                           filter_func: Callable[[int], bool] = lambda _: False) -> \
-            Iterable[Tuple[interfaces.objects.ObjectInterface,
-                           interfaces.objects.ObjectInterface,
-                           interfaces.objects.ObjectInterface]]:
+            Iterable[interfaces.objects.ObjectInterface]:
         """
         Enumerates the registered kauth scopes and yields each object
         Uses smear-safe enumeration API
@@ -50,20 +48,20 @@ class Kauth_scopes(interfaces.plugins.PluginInterface):
                 yield scope
 
     def _generator(self):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['kernel'])
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
-        for scope in self.list_kauth_scopes(self.context, self.config['darwin']):
+        for scope in self.list_kauth_scopes(self.context, self.config['kernel']):
 
             callback = scope.ks_callback
             if callback == 0:
                 continue
 
             module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, callback,
-                                                                              self.config['darwin'])
+                                                                              self.config['kernel'])
 
             identifier = utility.pointer_to_string(scope.ks_identifier, 128)
 

--- a/volatility3/framework/plugins/mac/kevents.py
+++ b/volatility3/framework/plugins/mac/kevents.py
@@ -48,7 +48,7 @@ class Kevents(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 2, 0)),
@@ -148,7 +148,7 @@ class Kevents(interfaces.plugins.PluginInterface):
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
 
         for task_name, pid, kn in self.list_kernel_events(self.context,
-                                                          self.config['darwin'],
+                                                          self.config['kernel'],
                                                           filter_func = filter_func):
 
             filter_index = kn.kn_kevent.filter * -1

--- a/volatility3/framework/plugins/mac/list_files.py
+++ b/volatility3/framework/plugins/mac/list_files.py
@@ -23,7 +23,7 @@ class List_Files(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'mount', plugin = mount.Mount, version = (2, 0, 0)),
         ]
@@ -165,7 +165,7 @@ class List_Files(plugins.PluginInterface):
             yield vnode, full_path
 
     def _generator(self):
-        for vnode, full_path in self.list_files(self.context, self.config['darwin']):
+        for vnode, full_path in self.list_files(self.context, self.config['kernel']):
 
             yield (0, (format_hints.Hex(vnode), full_path))
 

--- a/volatility3/framework/plugins/mac/lsmod.py
+++ b/volatility3/framework/plugins/mac/lsmod.py
@@ -22,7 +22,7 @@ class Lsmod(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
         ]
 
@@ -76,7 +76,7 @@ class Lsmod(plugins.PluginInterface):
                 return
 
     def _generator(self):
-        for module in self.list_modules(self.context, self.config['darwin']):
+        for module in self.list_modules(self.context, self.config['kernel']):
 
             mod_name = utility.array_to_string(module.name)
             mod_size = module.size

--- a/volatility3/framework/plugins/mac/lsof.py
+++ b/volatility3/framework/plugins/mac/lsof.py
@@ -21,7 +21,7 @@ class Lsof(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
@@ -32,11 +32,12 @@ class Lsof(plugins.PluginInterface):
         ]
 
     def _generator(self, tasks):
+        darwin = self.context.modules[self.config['kernel']]
         for task in tasks:
             pid = task.p_pid
 
-            for _, filepath, fd in mac.MacUtilities.files_descriptors_for_process(self.context, self.config[
-                'darwin.symbol_table_name'],
+            for _, filepath, fd in mac.MacUtilities.files_descriptors_for_process(self.context,
+                                                                                  darwin.symbol_table_name,
                                                                                   task):
                 if filepath and len(filepath) > 0:
                     yield (0, (pid, fd, filepath))
@@ -48,5 +49,5 @@ class Lsof(plugins.PluginInterface):
         return renderers.TreeGrid([("PID", int), ("File Descriptor", int), ("File Path", str)],
                                   self._generator(
                                       list_tasks(self.context,
-                                                 self.config['darwin'],
+                                                 self.config['kernel'],
                                                  filter_func = filter_func)))

--- a/volatility3/framework/plugins/mac/malfind.py
+++ b/volatility3/framework/plugins/mac/malfind.py
@@ -18,7 +18,7 @@ class Malfind(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.ListRequirement(name = 'pid',
@@ -38,13 +38,13 @@ class Malfind(interfaces.plugins.PluginInterface):
         proc_layer = self.context.layers[proc_layer_name]
 
         for vma in task.get_map_iter():
-            if not vma.is_suspicious(self.context, self.context.modules[self.config['darwin']].symbol_table_name):
+            if not vma.is_suspicious(self.context, self.context.modules[self.config['kernel']].symbol_table_name):
                 data = proc_layer.read(vma.links.start, 64, pad = True)
                 yield vma, data
 
     def _generator(self, tasks):
         # determine if we're on a 32 or 64 bit kernel
-        if self.context.modules[self.config['darwin']].get_type("pointer").size == 4:
+        if self.context.modules[self.config['kernel']].get_type("pointer").size == 4:
             is_32bit_arch = True
         else:
             is_32bit_arch = False
@@ -72,5 +72,5 @@ class Malfind(interfaces.plugins.PluginInterface):
                                    ("Disasm", interfaces.renderers.Disassembly)],
                                   self._generator(
                                       list_tasks(self.context,
-                                                 self.config['darwin'],
+                                                 self.config['kernel'],
                                                  filter_func = filter_func)))

--- a/volatility3/framework/plugins/mac/mount.py
+++ b/volatility3/framework/plugins/mac/mount.py
@@ -21,7 +21,7 @@ class Mount(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
         ]
@@ -46,7 +46,7 @@ class Mount(plugins.PluginInterface):
             yield mount
 
     def _generator(self):
-        for mount in self.list_mounts(self.context, self.config['darwin']):
+        for mount in self.list_mounts(self.context, self.config['kernel']):
             vfs = mount.mnt_vfsstat
             device_name = utility.array_to_string(vfs.f_mntonname)
             mount_point = utility.array_to_string(vfs.f_mntfromname)

--- a/volatility3/framework/plugins/mac/netstat.py
+++ b/volatility3/framework/plugins/mac/netstat.py
@@ -24,7 +24,7 @@ class Netstat(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
@@ -74,7 +74,7 @@ class Netstat(plugins.PluginInterface):
                     continue
 
                 if not context.layers[task.vol.native_layer_name].is_valid(socket.vol.offset,
-                                                                                 socket.vol.size):
+                                                                           socket.vol.size):
                     continue
 
                 yield task_name, pid, socket
@@ -83,7 +83,7 @@ class Netstat(plugins.PluginInterface):
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
 
         for task_name, pid, socket in self.list_sockets(self.context,
-                                                        self.config['darwin'],
+                                                        self.config['kernel'],
                                                         filter_func = filter_func):
 
             family = socket.get_family()

--- a/volatility3/framework/plugins/mac/proc_maps.py
+++ b/volatility3/framework/plugins/mac/proc_maps.py
@@ -17,7 +17,7 @@ class Maps(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.ListRequirement(name = 'pid',
@@ -32,7 +32,7 @@ class Maps(interfaces.plugins.PluginInterface):
             process_pid = task.p_pid
 
             for vma in task.get_map_iter():
-                path = vma.get_path(self.context, self.context.modules[self.config['darwin']].symbol_table_name)
+                path = vma.get_path(self.context, self.context.modules[self.config['kernel']].symbol_table_name)
                 if path == "":
                     path = vma.get_special_path()
 
@@ -47,5 +47,5 @@ class Maps(interfaces.plugins.PluginInterface):
                                    ("End", format_hints.Hex), ("Protection", str), ("Map Name", str)],
                                   self._generator(
                                       list_tasks(self.context,
-                                                 self.config['darwin'],
+                                                 self.config['kernel'],
                                                  filter_func = filter_func)))

--- a/volatility3/framework/plugins/mac/psaux.py
+++ b/volatility3/framework/plugins/mac/psaux.py
@@ -19,7 +19,7 @@ class Psaux(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0)),
             requirements.ListRequirement(name = 'pid',
@@ -96,5 +96,5 @@ class Psaux(plugins.PluginInterface):
         return renderers.TreeGrid([("PID", int), ("Process", str), ("Argc", int), ("Arguments", str)],
                                   self._generator(
                                       list_tasks(self.context,
-                                                 self.config['darwin'],
+                                                 self.config['kernel'],
                                                  filter_func = filter_func)))

--- a/volatility3/framework/plugins/mac/pslist.py
+++ b/volatility3/framework/plugins/mac/pslist.py
@@ -23,7 +23,7 @@ class PsList(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 1, 0)),
             requirements.ChoiceRequirement(name = 'pslist_method',
@@ -89,7 +89,7 @@ class PsList(interfaces.plugins.PluginInterface):
         list_tasks = self.get_list_tasks(self.config.get('pslist_method', self.pslist_methods[0]))
 
         for task in list_tasks(self.context,
-                               self.config['darwin'],
+                               self.config['kernel'],
                                filter_func = self.create_pid_filter(self.config.get('pid', None))):
             pid = task.p_pid
             ppid = task.p_ppid

--- a/volatility3/framework/plugins/mac/pstree.py
+++ b/volatility3/framework/plugins/mac/pstree.py
@@ -24,7 +24,7 @@ class PsTree(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (3, 0, 0))
         ]
@@ -48,7 +48,7 @@ class PsTree(plugins.PluginInterface):
         """Generates the tree list of processes"""
         list_tasks = pslist.PsList.get_list_tasks(self.config.get('pslist_method', pslist.PsList.pslist_methods[0]))
 
-        for proc in list_tasks(self.context, self.config['darwin']):
+        for proc in list_tasks(self.context, self.config['kernel']):
             self._processes[proc.p_pid] = proc
 
         # Build the child/level maps

--- a/volatility3/framework/plugins/mac/socket_filters.py
+++ b/volatility3/framework/plugins/mac/socket_filters.py
@@ -24,16 +24,16 @@ class Socket_filters(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 0, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['kernel'])
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 

--- a/volatility3/framework/plugins/mac/timers.py
+++ b/volatility3/framework/plugins/mac/timers.py
@@ -23,16 +23,16 @@ class Timers(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 3, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
-        mods = lsmod.Lsmod.list_modules(self.context, self.config['darwin'])
+        mods = lsmod.Lsmod.list_modules(self.context, self.config['kernel'])
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
@@ -69,7 +69,7 @@ class Timers(plugins.PluginInterface):
                     entry_time = -1
 
                 module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, handler,
-                                                                                  self.config['darwin'])
+                                                                                  self.config['kernel'])
 
                 yield (0, (format_hints.Hex(handler), format_hints.Hex(timer.param0), format_hints.Hex(timer.param1),
                            timer.deadline, entry_time, module_name, symbol_name))

--- a/volatility3/framework/plugins/mac/trustedbsd.py
+++ b/volatility3/framework/plugins/mac/trustedbsd.py
@@ -25,14 +25,14 @@ class Trustedbsd(plugins.PluginInterface):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
             requirements.VersionRequirement(name = 'macutils', component = mac.MacUtilities, version = (1, 3, 0)),
             requirements.PluginRequirement(name = 'lsmod', plugin = lsmod.Lsmod, version = (2, 0, 0))
         ]
 
     def _generator(self, mods: Iterator[Any]):
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
         handlers = mac.MacUtilities.generate_kernel_handler_info(self.context, kernel.layer_name, kernel, mods)
 
@@ -65,7 +65,7 @@ class Trustedbsd(plugins.PluginInterface):
                     continue
 
                 module_name, symbol_name = mac.MacUtilities.lookup_module_address(self.context, handlers, call_addr,
-                                                                                  self.config['darwin'])
+                                                                                  self.config['kernel'])
 
                 yield (0, (check, ent_name, format_hints.Hex(call_addr), module_name, symbol_name))
 
@@ -73,4 +73,4 @@ class Trustedbsd(plugins.PluginInterface):
         return renderers.TreeGrid([("Member", str), ("Policy Name", str), ("Handler Address", format_hints.Hex),
                                    ("Handler Module", str), ("Handler Symbol", str)],
                                   self._generator(
-                                      lsmod.Lsmod.list_modules(self.context, self.config['darwin'])))
+                                      lsmod.Lsmod.list_modules(self.context, self.config['kernel'])))

--- a/volatility3/framework/plugins/mac/vfsevents.py
+++ b/volatility3/framework/plugins/mac/vfsevents.py
@@ -20,7 +20,7 @@ class VFSevents(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.ModuleRequirement(name = 'darwin', description = 'Kernel module for the OS',
+            requirements.ModuleRequirement(name = 'kernel', description = 'Kernel module for the OS',
                                            architectures = ["Intel32", "Intel64"]),
         ]
 
@@ -30,7 +30,7 @@ class VFSevents(interfaces.plugins.PluginInterface):
         Also lists which event(s) a process is registered for
         """
 
-        kernel = self.context.modules[self.config['darwin']]
+        kernel = self.context.modules[self.config['kernel']]
 
         watcher_table = kernel.object_from_symbol("watcher_table")
 


### PR DESCRIPTION
The situation we face is that where previously we use the standard "primary" as the name of the layer, the symbol tables could be called nt_symbols, darwin or vmlinux, just through convention.  This allowed config files to write `primary.` layer information and plugins could make use of this.  Since we've now moved to a kernel module, the layer name becomes `kernel.layer_name`, which can only be used consistently if the kernels for linux and macos are called `kernel` rather than `vmlinux` or `darwin`.

Usually layers will be specific to a particular OS and therefore this shouldn't matter *but* we can partially fill out a layer (without knowing its OS) and the correct OS plugins may then not work, depending on the choice of kernel module name (or we'd have to include the config option three times over, one for each standard kernel name).  Instead, the easiest route is to rename the module requirements in linux and mac to a standardized `kernel`.

Again, this shouldn't be contentious, so I'll be applying it in a few days unless anyone speaks up...