### PR TITLE
Windows: Set a 100Gb VAD max size for vadinfo

### DIFF
--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -35,7 +35,7 @@ class VadInfo(interfaces.plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
     _version = (2, 0, 0)
-    MAXSIZE_DEFAULT = 100 * 1024 * 1024 * 1024  # 100 Gb
+    MAXSIZE_DEFAULT = 1024 * 1024 * 1024  # 1 Gb
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -35,7 +35,7 @@ class VadInfo(interfaces.plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
     _version = (2, 0, 0)
-    MAXSIZE_DEFAULT = 0
+    MAXSIZE_DEFAULT = 100 * 1024 * 1024 * 1024  # 100 Gb
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Potential fix for #578

@iMHLv2 is 100Gb a reasonable limit (ie, one that we are unlikely to have to change in the near future, but won't lead people to run out of disk disk space so quickly as without a limit)?