### PR TITLE
QEMU: Take PCI-holes into account

### DIFF
--- a/volatility3/framework/layers/qemu.py
+++ b/volatility3/framework/layers/qemu.py
@@ -5,6 +5,7 @@ import functools
 import json
 import logging
 import re
+import struct
 from typing import Optional, Dict, Any, Tuple, List, Set
 
 from volatility3.framework import interfaces, exceptions, constants
@@ -192,9 +193,8 @@ class QemuSuspendLayer(segmented.NonLinearlySegmentedLayer):
         base_layer = self.context.layers[self._base_layer]
 
         while not done:
-            addr = self.context.object(self._qemu_table_name + constants.BANG + 'unsigned long long',
-                                       offset = index,
-                                       layer_name = self._base_layer)
+            # Use struct.unpack here for performance improvements
+            addr = struct.unpack('>Q', base_layer.read(index, 8))[0]
             # Flags are stored in the n least significant bits, where n equals the bit-length of pagesize
             flags = addr & (page_size - 1)
             # addr equals the highest multiple of pagesize <= offset

--- a/volatility3/framework/layers/qemu.py
+++ b/volatility3/framework/layers/qemu.py
@@ -111,10 +111,16 @@ class QemuSuspendLayer(segmented.NonLinearlySegmentedLayer):
 
         if architecture:
             if architecture[0] == 'i440fx':
-                if architecture[1] and architecture[1] < '2.0':
-                    start = 0xe0000000
+                if ram_size >= 0xe0000000:
+                    if architecture[1] and architecture[1] < '2.0':
+                        start = 0xe0000000
+                    else:
+                        start = 0xc0000000
                 else:
-                    start = 0xc0000000
+                    vollog.log(constants.LOGLEVEL_VV, f"No PCI-hole present in this memory layout "
+                                                      f"(PC i440FX + RAM size < 0xe0000000)")
+                    return None
+
             elif architecture[0] == 'q35':
                 if ram_size >= 0xb0000000:
                     start = 0x80000000


### PR DESCRIPTION
Fixes #587

What [seemed like](https://github.com/juergh/lqs2mem.py/blob/master/lqs2mem.py#L218) like a simple additional offset to take into account, ended up in implementing two methods:

- 1 for determining the current target architecture
- 1 for determining where the PCI-hole is located for that architecture (+ RAM size).

The difficulty lies in the fact that the location of PCI-hole cannot be easily retrieved directly from a memory dump (or at least I was not able to find an elegant solution to do so). Linux does have quite a bunch of informing `dmesg`-messages available in memory, but for Windows, this is not the case.

This is a best-effort approach. The default offsets are known, but users could use the `max-ram-below-4g`-parameter, which influences the size and location of the PCI-hole, Once again, this cannot be easily retrieved directly from a memory dump.

The MicroVM and Xen architectures haven't been implemented yet. Luckily, PC i440FX and Q35 are by far the most used QEMU target architectures.