### PR TITLE
refs #566 refactor dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,24 @@ the Volatility Software License (VSL). See the [LICENSE](LICENSE.txt) file for m
 
 ## Requirements
 
-- Python 3.6.0 or later. <https://www.python.org>
-- Pefile 2017.8.1 or later. <https://pypi.org/project/pefile/>
+Volatility 3 requires Python 3.6.0 or later. To install the most minimal set of dependencies (some plugins will not work) use a command such as:
 
-## Optional Dependencies
+```shell
+pip3 install requirements-minimal.txt
+```
 
-- yara-python 3.8.0 or later. <https://github.com/VirusTotal/yara-python>
-- capstone 3.0.0 or later. <https://www.capstone-engine.org/download.html>
+Alternately, the minimal packages can be installed automatically when Volatility 3 is installed. However, as noted in the Quick Start section below, Volatility 3 does not *need* to be installed prior to using it.
+
+```shell
+python3 setup.py build 
+python3 setup.py install
+```
+
+To enable the full range of Volatility 3 functionality, use a command like the one below. For partial functionality, comment out any unnecessary packages in [requirements.txt](requirements.txt) prior to running the command.
+
+```shell
+pip3 install requirements.txt
+```
 
 ## Downloading Volatility
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the Volatility Software License (VSL). See the [LICENSE](LICENSE.txt) file for m
 Volatility 3 requires Python 3.6.0 or later. To install the most minimal set of dependencies (some plugins will not work) use a command such as:
 
 ```shell
-pip3 install requirements-minimal.txt
+pip3 install -r requirements-minimal.txt
 ```
 
 Alternately, the minimal packages can be installed automatically when Volatility 3 is installed. However, as noted in the Quick Start section below, Volatility 3 does not *need* to be installed prior to using it.
@@ -34,7 +34,7 @@ python3 setup.py install
 To enable the full range of Volatility 3 functionality, use a command like the one below. For partial functionality, comment out any unnecessary packages in [requirements.txt](requirements.txt) prior to running the command.
 
 ```shell
-pip3 install requirements.txt
+pip3 install -r requirements.txt
 ```
 
 ## Downloading Volatility

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Volatility 3 requires Python 3.6.0 or later. To install the most minimal set of 
 pip3 install -r requirements-minimal.txt
 ```
 
-Alternately, the minimal packages can be installed automatically when Volatility 3 is installed. However, as noted in the Quick Start section below, Volatility 3 does not *need* to be installed prior to using it.
+Alternately, the minimal packages will be installed automatically when Volatility 3 is installed using setup.py. However, as noted in the Quick Start section below, Volatility 3 does not *need* to be installed via setup.py prior to using it.
 
 ```shell
 python3 setup.py build 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,4 @@
+# These packages are required for building the documentation.
+sphinx>=1.8.2
+sphinx_autodoc_typehints>=1.4.0
+sphinx-rtd-theme>=0.4.3

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,0 +1,2 @@
+# These packages are required for core functionality.
+pefile>=2017.8.1 #foo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,24 @@
+# The following packages are required for core functionality.
+pefile>=2017.8.1
+
+# The following packages are optional.
+# If certain packages are not necessary, place a comment (#) at the start of the line.
+
+# This is required for the yara plugins
+yara-python>=3.8.0
+
+# This is required for several plugins that perform malware analysis and disassemble code.
+# It can also improve accuracy of Windows 8 and later memory samples.
+capstone>=3.0.5
+
+# This is required by plugins that decrypt passwords, password hashes, etc.
+pycryptodome
+
+# This can improve error messages regarding improperly configured ISF files.
+jsonschema>=2.3.0
+
+# This is required for memory acquisition via leech.
+leechcorepyc>=2.4.0
+
+# This is required for analyzing Linux samples acquired with AVML.
+python-snappy==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,9 @@ pycryptodome
 # This can improve error messages regarding improperly configured ISF files.
 jsonschema>=2.3.0
 
-# This is required for memory acquisition via leech.
+# This is required for memory acquisition via leechcore/pcileech.
 leechcorepyc>=2.4.0
 
-# This is required for analyzing Linux samples acquired with AVML.
+# This is required for analyzing Linux samples compressed using AVMLs native
+# compression format.  It is not required for AVML's standard LiME compression.
 python-snappy==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,16 @@ from volatility3.framework import constants
 with open("README.md", "r", encoding = "utf-8") as fh:
     long_description = fh.read()
 
+def get_install_requires():
+    requirements = []
+    with open("requirements-minimal.txt", "r", encoding="utf-8") as fh:
+        for line in fh.readlines():
+            stripped_line = line.strip()
+            if stripped_line == "" or stripped_line.startswith("#"):
+                continue
+            requirements.append(stripped_line)
+    return requirements
+
 setuptools.setup(name = "volatility3",
                  description = "Memory forensics framework",
                  version = constants.PACKAGE_VERSION,
@@ -24,7 +34,7 @@ setuptools.setup(name = "volatility3",
                      "Documentation": "https://volatility3.readthedocs.io/",
                      "Source Code": "https://github.com/volatilityfoundation/volatility3",
                  },
-                 python_requires = '>=3.5.3',
+                 python_requires = '>=3.6.0',
                  include_package_data = True,
                  exclude_package_data = {
                      '': ['development', 'development.*'],
@@ -37,13 +47,4 @@ setuptools.setup(name = "volatility3",
                          'volshell = volatility3.cli.volshell:main',
                      ],
                  },
-                 install_requires = ["pefile"],
-                 extras_require = {
-                     'leechcorepyc': ["leechcorepyc>=2.4.0"],
-                     'jsonschema': ["jsonschema>=2.3.0"],
-                     'yara': ["yara-python>=3.8.0"],
-                     'crypto': ["pycryptodome>=3"],
-                     'disasm': ["capstone;platform_system=='Linux'", "capstone-windows;platform_system=='Windows'"],
-                     'doc': ["sphinx>=1.8.2", "sphinx_autodoc_typehints>=1.4.0", "sphinx-rtd-theme>=0.4.3"],
-                     'avml': ["python-snappy==0.6.0"],
-                 })
+                 install_requires = get_install_requires())


### PR DESCRIPTION
# Bugs and fixes 

* README said pefile>=2017.8.1 but setup.py said "pefile"
* README said python >= 3.6.0 but setup.py said python >= 3.6.0
* The oldest pycryptodome available is 3, so >= 3 is the same as not mentioning a version at all 
* setup.py mentions capstone for Linux and capstone-windows for Windows, but no versions for either, and nothing for Mac. The README says capstone >= 3.0.0. If we bump to 3.0.5 then the "capstone" package can be used for all 3 platforms. 

# Refactors

* Moved sphinx to doc/requirements.txt (out of sight, this is mainly for us and other devs)
* Moved core reqs to requirements-minimal.txt, and that is read dynamically by setup.py 
* The requirements.txt contains all dependencies, with comments 
* README discusses how to install with minimal, partial, and complete dependencies 