### PR TITLE
Feature/isf unification

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Symbol tables zip files must be placed, as named, into the `volatility3/symbols`
 
 Windows symbols that cannot be found will be queried, downloaded, generated and cached.  Mac and Linux symbol tables must be manually produced by a tool such as [dwarf2json](https://github.com/volatilityfoundation/dwarf2json).
 
+Important: The first run of volatility with new symbol files will require the cache to be updated.  The symbol packs contain a large number of symbol files and so may take some time to update!
+However, this process only needs to be run once on each new symbol file, so assuming the pack stays in the same location will not need to be done again.  Please also note it can be interrupted and next run will restart itself.
+
 Please note: These are representative and are complete up to the point of creation for Windows and Mac.  Due to the ease of compiling Linux kernels and the inability to uniquely distinguish them, an exhaustive set of Linux symbol tables cannot easily be supplied.
 
 ## Documentation

--- a/doc/source/symbol-tables.rst
+++ b/doc/source/symbol-tables.rst
@@ -18,7 +18,9 @@ configurable within the framework and can usually be set within the user interfa
 These files can also be compressed into ZIP files, which Volatility will process in order to locate symbol files.
 
 Volatility maintains a cache mapping the appropriate identifier for each symbol file against its filename.  This cache
-is update by automagic called as part of the standard automagic that's run each time a plugin is run.
+is updated by automagic called as part of the standard automagic that's run each time a plugin is run.  If a large number of new
+symbols file are detected, this may take some time, but can be safely interrupted and restarted and will not need to run again
+as long as the symbol files stay in the same location.
 
 Windows symbol tables
 ---------------------

--- a/doc/source/symbol-tables.rst
+++ b/doc/source/symbol-tables.rst
@@ -12,20 +12,20 @@ Volatility will automatically decompress them on use.  It will also cache their 
 under the user's home directory, in :file:`.cache/volatility3`, along with other useful data.  The cache directory currently
 cannot be altered.
 
-Symbol table JSON files live, by default, under the :file:`volatility3/symbols`, underneath an operating system directory
-(currently one of :file:`windows`, :file:`mac` or :file:`linux`).  The symbols directory is configurable within the framework and can
-usually be set within the user interface.
+Symbol table JSON files live, by default, under the :file:`volatility3/symbols` directory.  The symbols directory is
+configurable within the framework and can usually be set within the user interface.
 
 These files can also be compressed into ZIP files, which Volatility will process in order to locate symbol files.
-The ZIP file must be named after the appropriate operating system (such as `linux.zip`, `mac.zip` or `windows.zip`).
-Inside the ZIP file, the directory structure should match the uncompressed operating system directory.
+
+Volatility maintains a cache mapping the appropriate identifier for each symbol file against its filename.  This cache
+is update by automagic called as part of the standard automagic that's run each time a plugin is run.
 
 Windows symbol tables
 ---------------------
 
 For Windows systems, Volatility accepts a string made up of the GUID and Age of the required PDB file.  It then
-searches all files under the configured symbol directories under the windows subdirectory.  Any that match the filename
-pattern of :file:`<pdb-name>/<GUID>-<AGE>.json` (or any compressed variant) will be used.  If such a symbol table cannot be found, then
+searches all files under the configured symbol directories under the windows subdirectory.  Any that contain metadata
+which matches the pdb name and GUID/age (or any compressed variant) will be used.  If such a symbol table cannot be found, then
 the associated PDB file will be downloaded from Microsoft's Symbol Server and converted into the appropriate JSON
 format, and will be saved in the correct location.
 
@@ -41,11 +41,10 @@ or a virtual environment.
 Mac/Linux symbol tables
 -----------------------
 
-For Mac/Linux systems, both use the same mechanism for identification.  JSON files live under the symbol directories,
-under either the :file:`linux` or :file:`mac` directories.  The generated files contain an identifying string (the operating system
+For Mac/Linux systems, both use the same mechanism for identification.  The generated files contain an identifying string (the operating system
 banner), which Volatility's automagic can detect.  Volatility caches the mapping between the strings and the symbol
 tables they come from, meaning the precise file names don't matter and can be organized under any necessary hierarchy
-under the operating system directory.
+under the symbols directory.
 
 Linux and Mac symbol tables can be generated from a DWARF file using a tool called `dwarf2json <https://github.com/volatilityfoundation/dwarf2json>`_.
 Currently a kernel with debugging symbols is the only suitable means for recovering all the information required by

--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -5,8 +5,9 @@
 import logging
 from typing import Optional, Tuple, Type
 
-from volatility3.framework import interfaces, constants
+from volatility3.framework import constants, interfaces
 from volatility3.framework.automagic import symbol_cache, symbol_finder
+from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import intel, scanners
 from volatility3.framework.symbols import linux
 
@@ -23,6 +24,13 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
               layer_name: str,
               progress_callback: constants.ProgressCallback = None) -> Optional[interfaces.layers.DataLayerInterface]:
         """Attempts to identify linux within this layer."""
+        # Version check the SQlite cache
+        required = (1, 0, 0)
+        if not requirements.VersionRequirement.matches_required(required, symbol_cache.SqliteCache.version):
+            vollog.info(
+                f"SQLiteCache version not suitable: required {required} found {symbol_cache.SqliteCache.version}")
+            return None
+
         # Bail out by default unless we can stack properly
         layer = context.layers[layer_name]
         join = interfaces.configuration.path_join
@@ -32,7 +40,8 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
         if isinstance(layer, intel.Intel):
             return None
 
-        linux_banners = LinuxBannerCache.load_banners()
+        linux_banners = symbol_cache.SqliteCache(constants.IDENTIFIERS_PATH).get_identifier_dictionary(
+            operating_system = 'linux')
         # If we have no banners, don't bother scanning
         if not linux_banners:
             vollog.info("No Linux banners found - if this is a linux plugin, please check your symbol files location")
@@ -43,15 +52,8 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
             dtb = None
             vollog.debug(f"Identified banner: {repr(banner)}")
 
-            symbol_files = linux_banners.get(banner, None)
-            if symbol_files:
-                if len(symbol_files) > 1:
-                    using = "*"
-                    vollog.warning(f"Multiple symbol files identified (using {using}):")
-                    for symbol_file in symbol_files:
-                        vollog.warning(f" {using} {symbol_file}")
-                        using = " "
-                isf_path = symbol_files[0]
+            isf_path = linux_banners.get(banner, None)
+            if isf_path:
                 table_name = context.symbol_space.free_table_name('LintelStacker')
                 table = linux.LinuxKernelIntermedSymbols(context,
                                                          'temporary.' + table_name,
@@ -147,20 +149,11 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
         return addr - 0xc0000000
 
 
-class LinuxBannerCache(symbol_cache.SymbolBannerCache):
-    """Caches the banners found in the Linux symbol files."""
-
-    os = "linux"
-    symbol_name = "linux_banner"
-    banner_path = constants.LINUX_BANNERS_PATH
-    exclusion_list = ['mac', 'windows']
-
-
 class LinuxSymbolFinder(symbol_finder.SymbolFinder):
     """Linux symbol loader based on uname signature strings."""
 
     banner_config_key = "kernel_banner"
-    banner_cache = LinuxBannerCache
+    operating_system = 'linux'
     symbol_class = "volatility3.framework.symbols.linux.LinuxKernelIntermedSymbols"
     find_aslr = lambda cls, *args: LinuxIntelStacker.find_aslr(*args)[1]
     exclusion_list = ['mac', 'windows']

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -6,8 +6,9 @@ import logging
 import struct
 from typing import Optional
 
-from volatility3.framework import interfaces, constants, layers, exceptions
+from volatility3.framework import constants, exceptions, interfaces, layers
 from volatility3.framework.automagic import symbol_cache, symbol_finder
+from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import intel, scanners
 from volatility3.framework.symbols import mac
 
@@ -24,6 +25,13 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
               layer_name: str,
               progress_callback: constants.ProgressCallback = None) -> Optional[interfaces.layers.DataLayerInterface]:
         """Attempts to identify mac within this layer."""
+        # Version check the SQlite cache
+        required = (1, 0, 0)
+        if not requirements.VersionRequirement.matches_required(required, symbol_cache.SqliteCache.version):
+            vollog.info(
+                f"SQLiteCache version not suitable: required {required} found {symbol_cache.SqliteCache.version}")
+            return None
+
         # Bail out by default unless we can stack properly
         layer = context.layers[layer_name]
         new_layer = None
@@ -34,7 +42,8 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
         if isinstance(layer, intel.Intel):
             return None
 
-        mac_banners = MacBannerCache.load_banners()
+        mac_banners = symbol_cache.SqliteCache(constants.IDENTIFIERS_PATH).get_identifier_dictionary(
+            operating_system = 'mac')
         # If we have no banners, don't bother scanning
         if not mac_banners:
             vollog.info("No Mac banners found - if this is a mac plugin, please check your symbol files location")
@@ -46,9 +55,8 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
             dtb = None
             vollog.debug(f"Identified banner: {repr(banner)}")
 
-            symbol_files = mac_banners.get(banner, None)
-            if symbol_files:
-                isf_path = symbol_files[0]
+            isf_path = mac_banners.get(banner, None)
+            if isf_path:
                 table_name = context.symbol_space.free_table_name('MacintelStacker')
                 table = mac.MacKernelIntermedSymbols(context = context,
                                                      config_path = join('temporary', table_name),
@@ -197,19 +205,11 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
             yield offset, banner
 
 
-class MacBannerCache(symbol_cache.SymbolBannerCache):
-    """Caches the banners found in the Mac symbol files."""
-    os = "mac"
-    symbol_name = "version"
-    banner_path = constants.MAC_BANNERS_PATH
-    exclusion_list = ['windows', 'linux']
-
-
 class MacSymbolFinder(symbol_finder.SymbolFinder):
     """Mac symbol loader based on uname signature strings."""
 
     banner_config_key = 'kernel_banner'
-    banner_cache = MacBannerCache
+    operating_system = 'mac'
     find_aslr = MacIntelStacker.find_aslr
     symbol_class = "volatility3.framework.symbols.mac.MacKernelIntermedSymbols"
     exclusion_list = ['windows', 'linux']

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -169,7 +169,7 @@ class SqliteCache(CacheManagerInterface):
             os.unlink(filename)
             self._database = self._connect_storage(filename)
 
-    def _connect_storage(self, path: str):
+    def _connect_storage(self, path: str) -> sqlite3.Connection:
         database = sqlite3.connect(path)
         database.row_factory = sqlite3.Row
         database.cursor().execute(

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -284,7 +284,7 @@ class SqliteCache(CacheManagerInterface):
                 f"SELECT cached FROM cache WHERE remote = True and cached < datetime('now', {self.cache_period})")
             remote_identifiers = RemoteIdentifierFormat(constants.REMOTE_ISF_URL)
             progress_callback(50, 'Reading remote ISF list')
-            for operating_system in ['mac', 'linux', 'windows']:
+            for operating_system in constants.OS_CATEGORIES:
                 identifiers = remote_identifiers.process({}, operating_system = operating_system)
                 for identifier, location in identifiers:
                     cursor.execute(

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -347,7 +347,7 @@ class SqliteCache(CacheManagerInterface):
 
         if missing_locations:
             self._database.cursor().execute(
-                f"DELETE FROM cache WHERE location IN ({','.join(['?'] * len(missing_locations))})", *missing_locations)
+                f"DELETE FROM cache WHERE location IN ({','.join(['?'] * len(missing_locations))})", [x for x in missing_locations])
             self._database.commit()
 
     def get_identifier_dictionary(self, operating_system: Optional[str] = None, local_only: bool = False) -> \

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -276,7 +276,7 @@ class SqliteCache(CacheManagerInterface):
         number_files_to_process = len(files_to_process)
         cursor = self._database.cursor()
         try:
-            for location in files_to_process:
+            for counter, location in enumerate(files_to_process):
                 # Open location
                 counter += 1
                 progress_callback(counter * 100 / number_files_to_process,

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -271,14 +271,12 @@ class SqliteCache(CacheManagerInterface):
 
         # New or not recently updated
 
-        counter = 0
         files_to_process = new_locations.union(cache_update)
         number_files_to_process = len(files_to_process)
         cursor = self._database.cursor()
         try:
             for counter, location in enumerate(files_to_process):
                 # Open location
-                counter += 1
                 progress_callback(counter * 100 / number_files_to_process,
                                   f"Updating caches for {number_files_to_process} files...")
                 try:

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -426,7 +426,6 @@ class RemoteIdentifierFormat:
         if operating_system in self._data:
             for identifier in self._data[operating_system]:
                 binary_identifier = base64.b64decode(identifier)
-                file_list = identifiers.get(binary_identifier, [])
                 for value in self._data[operating_system][identifier]:
                     yield binary_identifier, value
         if 'additional' in self._data:

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -10,7 +10,7 @@ import urllib
 import urllib.parse
 import urllib.request
 from abc import abstractmethod
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import Dict, Generator, Iterable, List, Optional, Tuple
 
 import volatility3.framework
 import volatility3.schemas
@@ -113,7 +113,7 @@ class CacheManagerInterface(interfaces.configuration.VersionableInterface):
         """
         pass
 
-    def get_local_locations(self) -> List[str]:
+    def get_local_locations(self) -> Iterable[str]:
         """Returns a list of all the local locations"""
         pass
 
@@ -141,7 +141,7 @@ class CacheManagerInterface(interfaces.configuration.VersionableInterface):
         """Returns an identifier based on a specific location or None"""
         pass
 
-    def get_identifiers(self, operating_system: Optional[str]):
+    def get_identifiers(self, operating_system: Optional[str]) -> List[bytes]:
         """Returns all identifiers for a particular operating system"""
         pass
 
@@ -369,7 +369,7 @@ class SqliteCache(CacheManagerInterface):
             output[row['identifier']] = row['location']
         return output
 
-    def get_identifiers(self, operating_system: Optional[str]):
+    def get_identifiers(self, operating_system: Optional[str]) -> List[bytes]:
         if operating_system:
             results = self._database.cursor().execute('SELECT identifier FROM cache WHERE operating_system = ?',
                                                       (operating_system,)).fetchall()

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -151,7 +151,7 @@ class CacheManagerInterface(interfaces.configuration.VersionableInterface):
         Returns:
             A tuple of base_types, types, enums, symbols, or None is location not found"""
 
-    def get_hash(self, location: str) -> bool:
+    def get_hash(self, location: str) -> Optional[str]:
         """Returns the hash of the JSON from within a location ISF"""
 
 

--- a/volatility3/framework/automagic/symbol_finder.py
+++ b/volatility3/framework/automagic/symbol_finder.py
@@ -3,9 +3,9 @@
 #
 
 import logging
-from typing import Any, Iterable, List, Tuple, Type, Optional, Callable
+from typing import Any, Callable, Iterable, List, Optional, Tuple
 
-from volatility3.framework import interfaces, constants, layers
+from volatility3.framework import constants, interfaces, layers
 from volatility3.framework.automagic import symbol_cache
 from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import scanners
@@ -18,7 +18,7 @@ class SymbolFinder(interfaces.automagic.AutomagicInterface):
     priority = 40
 
     banner_config_key: str = "banner"
-    banner_cache: Optional[Type[symbol_cache.SymbolBannerCache]] = None
+    operating_system: Optional[str] = None
     symbol_class: Optional[str] = None
     find_aslr: Optional[Callable] = None
 
@@ -27,14 +27,21 @@ class SymbolFinder(interfaces.automagic.AutomagicInterface):
         self._requirements: List[Tuple[str, interfaces.configuration.RequirementInterface]] = []
         self._banners: symbol_cache.BannersType = {}
 
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.VersionRequirement(name = 'SQLiteCache',
+                                            component = symbol_cache.SqliteCache,
+                                            version = (1, 0, 0))
+        ]
+
     @property
     def banners(self) -> symbol_cache.BannersType:
         """Creates a cached copy of the results, but only it's been
         requested."""
         if not self._banners:
-            if not self.banner_cache:
-                raise RuntimeError(f"Cache has not been properly defined for {self.__class__.__name__}")
-            self._banners = self.banner_cache.load_banners()
+            cache = symbol_cache.SqliteCache(constants.IDENTIFIERS_PATH)
+            self._banners = cache.get_identifier_dictionary(operating_system = self.operating_system)
         return self._banners
 
     def __call__(self,
@@ -103,8 +110,8 @@ class SymbolFinder(interfaces.automagic.AutomagicInterface):
             vollog.debug(f"Identified banner: {repr(banner)}")
             symbol_files = self.banners.get(banner, None)
             if symbol_files:
-                isf_path = symbol_files[0]
-                vollog.debug(f"Using symbol library: {symbol_files[0]}")
+                isf_path = symbol_files
+                vollog.debug(f"Using symbol library: {symbol_files}")
                 clazz = self.symbol_class
                 # Set the discovered options
                 path_join = interfaces.configuration.path_join
@@ -117,7 +124,7 @@ class SymbolFinder(interfaces.automagic.AutomagicInterface):
                 break
             else:
                 if symbol_files:
-                    vollog.debug(f"Symbol library path not found: {symbol_files[0]}")
+                    vollog.debug(f"Symbol library path not found: {symbol_files}")
                     # print("Kernel", banner, hex(banner_offset))
         else:
             vollog.debug("No existing banners found")

--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -414,7 +414,7 @@ class VersionRequirement(interfaces.configuration.RequirementInterface):
         return {}
 
     @classmethod
-    def matches_required(cls, required: Tuple[int, ...], version: Tuple[int, int, int]):
+    def matches_required(cls, required: Tuple[int, ...], version: Tuple[int, int, int]) -> bool:
         if len(required) > 0 and version[0] != required[0]:
             return False
         if len(required) > 1 and version[1] < required[1]:

--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -408,12 +408,18 @@ class VersionRequirement(interfaces.configuration.RequirementInterface):
                     config_path: str) -> Dict[str, interfaces.configuration.RequirementInterface]:
         # Mypy doesn't appreciate our classproperty implementation, self._plugin.version has no type
         config_path = interfaces.configuration.path_join(config_path, self.name)
-        if len(self._version) > 0 and self._component.version[0] != self._version[0]:
-            return {config_path: self}
-        if len(self._version) > 1 and self._component.version[1] < self._version[1]:
+        if not self.matches_required(self._version, self._component.version):
             return {config_path: self}
         context.config[interfaces.configuration.path_join(config_path, self.name)] = True
         return {}
+
+    @classmethod
+    def matches_required(cls, required: Tuple[int, ...], version: Tuple[int, int, int]):
+        if len(required) > 0 and version[0] != required[0]:
+            return False
+        if len(required) > 1 and version[1] < required[1]:
+            return False
+        return True
 
 
 class PluginRequirement(VersionRequirement):

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -68,10 +68,13 @@ if sys.platform == 'win32':
 os.makedirs(CACHE_PATH, exist_ok = True)
 
 LINUX_BANNERS_PATH = os.path.join(CACHE_PATH, "linux_banners.cache")
-""""Default location to record information about available linux banners"""
+"""Default location to record information about available linux banners"""
 
 MAC_BANNERS_PATH = os.path.join(CACHE_PATH, "mac_banners.cache")
-""""Default location to record information about available mac banners"""
+"""Default location to record information about available mac banners"""
+
+IDENTIFIERS_PATH = os.path.join(CACHE_PATH, "identifiers.cache")
+"""Default location to record information about available identifiers"""
 
 BUG_URL = "https://github.com/volatilityfoundation/volatility3/issues"
 

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -76,6 +76,9 @@ MAC_BANNERS_PATH = os.path.join(CACHE_PATH, "mac_banners.cache")
 IDENTIFIERS_PATH = os.path.join(CACHE_PATH, "identifiers.cache")
 """Default location to record information about available identifiers"""
 
+CACHE_SQLITE_SCEMA_VERSION = 1
+"""Version for the sqlite3 cache schema"""
+
 BUG_URL = "https://github.com/volatilityfoundation/volatility3/issues"
 
 ProgressCallback = Optional[Callable[[float, str], None]]

--- a/volatility3/framework/interfaces/automagic.py
+++ b/volatility3/framework/interfaces/automagic.py
@@ -9,9 +9,9 @@ that a user has not filled.
 """
 import logging
 from abc import ABCMeta
-from typing import Any, List, Optional, Tuple, Union, Type
+from typing import Any, List, Optional, Tuple, Type, Union
 
-from volatility3.framework import interfaces, constants
+from volatility3.framework import constants, interfaces
 from volatility3.framework.configuration import requirements
 
 vollog = logging.getLogger(__name__)
@@ -47,9 +47,10 @@ class AutomagicInterface(interfaces.configuration.ConfigurableInterface, metacla
         super().__init__(context, config_path)
         for requirement in self.get_requirements():
             if not isinstance(requirement, (interfaces.configuration.SimpleTypeRequirement,
-                                            requirements.ChoiceRequirement, requirements.ListRequirement)):
+                                            requirements.ChoiceRequirement, requirements.ListRequirement,
+                                            requirements.VersionRequirement)):
                 raise TypeError(
-                    "Automagic requirements must be a SimpleTypeRequirement, ChoiceRequirement or ListRequirement")
+                    "Automagic requirements must be a SimpleTypeRequirement, ChoiceRequirement, ListRequirement or VersionRequirement")
 
     def __call__(self,
                  context: interfaces.context.ContextInterface,

--- a/volatility3/framework/plugins/isfinfo.py
+++ b/volatility3/framework/plugins/isfinfo.py
@@ -144,4 +144,4 @@ class IsfInfo(plugins.PluginInterface):
     def run(self):
         return renderers.TreeGrid([("URI", str), ("Valid", str),
                                    ("Number of base_types", int), ("Number of types", int), ("Number of symbols", int),
-                                   ("Number of enums", int), ("Identifying infomration", str)], self._generator())
+                                   ("Number of enums", int), ("Identifying information", str)], self._generator())

--- a/volatility3/framework/symbols/intermed.py
+++ b/volatility3/framework/symbols/intermed.py
@@ -202,8 +202,7 @@ class IntermediateSymbolTable(interfaces.symbols.SymbolTableInterface):
                     pass
 
             # Finally try looking in zip files
-            zip_path = os.path.join(path, sub_path + ".zip")
-            if os.path.exists(zip_path):
+            for zip_path in pathlib.Path(path).joinpath(sub_path).resolve().rglob(filename + '.zip'):
                 # We have a zipfile, so run through it and look for sub files that match the filename
                 with zipfile.ZipFile(zip_path) as zfile:
                     for name in zfile.namelist():

--- a/volatility3/framework/symbols/windows/pdbconv.py
+++ b/volatility3/framework/symbols/windows/pdbconv.py
@@ -521,7 +521,7 @@ class PdbReader:
 
         self.metadata['windows']['pdb'] = {
             "GUID": self.convert_bytes_to_guid(pdb_info.GUID),
-            "age": pdb_info.age,
+            "age": self._dbiheader.age,
             "database": self._database_name or 'unknown.pdb',
             "machine_type": self._dbiheader.machine
         }

--- a/volatility3/schemas/__init__.py
+++ b/volatility3/schemas/__init__.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import logging
 import os
-from typing import Set, Any, Dict
+from typing import Any, Dict, Optional, Set
 
 from volatility3.framework import constants
 
@@ -51,9 +51,21 @@ def validate(input: Dict[str, Any], use_cache: bool = True) -> bool:
     return valid(input, schema, use_cache)
 
 
-def create_json_hash(input: Dict[str, Any], schema: Dict[str, Any]) -> str:
+def create_json_hash(input: Dict[str, Any], schema: Optional[Dict[str, Any]] = None) -> Optional[str]:
     """Constructs the hash of the input and schema to create a unique
     identifier for a particular JSON file."""
+    if schema is None:
+        format = input.get('metadata', {}).get('format', None)
+        if not format:
+            vollog.debug("No schema format defined")
+            return None
+        basepath = os.path.abspath(os.path.dirname(__file__))
+        schema_path = os.path.join(basepath, 'schema-' + format + '.json')
+        if not os.path.exists(schema_path):
+            vollog.debug(f"Schema for format not found: {schema_path}")
+            return None
+        with open(schema_path, 'r') as s:
+            schema = json.load(s)
     return hashlib.sha1(bytes(json.dumps((input, schema), sort_keys = True), 'utf-8')).hexdigest()
 
 


### PR DESCRIPTION
Big, but hopefully unnoticable change to how we handle a generic list of identifiers and ISF files.  Previously this was only used for linux/mac, and the identifiers were the banner, however the guid/age/pdbname could also be used as an identifier for windows ISF files.  This luckily *should* be stored in the ISF files in the metadata section, and the autogeneration code of volatility has always done this.  Previously volatility used the file name and location to identify and load the right ISF for windows.

Now, the various OSes are unified under a single cache and allows symbol files to be dropped under any name in any subdirectory under the symbols directory.  The primary implementation stores the data in a database that's updated each run (the first run will take a while depending on how many ISF files there are).  If the database ever is corrupted, it's wiped and starts again, so it shouldn't be possible for a bad cache to hang volatility, but it's worth checking.  The database *can* return multiple locations for a single identifier (although each location can only store one identifier), but that should result in warnings.|

ISF files are allowed to not contain an identifier, but then they must not have an operating system associated with them.  The changes should not have been relied on, however the sqlcache is versionable to make sure that internal components that use it can check it's the right implementation (the interface isn't versioned, perhaps it should be instead of the concrete implementation?).\

isfinfo now makes use of it, as does the pdbutility code.

I think that covers everything, but this could do with a fair amount of tire kicking.  There's been a lot changed and it could almost certainly do with tweaks, both in terms of bugs and in terms of how it's architected.  Going to wait for review on this rather than the usual week for review...