### PR TITLE
CLI: Add in None renderer to avoid text output

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -182,6 +182,17 @@ class QuickTextRenderer(CLIRenderer):
         outfd.write("\n")
 
 
+class NoneRenderer(CLIRenderer):
+    """Outputs no results"""
+    name = "none"
+
+    def get_render_options(self):
+        pass
+
+    def render(self, grid: interfaces.renderers.TreeGrid) -> None:
+        if not grid.populated:
+            grid.populate(lambda x, y: True, True)
+
 class CSVRenderer(CLIRenderer):
     _type_renderers = {
         format_hints.Bin: quoted_optional(lambda x: f"0b{x:b}"),


### PR DESCRIPTION
This is useful for dump plugins where the specifically generated output isn't necessary, only the generated files.