### PR TITLE
Fixed an issue where the symbol file download from the Microsoft site failed

### DIFF
--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -170,9 +170,9 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
 
         pdb_name = debug_entry.PdbFileName.decode("utf-8").strip('\x00')
         age = debug_entry.Age
-        guid = "{:x}{:x}{:x}{}".format(debug_entry.Signature_Data1, debug_entry.Signature_Data2,
-                                       debug_entry.Signature_Data3,
-                                       binascii.hexlify(debug_entry.Signature_Data4).decode('utf-8'))
+        guid = "{:08x}{:04x}{:04x}{}".format(debug_entry.Signature_Data1, debug_entry.Signature_Data2,
+                                             debug_entry.Signature_Data3,
+                                             binascii.hexlify(debug_entry.Signature_Data4).decode('utf-8'))
         return guid, age, pdb_name
 
     @classmethod


### PR DESCRIPTION
I found an issue with the _get_guid_from_mz_ function where the guid value was not zero padded. This issue causes the PDB file download from the Microsoft website to fail.