### PR TITLE
Core: Change Module to ConfigurableInterface

### DIFF
--- a/volatility3/framework/automagic/module.py
+++ b/volatility3/framework/automagic/module.py
@@ -22,7 +22,7 @@ class KernelModule(interfaces.automagic.AutomagicInterface):
         # The requirement is unfulfilled and is a ModuleRequirement
 
         context.config[interfaces.configuration.path_join(
-            new_config_path, 'class')] = 'volatility3.framework.contexts.ConfigurableModule'
+            new_config_path, 'class')] = 'volatility3.framework.contexts.Module'
 
         for req in requirement.requirements:
             if requirement.requirements[req].unsatisfied(context, new_config_path) and req != 'offset':

--- a/volatility3/framework/interfaces/configuration.py
+++ b/volatility3/framework/interfaces/configuration.py
@@ -192,7 +192,7 @@ class HierarchicalDict(collections.abc.Mapping):
         elif value is None:
             return None
         else:
-            raise TypeError("Invalid type stored in configuration")
+            raise TypeError(f"Invalid type stored in configuration: {type(value)}")
 
     def __delitem__(self, key: str) -> None:
         """Deletes an item from the hierarchical dict."""

--- a/volatility3/framework/plugins/linux/kmsg.py
+++ b/volatility3/framework/plugins/linux/kmsg.py
@@ -60,7 +60,7 @@ class ABCKmsg(ABC):
         vmlinux = context.modules[self._config['kernel']]
         self.layer_name = vmlinux.layer_name  # type: ignore
         symbol_table_name = vmlinux.symbol_table_name  # type: ignore
-        self.vmlinux = contexts.Module(context, symbol_table_name, self.layer_name, 0)  # type: ignore
+        self.vmlinux = contexts.Module.create(context, symbol_table_name, self.layer_name, 0)  # type: ignore
         self.long_unsigned_int_size = self.vmlinux.get_type('long unsigned int').size
 
     @classmethod

--- a/volatility3/framework/plugins/windows/ssdt.py
+++ b/volatility3/framework/plugins/windows/ssdt.py
@@ -60,12 +60,12 @@ class SSDT(plugins.PluginInterface):
             if module_name in constants.windows.KERNEL_MODULE_NAMES:
                 symbol_table_name = symbol_table
 
-            context_module = contexts.SizedModule(context,
-                                                  module_name,
-                                                  layer_name,
-                                                  mod.DllBase,
-                                                  mod.SizeOfImage,
-                                                  symbol_table_name = symbol_table_name)
+            context_module = contexts.SizedModule.create(context = context,
+                                                         module_name = module_name,
+                                                         layer_name = layer_name,
+                                                         offset = mod.DllBase,
+                                                         size = mod.SizeOfImage,
+                                                         symbol_table_name = symbol_table_name)
 
             context_modules.append(context_module)
 


### PR DESCRIPTION
Last big change intended for the 2.0.0 release, it draws module into the same pattern as layers and symbols (a uniquely named member of a collection stored in the context).

This could do with some testing to make sure people are happy with using the `create` classmethod to create a module (or manually building the config, but that's a little clumsy, hence the `create` convenience method).

Once this has been oked, we can merged the four API change pull requests and then fork for a new release.  We can also prefork if this proves to be too much of a shift and needs more time for review...