### PR TITLE
Improving --config and --write-config

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -104,8 +104,10 @@ class CommandLine:
                 parser.prog))
         parser.add_argument("-c",
                             "--config",
+                            nargs='?',
                             help = "Load the configuration from a json file",
                             default = None,
+                            const= "",
                             type = str)
         parser.add_argument("--parallelism",
                             help = "Enables parallelism (defaults to off if no argument given)",
@@ -274,6 +276,7 @@ class CommandLine:
         # It has to go here so it can be overridden by single-location if it's defined
         # NOTE: This will *BREAK* if LayerStacker, or the automagic configuration system, changes at all
         ###
+        single_location = None
         if args.file:
             try:
                 single_location = self.location_from_file(args.file)
@@ -282,10 +285,15 @@ class CommandLine:
                 parser.error(str(excp))
 
         # UI fills in the config, here we load it from the config file and do it before we process the CL parameters
-        if args.config:
-            with open(args.config, "r") as f:
-                json_val = json.load(f)
-                ctx.config.splice(plugin_config_path, interfaces.configuration.HierarchicalDict(json_val))
+        if args.config is not None:
+            config_path = args.config
+            if config_path == "":
+                config_path = f"{os.path.basename(parse.urlparse(single_location).path)}.json"
+            if os.path.exists(config_path):
+                with open(config_path, "r") as f:
+                    vollog.debug(f"Read out configuration data from {config_path}")
+                    json_val = json.load(f)
+                    ctx.config.splice(plugin_config_path, interfaces.configuration.HierarchicalDict(json_val))
 
         # It should be up to the UI to determine which automagics to run, so this is before BACK TO THE FRAMEWORK
         automagics = automagic.choose_automagic(automagics, plugin)
@@ -319,9 +327,10 @@ class CommandLine:
             constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
                                                    self.file_handler_class_factory())
 
-            if args.write_config:
-                vollog.debug("Writing out configuration data to config.json")
-                with open("config.json", "w") as f:
+            if single_location is not None and args.write_config:
+                config_filename = f"{os.path.basename(parse.urlparse(single_location).path)}.json"
+                vollog.debug(f"Writing out configuration data to {config_filename}")
+                with open(config_filename, "w") as f:
                     json.dump(dict(constructed.build_configuration()), f, sort_keys = True, indent = 2)
         except exceptions.UnsatisfiedException as excp:
             self.process_unsatisfied_exceptions(excp)

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -294,6 +294,8 @@ class CommandLine:
                     vollog.debug(f"Read out configuration data from {config_path}")
                     json_val = json.load(f)
                     ctx.config.splice(plugin_config_path, interfaces.configuration.HierarchicalDict(json_val))
+            else:
+                vollog.warning(f"{config_path} does not exist. No configuration was read!")
 
         # It should be up to the UI to determine which automagics to run, so this is before BACK TO THE FRAMEWORK
         automagics = automagic.choose_automagic(automagics, plugin)


### PR DESCRIPTION
For automation it's better to specify both `--config` and `--write-config`. Under these circumstances, an existing config is used, or will be created.
This PR generates the config file name based on `single_location`.

With this improvement you can run:
```
vol.py -f FILE_LOCATION --config --write-config windows.pslist
```
This will work without an existing config (and will write it anyways).

If you want to use the default config for the FILE_LOCATION without the --write-config you need to write
```
vol.py -f FILE_LOCATION --config="" windows.pslist
```
(Otherwise, argparse will consider `windows.pslist` as the config path)

This improvement is better for automation because the script doesn't need to keep track of whether a configuration was create already or not.

Right now I think this improvement fits the CLI usage best, but in the future this can also be implemented in volshell if requested.
Of course you can still also run the plugin without the `FILE_LOCATION` if the config is specified and config files created in the past will still work.
