### PR TITLE
Fix: typo for Windows constants code comment.

### DIFF
--- a/volatility3/framework/constants/windows/__init__.py
+++ b/volatility3/framework/constants/windows/__init__.py
@@ -1,7 +1,7 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-"""Volatility 3 Linux Constants.
+"""Volatility 3 Windows Constants.
 
 Windows-specific values that aren't found in debug symbols
 """


### PR DESCRIPTION
Hello, I'm a security engineer interested in the Volatility3 project.
I found some typo error while analyzing the Volatility3 code.
So, I corrected the typo written in "Linux" in the code comments of Windows Constants.