### PR TITLE
Fix read whole module

### DIFF
--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -146,7 +146,7 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
         max_size = pe_data.OPTIONAL_HEADER.SizeOfImage
 
         # Proper data
-        virtual_data = layer.read(offset, max_size)
+        virtual_data = layer.read(offset, max_size, pad=True)
         pe_data = pefile.PE(data = virtual_data)
 
         # De-virtualize the memory


### PR DESCRIPTION
When calling `get_guid_from_mz` the whole module is read from memory.

I have a dump where one page in the module was paged out, and therefore an exception was thrown (even though the rest of the pages are valid). With this little fix the executable parsing works correctly and the PDB is fetched.