### PR TITLE
Automagic: Warn when multiple symbol files match a banner

### DIFF
--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -45,6 +45,12 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
 
             symbol_files = linux_banners.get(banner, None)
             if symbol_files:
+                if len(symbol_files) > 1:
+                    using = "*"
+                    vollog.warning(f"Multiple symbol files identified (using {using}):")
+                    for symbol_file in symbol_files:
+                        vollog.warning(f" {using} {symbol_file}")
+                        using = " "
                 isf_path = symbol_files[0]
                 table_name = context.symbol_space.free_table_name('LintelStacker')
                 table = linux.LinuxKernelIntermedSymbols(context,


### PR DESCRIPTION
Ensures that a banner which is matched by multiple files lists the multiple files that match (and which one will be used).  This should make the need for full cache clearing redundant, since the issue encountered was actually the fact that the list of banners to files was choosing the first file, rather than the most recent.  This should make the issue clearer.

Fixes #599.

