### PR TITLE
[API] Issues/issue 529 driverscan additional structures

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/pool.py
+++ b/volatility3/framework/symbols/windows/extensions/pool.py
@@ -25,16 +25,15 @@ class POOL_HEADER(objects.StructType):
         """Carve an object or data structure from a kernel pool allocation
 
         Args:
-            type_name: the data structure type name
-            native_layer_name: the name of the layer where the data originally lived
-            object_type: the object type (executive kernel objects only)
+            constraint: a PoolConstraint object used to get the pool allocation header object 
+            use_top_down: for delineating how a windows version finds the size of the object body
             kernel_symbol_table: in case objects of a different symbol table are scanned for
+            native_layer_name: the name of the layer where the data originally lived
 
         Returns:
             An object as found from a POOL_HEADER
         """
 
-        # TODO: I wasn't quite sure what to do with these values, so I just set them here for now.
         type_name = constraint.type_name
         executive = constraint.object_type is not None
 

--- a/volatility3/plugins/windows/poolscanner.py
+++ b/volatility3/plugins/windows/poolscanner.py
@@ -39,7 +39,8 @@ class PoolConstraint:
                  size: Optional[Tuple[Optional[int], Optional[int]]] = None,
                  index: Optional[Tuple[Optional[int], Optional[int]]] = None,
                  alignment: Optional[int] = 1,
-                 skip_type_test: bool = False) -> None:
+                 skip_type_test: bool = False,
+                 additional_structures: Optional[List[str]] = None) -> None:
         self.tag = tag
         self.type_name = type_name
         self.object_type = object_type
@@ -48,6 +49,7 @@ class PoolConstraint:
         self.index = index
         self.alignment = alignment
         self.skip_type_test = skip_type_test
+        self.additional_structures = additional_structures
 
 
 class PoolHeaderScanner(interfaces.layers.ScannerInterface):
@@ -212,7 +214,8 @@ class PoolScanner(plugins.PluginInterface):
                            type_name = symbol_table + constants.BANG + "_DRIVER_OBJECT",
                            object_type = "Driver",
                            size = (248, None),
-                           page_type = PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE),
+                           page_type = PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE, 
+                           additional_structures = ["_DRIVER_EXTENSION"]),
             # drivers on windows starting with windows 8
             PoolConstraint(b'Driv',
                            type_name = symbol_table + constants.BANG + "_DRIVER_OBJECT",
@@ -291,10 +294,9 @@ class PoolScanner(plugins.PluginInterface):
 
         for constraint, header in cls.pool_scan(context, scan_layer, symbol_table, constraints, alignment = alignment):
 
-            mem_object = header.get_object(type_name = constraint.type_name,
+            mem_object = header.get_object(constraint = constraint,
                                            use_top_down = is_windows_8_or_later,
-                                           executive = constraint.object_type is not None,
-                                           native_layer_name = layer_name,
+                                           native_layer_name = 'primary',
                                            kernel_symbol_table = symbol_table)
 
             if mem_object is None:

--- a/volatility3/plugins/windows/poolscanner.py
+++ b/volatility3/plugins/windows/poolscanner.py
@@ -39,7 +39,8 @@ class PoolConstraint:
                  size: Optional[Tuple[Optional[int], Optional[int]]] = None,
                  index: Optional[Tuple[Optional[int], Optional[int]]] = None,
                  alignment: Optional[int] = 1,
-                 skip_type_test: bool = False) -> None:
+                 skip_type_test: bool = False,
+                 additional_structures: Optional[List[str]] = None) -> None:
         self.tag = tag
         self.type_name = type_name
         self.object_type = object_type
@@ -48,6 +49,7 @@ class PoolConstraint:
         self.index = index
         self.alignment = alignment
         self.skip_type_test = skip_type_test
+        self.additional_structures = additional_structures
 
 
 class PoolHeaderScanner(interfaces.layers.ScannerInterface):
@@ -212,7 +214,8 @@ class PoolScanner(plugins.PluginInterface):
                            type_name = symbol_table + constants.BANG + "_DRIVER_OBJECT",
                            object_type = "Driver",
                            size = (248, None),
-                           page_type = PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE),
+                           page_type = PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE, 
+                           additional_structures = ["_DRIVER_EXTENSION"]),
             # drivers on windows starting with windows 8
             PoolConstraint(b'Driv',
                            type_name = symbol_table + constants.BANG + "_DRIVER_OBJECT",
@@ -291,9 +294,8 @@ class PoolScanner(plugins.PluginInterface):
 
         for constraint, header in cls.pool_scan(context, scan_layer, symbol_table, constraints, alignment = alignment):
 
-            mem_object = header.get_object(type_name = constraint.type_name,
+            mem_object = header.get_object(constraint = constraint,
                                            use_top_down = is_windows_8_or_later,
-                                           executive = constraint.object_type is not None,
                                            native_layer_name = 'primary',
                                            kernel_symbol_table = symbol_table)
 


### PR DESCRIPTION
N.B. This PR requires a major version change which is not currently part of the PR.

This patches an issue for some versions of windows that require the bottom-up approach for finding the size of "object body" by recognizing additional structures occupying the "object body" position. The sizes of these additional structures are added to the size of _DRIVER_OBJECT to more accurately compute the actual size of "object body".

This PR resolves #529