### PR TITLE
CLI: Support multi-line fields and tabstops in pretty renderer

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -283,9 +283,10 @@ class PrettyTextRenderer(CLIRenderer):
                 column = grid.columns[column_index]
                 renderer = self._type_renderers.get(column.type, self._type_renderers['default'])
                 data = renderer(node.values[column_index])
+                field_width = max([len(self.tab_stop(x)) for x in f"{data}".split("\n")])
                 max_column_widths[column.name] = max(max_column_widths.get(column.name, len(column.name)),
-                                                     len(f"{data}"))
-                line[column] = data
+                                                     field_width)
+                line[column] = data.split("\n")
             accumulator.append((node.path_depth, line))
             return accumulator
 
@@ -307,7 +308,25 @@ class PrettyTextRenderer(CLIRenderer):
         column_titles = [""] + [column.name for column in grid.columns]
         outfd.write(format_string.format(*column_titles))
         for (depth, line) in final_output:
-            outfd.write(format_string.format("*" * depth, *[line[column] for column in grid.columns]))
+            nums_line = max([len(line[column]) for column in line])
+            for column in line:
+                line[column] = line[column] + ([""] * (nums_line - len(line[column])))
+            for index in range(nums_line):
+                if index == 0:
+                    outfd.write(format_string.format("*" * depth, *[self.tab_stop(line[column][index]) for column in grid.columns]))
+                else:
+                    outfd.write(format_string.format(" " * depth, *[self.tab_stop(line[column][index]) for column in grid.columns]))
+
+    def tab_stop(self, line: str) -> str:
+        tab_width = 8
+        while line.find('\t') >= 0:
+            i = line.find('\t')
+            if (tab_width > 0):
+                pad = " " * (tab_width - (i % tab_width))
+            else:
+                pad = ""
+            line = line.replace("\t", pad, 1)
+        return line
 
 
 class JsonRenderer(CLIRenderer):


### PR DESCRIPTION
So this only changes the pretty output renderer (because the quick renderer already doesn't deal properly with column widths, so even if we put the output on multiple lines we couldn't align them properly).  It should also handle tabstops properly now (they won't align across fields, but tabstops within each field should be consistent and the field start locations are consistent, so it should all match up).

Please could you test this and let me know if it solves the problem.  I've kicked the tyres a bit and it seems fine, so I'm likely to commit in a week anyway, but confirmation that it sorts the problem would be nice.  5;)

Fixes #602