### PR TITLE
Layers: Fix opening UNC paths on windows

### DIFF
--- a/volatility3/framework/layers/resources.py
+++ b/volatility3/framework/layers/resources.py
@@ -105,7 +105,9 @@ class ResourceAccessor(object):
         if sys.platform == 'win32':
             # We only need to worry about UNC paths on windows, on linux they'd be smb:// and need pysmb or similar
             parsed_url = urllib.parse.urlparse(url, scheme = 'file')
-            if parsed_url.scheme == 'file' and parsed_url.netloc:
+            # Only worry about file scheme URLs, make sure that there's either a host or
+            # the unparsing left an extra slash at the start (which will get lost with urlunparse)
+            if parsed_url.scheme == 'file' and (parsed_url.netloc or parsed_url.path.startswith('//')):
                 # Change the netloc to '/' and then prepend the netloc to the path
                 # Urlunparse will remove extra initial slashes from path, hence setting netloc
                 new_url = urllib.parse.urlunparse((parsed_url.scheme, '/',

--- a/volatility3/framework/layers/resources.py
+++ b/volatility3/framework/layers/resources.py
@@ -10,10 +10,11 @@ import logging
 import lzma
 import os
 import ssl
+import sys
 import urllib.parse
 import urllib.request
 import zipfile
-from typing import Optional, Any, IO, List
+from typing import Any, IO, List, Optional
 from urllib import error
 
 from volatility3 import framework
@@ -99,6 +100,19 @@ class ResourceAccessor(object):
         If the file is remote, it will be downloaded and locally cached
         """
         urllib.request.install_opener(urllib.request.build_opener(*self._handlers))
+
+        # Python bug 46654
+        if sys.platform == 'win32':
+            # We only need to worry about UNC paths on windows, on linux they'd be smb:// and need pysmb or similar
+            parsed_url = urllib.parse.urlparse(url, scheme = 'file')
+            if parsed_url.scheme == 'file' and parsed_url.netloc:
+                # Change the netloc to '/' and then prepend the netloc to the path
+                # Urlunparse will remove extra initial slashes from path, hence setting netloc
+                new_url = urllib.parse.urlunparse((parsed_url.scheme, '/',
+                                                   '/' + parsed_url.netloc + parsed_url.path, parsed_url.params,
+                                                   parsed_url.query, parsed_url.fragment))
+                vollog.log(constants.LOGLEVEL_VVVV, f'UNC path detected, converted path {url} to {new_url}')
+                url = new_url
 
         try:
             fp = urllib.request.urlopen(url, context = self._context)


### PR DESCRIPTION
Fixes #627  

I'm kind of happier with this, it applies to all URLs we try to open and if it's ever a file with a host on windows, then it gets additional slashes added (which currently urlopen can handle, whereas the other form of the same URL it can't).

Existing URLs either shouldn't have a netloc and file scheme on windows, or will get an additional slash added.  Urlunparse will swallow all starting slashes in `path` except one, so we make sure to set `netloc` to `/` if it's already a quadruple slashed URL.