### PR TITLE
Fixed pdb scanning bug

### DIFF
--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -357,4 +357,4 @@ class PdbSignatureScanner(interfaces.layers.ScannerInterface):
 
                 guid = (16 * '{:02X}').format(g0, g1, g2, g3, g4, g5, g6, g7, g8, g9, ga, gb, gc, gd, ge, gf)
                 if match.start(0) < self.chunk_size:
-                    yield (guid, a, pdb_name, match.start(0))
+                    yield (guid, a, pdb_name, data_offset + match.start(0))


### PR DESCRIPTION
Added missing `data_offset` to pattern matching result. This fixes an issue in identifying Windows PDB records. 

_Previous versions of this code used to have this fix_. See the change in the yield (line 362), in commit c5c726ab2865966597b647576e20dbf6175b7aa3