### PR TITLE
Automagic: Allow automagic to exclude unsupported OSes

### DIFF
--- a/doc/source/using-as-a-library.rst
+++ b/doc/source/using-as-a-library.rst
@@ -131,7 +131,8 @@ A suitable list of automagics for a particular plugin (based on operating system
     automagics = automagic.choose_automagic(available_automagics, plugin)
 
 This will take the plugin module, extract the operating system (first level of the hierarchy) and then return just
-the automagics which apply to the operating system.
+the automagics which apply to the operating system.  Each automagic can exclude itself from being used for specific
+operating systems, so that an automagic designed for linux is not used for windows or mac plugins.
 
 These automagics can then be run by providing the list, the context, the plugin to be run, the hierarchy name that
 the plugin will be constructed on ('plugins' by default) and a progress_callback.  This is a callable which takes

--- a/doc/source/vol2to3.rst
+++ b/doc/source/vol2to3.rst
@@ -62,6 +62,10 @@ automagic processes are clearly defined and can be enabled or disabled as necess
 included a stacker automagic to emulate the most common feature of Volatility 2, automatically stacking address spaces
 (now translation layers) on top of each other.
 
+By default the automagic chosen to be run are determined based on the plugin requested, so that linux plugins get linux
+specific automagic and windows plugins get windows specific automagic.  This should reduce unnecessarily searching for
+linux kernels in a windows image, for example.  At the moment this is not user configurableS.
+
 Searching and Scanning
 ----------------------
 Scanning is very similar to scanning in Volatility 2, a scanner object (such as a

--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -147,6 +147,7 @@ class LinuxBannerCache(symbol_cache.SymbolBannerCache):
     os = "linux"
     symbol_name = "linux_banner"
     banner_path = constants.LINUX_BANNERS_PATH
+    exclusion_list = ['mac', 'windows']
 
 
 class LinuxSymbolFinder(symbol_finder.SymbolFinder):
@@ -156,3 +157,4 @@ class LinuxSymbolFinder(symbol_finder.SymbolFinder):
     banner_cache = LinuxBannerCache
     symbol_class = "volatility3.framework.symbols.linux.LinuxKernelIntermedSymbols"
     find_aslr = lambda cls, *args: LinuxIntelStacker.find_aslr(*args)[1]
+    exclusion_list = ['mac', 'windows']

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -202,6 +202,7 @@ class MacBannerCache(symbol_cache.SymbolBannerCache):
     os = "mac"
     symbol_name = "version"
     banner_path = constants.MAC_BANNERS_PATH
+    exclusion_list = ['windows', 'linux']
 
 
 class MacSymbolFinder(symbol_finder.SymbolFinder):
@@ -211,3 +212,4 @@ class MacSymbolFinder(symbol_finder.SymbolFinder):
     banner_cache = MacBannerCache
     find_aslr = MacIntelStacker.find_aslr
     symbol_class = "volatility3.framework.symbols.mac.MacKernelIntermedSymbols"
+    exclusion_list = ['windows', 'linux']

--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -44,6 +44,7 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
     """
     priority = 30
     max_pdb_size = 0x400000
+    exclusion_list = ['linux', 'mac']
 
     def find_virtual_layers_from_req(self, context: interfaces.context.ContextInterface, config_path: str,
                                      requirement: interfaces.configuration.RequirementInterface) -> List[str]:

--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -238,6 +238,8 @@ class WinSwapLayers(interfaces.automagic.AutomagicInterface):
     """Class to read swap_layers filenames from single-swap-layers, create the
     layers and populate the single-layers swap_layers."""
 
+    exclusion_list = ['linux', 'mac']
+
     def __call__(self,
                  context: interfaces.context.ContextInterface,
                  config_path: str,

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -78,6 +78,7 @@ BUG_URL = "https://github.com/volatilityfoundation/volatility3/issues"
 ProgressCallback = Optional[Callable[[float, str], None]]
 """Type information for ProgressCallback objects"""
 
+OS_CATEGORIES = ['windows', 'mac', 'linux']
 
 class Parallelism(enum.IntEnum):
     """An enumeration listing the different types of parallelism applied to

--- a/volatility3/framework/interfaces/automagic.py
+++ b/volatility3/framework/interfaces/automagic.py
@@ -40,6 +40,9 @@ class AutomagicInterface(interfaces.configuration.ConfigurableInterface, metacla
     priority = 10
     """An ordering to indicate how soon this automagic should be run"""
 
+    exclusion_list = []
+    """A list of plugin categories (typically operating systems) which the plugin will not operate on"""
+
     def __init__(self, context: interfaces.context.ContextInterface, config_path: str, *args, **kwargs) -> None:
         super().__init__(context, config_path)
         for requirement in self.get_requirements():


### PR DESCRIPTION
Improves the documentation, and allows automagics to specify which operating systems the automagic will not work on.

Fixes #588 