### PR TITLE
Plugins: Update yarascan options

### DIFF
--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -3,7 +3,7 @@
 #
 
 import logging
-from typing import Iterable, Tuple, List, Dict, Any
+from typing import Any, Dict, Iterable, List, Tuple
 
 from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
@@ -40,7 +40,7 @@ class YaraScan(plugins.PluginInterface):
     """Scans kernel memory using yara rules (string or file)."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -83,6 +83,8 @@ class YaraScan(plugins.PluginInterface):
             if config.get('wide', False):
                 rule += " wide ascii"
             rules = yara.compile(sources = {'n': f'rule r1 {{strings: $a = {rule} condition: $a}}'})
+        elif config.get('yara_source', None) is not None:
+            rules = yara.compile(source = config['yara_source'])
         elif config.get('yara_file', None) is not None:
             rules = yara.compile(file = resources.ResourceAccessor().open(config['yara_file'], "rb"))
         elif config.get('yara_compiled_file', None) is not None:

--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -42,6 +42,9 @@ class YaraScan(plugins.PluginInterface):
     _required_framework_version = (2, 0, 0)
     _version = (1, 1, 0)
 
+    # TODO: When the major version is bumped, take the opportunity to rename the yara_rules config to yara_string
+    # or something that makes more sense
+
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [


### PR DESCRIPTION
Add in a yara_source option in the process method.  Unfortunately
yara_rules is still poorly named, but would require a major version
bump, so to avoid major disruption, we're just adding the yara_source
option instead.