### PR TITLE
Sessions Plugin

### DIFF
--- a/volatility3/framework/plugins/windows/sessions.py
+++ b/volatility3/framework/plugins/windows/sessions.py
@@ -1,0 +1,96 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import datetime
+import logging
+
+from volatility3.framework import renderers, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects import utility
+from volatility3.plugins.windows import pslist
+
+vollog = logging.getLogger(__name__)
+
+
+class Sessions(interfaces.plugins.PluginInterface):
+    """lists Processes with Session information extracted from Environmental Variables"""
+
+    _required_framework_version = (2, 0, 0)
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.TranslationLayerRequirement(name = 'primary',
+                                                     description = 'Memory layer for the kernel',
+                                                     architectures = ["Intel32", "Intel64"]),
+            requirements.SymbolTableRequirement(name = "nt_symbols", description = "Windows kernel symbols"),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.ListRequirement(name = 'pid',
+                                         element_type = int,
+                                         description = "Process IDs to include (all other processes are excluded)",
+                                         optional = True)
+        ]
+
+    def _generator(self, procs):
+
+        # Collect all the values as we will want to group them later
+        sessions = {}
+
+        for proc in procs:
+
+            session_id = proc.get_session_id()
+
+            # Detect RDP, Console or set default value
+            session_type = renderers.NotAvailableValue()
+
+            # Construct Username from Process Env
+            user_domain = ''
+            user_name = ''
+
+            for var, val in proc.environment_variables():
+                if var.lower() == 'username':
+                    user_name = val
+                elif var.lower() == 'userdomain':
+                    user_domain = val
+                if var.lower() == 'sessionname':
+                    session_type = val
+
+            # Concat Domain and User 
+            full_user = f'{user_domain}/{user_name}'
+            if full_user == '/':
+                full_user = renderers.NotAvailableValue()
+
+            # Collect all the values in to a row we can yield after sorting.
+            row = {
+                "session_id": session_id,
+                "process_id": proc.UniqueProcessId,
+                "process_name": utility.array_to_string(proc.ImageFileName),
+                "user_name": full_user,
+                "process_start": proc.get_create_time(),
+                "session_type": session_type
+            }
+
+            # Add row to correct session so we can sort it later
+            if session_id in sessions:
+                sessions[session_id].append(row)
+            else:
+                sessions[session_id] = [row]
+
+        # Group and yield each row
+        for rows in sessions.values():
+            for row in rows:
+                yield 0, (row.get('session_id'), row.get('session_type'), row.get('process_id'),
+                          row.get('process_name'), row.get('user_name'), row.get('process_start'))
+
+    def run(self):
+
+        filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
+
+        return renderers.TreeGrid([("Session ID", int), ('Session Type', str), ("Process ID", int), ("Process", str),
+                                   ("User Name", str), ("Create Time", datetime.datetime)],
+                                  self._generator(
+                                      pslist.PsList.list_processes(self.context,
+                                                                   self.config['primary'],
+                                                                   self.config['nt_symbols'],
+                                                                   filter_func = filter_func)))


### PR DESCRIPTION
Migration of the Vol2 windows sessions plugin.

This one uses existing data from the process and the envar to create a useful output for analysts. 

Example output (Partial)
```
  | Session ID | Session Type | Process ID |        Process |                  User Name |                 Create Time
* |          1 |      Console |       5776 | Rocket.Chat.ex |       SPARKSTUDIO/lfrazier | 2021-11-22 19:28:28.000000 
* |          1 |      Console |       5816 | Rocket.Chat.ex |       SPARKSTUDIO/lfrazier | 2021-11-22 19:28:28.000000 
* |          1 |      Console |       5824 | Rocket.Chat.ex |       SPARKSTUDIO/lfrazier | 2021-11-22 19:28:28.000000 
* |          2 |            - |       3180 |       smss.exe |                          - | 2021-11-22 19:27:51.000000 
* |          2 |            - |       3188 |      csrss.exe |                    /SYSTEM | 2021-11-22 19:27:51.000000 
* |          2 |            - |       3224 |   winlogon.exe |                    /SYSTEM | 2021-11-22 19:27:51.000000 
* |          2 |            - |       3376 |        dwm.exe |                    /SYSTEM | 2021-11-22 19:27:53.000000 
* |          2 |            - |       3016 |    rdpclip.exe |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:01.000000 
* |          2 |            - |       2336 |    svchost.exe |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:01.000000 
* |          2 |            - |       3388 |     sihost.exe |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:01.000000 
* |          2 |            - |       3796 |  taskhostw.exe |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:01.000000 
* |          2 |            - |       1276 | RuntimeBroker. |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:01.000000 
* |          2 |            - |       3856 |   userinit.exe |                          - | 2021-11-22 19:28:01.000000 
* |          2 |    RDP-Tcp#1 |       4112 |   explorer.exe |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:01.000000 
* |          2 |            - |       4396 | ShellExperienc |                          - | 2021-11-22 19:28:03.000000 
* |          2 |            - |       4764 |   SearchUI.exe |                          - | 2021-11-22 19:28:04.000000 
* |          2 |    RDP-Tcp#1 |       5268 | Rocket.Chat.ex |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:16.000000 
* |          2 |    RDP-Tcp#1 |       5784 | Rocket.Chat.ex |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:28.000000 
* |          2 |    RDP-Tcp#1 |       5832 | Rocket.Chat.ex |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:28.000000 
* |          2 |    RDP-Tcp#1 |       5840 | Rocket.Chat.ex |        SPARKSTUDIO/lportyr | 2021-11-22 19:28:28.000000 
* |          2 |    RDP-Tcp#1 |       4132 |     chrome.exe |        SPARKSTUDIO/lportyr | 2021-11-22 19:37:25.000000 


```

Vol2 output for comparison

```
Process: 5776 Rocket.Chat.ex 2021-11-22 19:28:28 UTC+0000
 Process: 5816 Rocket.Chat.ex 2021-11-22 19:28:28 UTC+0000
 Process: 5824 Rocket.Chat.ex 2021-11-22 19:28:28 UTC+0000
**************************************************
Session(V): ffff9101e2cc4000 ID: 2 Processes: 35
PagedPoolStart: ffff800380000000 PagedPoolEnd ffff80237fffffff
 Process: 3180 smss.exe 2021-11-22 19:27:51 UTC+0000
 Process: 3188 csrss.exe 2021-11-22 19:27:51 UTC+0000
 Process: 3224 winlogon.exe 2021-11-22 19:27:51 UTC+0000
 Process: 3376 dwm.exe 2021-11-22 19:27:53 UTC+0000
 Process: 3016 rdpclip.exe 2021-11-22 19:28:01 UTC+0000
 Process: 2336 svchost.exe 2021-11-22 19:28:01 UTC+0000
 Process: 3388 sihost.exe 2021-11-22 19:28:01 UTC+0000
 Process: 3796 taskhostw.exe 2021-11-22 19:28:01 UTC+0000
 Process: 1276 RuntimeBroker. 2021-11-22 19:28:01 UTC+0000
 Process: 3856 userinit.exe 2021-11-22 19:28:01 UTC+0000
 Process: 4112 explorer.exe 2021-11-22 19:28:01 UTC+0000
 Process: 4396 ShellExperienc 2021-11-22 19:28:03 UTC+0000
 Process: 4764 SearchUI.exe 2021-11-22 19:28:04 UTC+0000
```