### PR TITLE
Objects: Don't try to read 0 bytes when unmarshalling

### DIFF
--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -142,10 +142,9 @@ class PrimitiveObject(interfaces.objects.ObjectInterface):
     def _unmarshall(cls, context: interfaces.context.ContextInterface, data_format: DataFormatInfo,
                     object_info: interfaces.objects.ObjectInformation) -> TUnion[int, float, bool, bytes, str]:
         # Don't try to lookup a 0 length data format, incase it's at an invalid offset.  Length 0 means b''
+        data = b''
         if data_format.length > 0:
             data = context.layers.read(object_info.layer_name, object_info.offset, data_format.length)
-        else:
-            data = b''
         return convert_data_to_value(data, cls._struct_type, data_format)
 
     class VolTemplateProxy(interfaces.objects.ObjectInterface.VolTemplateProxy):

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -141,7 +141,11 @@ class PrimitiveObject(interfaces.objects.ObjectInterface):
     @classmethod
     def _unmarshall(cls, context: interfaces.context.ContextInterface, data_format: DataFormatInfo,
                     object_info: interfaces.objects.ObjectInformation) -> TUnion[int, float, bool, bytes, str]:
-        data = context.layers.read(object_info.layer_name, object_info.offset, data_format.length)
+        # Don't try to lookup a 0 length data format, incase it's at an invalid offset.  Length 0 means b''
+        if data_format.length > 0:
+            data = context.layers.read(object_info.layer_name, object_info.offset, data_format.length)
+        else:
+            data = b''
         return convert_data_to_value(data, cls._struct_type, data_format)
 
     class VolTemplateProxy(interfaces.objects.ObjectInterface.VolTemplateProxy):


### PR DESCRIPTION
Closes #652.

This patch fixes unicode `get_string` on 0 length by firstly, constructing the string directly rather than dereferencing to a null pointer and then building a string.  This allows for the second change, which allows construction of a string object (any primitive of 0 length) to avoid reading the layer if the string `max_length` is 0. 