### PR TITLE
update version to 2.0.0

### DIFF
--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -14,7 +14,7 @@ vollog = logging.getLogger(__name__)
 
 
 class Crashinfo(interfaces.plugins.PluginInterface):
-    _required_framework_version = (1, 1, 0)
+    _required_framework_version = (2, 0, 0)
 
     @classmethod
     def get_requirements(cls):


### PR DESCRIPTION
Using windows.crashinfo plugin from develop branch, I came across the following error:
```
Volatility 3 Framework 2.0.0
Traceback (most recent call last):B scanning finished
  File "vol.py", line 10, in <module>
    volatility3.cli.main()
  File "/opt/volatility3/volatility3/cli/__init__.py", line 625, in main
    CommandLine().run()
  File "/opt/volatility3/volatility3/cli/__init__.py", line 319, in run
    constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
  File "/opt/volatility3/volatility3/framework/plugins/__init__.py", line 51, in construct_plugin
    constructed = plugin(context, plugin_config_path, progress_callback = progress_callback)
  File "/opt/volatility3/volatility3/framework/interfaces/plugins.py", line 111, in __init__
    super().__init__(context, config_path)
  File "/opt/volatility3/volatility3/framework/interfaces/configuration.py", line 620, in __init__
    super().__init__()
  File "/opt/volatility3/volatility3/framework/interfaces/configuration.py", line 736, in __init__
    framework.require_interface_version(*self._required_framework_version)
  File "/opt/volatility3/volatility3/framework/__init__.py", line 48, in require_interface_version
    raise RuntimeError("Framework interface version {} is incompatible with required version {}".format(
RuntimeError: Framework interface version 2 is incompatible with required version 1
```
_required_framework_version in crashinfo.py should also be updated to 2.0.0 for this version of framework, I believe.  If this fix seems OK, would you merge it, please?