### PR TITLE
task_struct get all threads from the parent task.

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -201,6 +201,24 @@ class task_struct(generic.GenericIntelProcess):
 
             yield (start, end - start)
 
+    def get_thread_nodes(self) -> Iterable[interfaces.objects.ObjectInterface]:
+        """Returns a list of the task_struct based on the list_head 
+        thread_node structure."""
+
+        task_symbol_table_name = self.get_symbol_table_name()
+
+        parent = self.group_leader
+        for task in self.thread_node.to_list(
+            f"{task_symbol_table_name}{constants.BANG}task_struct",
+            "thread_node"
+        ):
+
+            if task.group_leader != parent: continue
+
+            yield task
+
+
+
 
 class fs_struct(objects.StructType):
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -201,24 +201,21 @@ class task_struct(generic.GenericIntelProcess):
 
             yield (start, end - start)
 
-    def get_thread_nodes(self) -> Iterable[interfaces.objects.ObjectInterface]:
+    def get_threads(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Returns a list of the task_struct based on the list_head 
         thread_node structure."""
 
         task_symbol_table_name = self.get_symbol_table_name()
 
-        parent = self.group_leader
-        for task in self.thread_node.to_list(
+        # iterating through the thread_list from thread_group
+        # this allows iterating through pointers to grab the 
+        # threads and using the thread_group offset to get the 
+        # corresponding task_struct
+        for task in self.thread_group.to_list(
             f"{task_symbol_table_name}{constants.BANG}task_struct",
-            "thread_node"
+            "thread_group"
         ):
-
-            if task.group_leader != parent: continue
-
             yield task
-
-
-
 
 class fs_struct(objects.StructType):
 


### PR DESCRIPTION
Hello,

I found myself wanting to go through the thread_nodes of a given process often for Linux images. Thought other people who are developing plugins or other modules may find this useful when dealing with the task_struct. The picture bellow shows what this small function does.

![image](https://user-images.githubusercontent.com/34222183/156952901-2b629ad0-c8c7-4dd2-acc2-d9cf0e7229f8.png)