### PR TITLE
Object information ChainMap invalid order

### DIFF
--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -115,7 +115,7 @@ class ObjectInterface(metaclass = abc.ABCMeta):
         mask = context.layers[object_info.layer_name].address_mask
         normalized_offset = object_info.offset & mask
 
-        self._vol = collections.ChainMap({}, object_info, {'type_name': type_name, 'offset': normalized_offset}, kwargs)
+        self._vol = collections.ChainMap({}, {'type_name': type_name, 'offset': normalized_offset}, object_info, kwargs)
         self._context = context
 
     def __getattr__(self, attr: str) -> Any:

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -136,7 +136,7 @@ class PrimitiveObject(interfaces.objects.ObjectInterface):
             if k not in ["context", "data_format", "object_info", "type_name"]:
                 kwargs[k] = v
         kwargs['new_value'] = self.__new_value
-        return (self._context, self._vol.maps[-2]['type_name'], self._vol.maps[-3], self._data_format), kwargs
+        return (self._context, self._vol.maps[-3]['type_name'], self._vol.maps[-2], self._data_format), kwargs
 
     @classmethod
     def _unmarshall(cls, context: interfaces.context.ContextInterface, data_format: DataFormatInfo,


### PR DESCRIPTION
When creating the `self._vol` the input is the new dict with the masked offset and the original `object_info`.
By passing the `object_info` first the `normalized_offset` is not accessible.
Example:
```
context.object("function", offset=0xffffffff80000000, ...).vol.offset == 0xffffffff80000000 # problem
context.object("function", offset=0xffff80000000,     ...).vol.offset == 0xffffffff80000000 # ok
```
By reversing the order we get the expected offset.