### PR TITLE
Windows Malfind is_vad_empty error

### DIFF
--- a/volatility3/framework/plugins/windows/malfind.py
+++ b/volatility3/framework/plugins/windows/malfind.py
@@ -53,7 +53,7 @@ class Malfind(interfaces.plugins.PluginInterface):
         """
 
         CHUNK_SIZE = 0x1000
-        all_zero_page = "\x00" * CHUNK_SIZE
+        all_zero_page = b"\x00" * CHUNK_SIZE
 
         offset = 0
         vad_length = vad.get_end() - vad.get_start()


### PR DESCRIPTION
The `is_vad_empty` all_zero_page is `str` and not `bytes` as it should be.
Therefore `is_vad_empty` will always return `False`

This fixes that issue.