### PR TITLE
Implement `--save-config <filename>` option to replace `--write-config`

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -324,18 +324,13 @@ class CommandLine:
             constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
                                                    self.file_handler_class_factory())
 
-            backup_filename = constants.BACKUP_EXISTING_CONFIG_OUTPUT
             if args.write_config:
                 vollog.warning('Use of --write-config has been deprecated, replaced by --save-config <filename>')
                 args.save_config = 'config.json'
-                backup_filename = False
             if args.save_config:
                 vollog.debug("Writing out configuration data to {args.save_config}")
-                if os.path.exists(os.path.abspath(args.save_config)) and backup_filename:
-                    # Backup existing file
-                    backup_filename = self.find_backup_filename(args.save_config)
-                    vollog.debug(f"Backing up existing file to {backup_filename}")
-                    os.rename(args.save_config, backup_filename)
+                if os.path.exists(os.path.abspath(args.save_config)):
+                    parser.error(f"Cannot write configuration: file {args.save_config} already exists")
                 with open(args.save_config, "w") as f:
                     json.dump(dict(constructed.build_configuration()), f, sort_keys = True, indent = 2)
         except exceptions.UnsatisfiedException as excp:

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -324,11 +324,14 @@ class CommandLine:
             constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
                                                    self.file_handler_class_factory())
 
+            backup_filename = True
             if args.write_config:
+                vollog.warning('Use of --write-config has been deprecated, replaced by --save-config <filename>')
                 args.save_config = 'config.json'
+                backup_filename = False
             if args.save_config:
                 vollog.debug("Writing out configuration data to {args.save_config}")
-                if os.path.exists(os.path.abspath(args.save_config)):
+                if os.path.exists(os.path.abspath(args.save_config)) and backup_filename:
                     # Backup existing file
                     backup_filename = self.find_backup_filename(args.save_config)
                     vollog.debug(f"Backing up existing file to {backup_filename}")

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -324,7 +324,7 @@ class CommandLine:
             constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
                                                    self.file_handler_class_factory())
 
-            backup_filename = True
+            backup_filename = constants.BACKUP_EXISTING_CONFIG_OUTPUT
             if args.write_config:
                 vollog.warning('Use of --write-config has been deprecated, replaced by --save-config <filename>')
                 args.save_config = 'config.json'

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -344,15 +344,6 @@ class CommandLine:
         except (exceptions.VolatilityException) as excp:
             self.process_exceptions(excp)
 
-    def find_backup_filename(self, original: str):
-        suffix = ""
-        new_name = f"{original}.{datetime.strftime(datetime.today(), '%y%m%d')}.bak"
-        while os.path.exists(f"{new_name}{suffix}"):
-            if not suffix:
-                suffix = 1
-            suffix += 1
-        return f"{new_name}{suffix}"
-
     @classmethod
     def location_from_file(cls, filename: str) -> str:
         """Returns the URL location from a file parameter (which may be a URL)

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -237,7 +237,7 @@ class VolShell(cli.CommandLine):
             constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
                                                    self.file_handler_class_factory())
 
-            backup_filename = True
+            backup_filename = constants.BACKUP_EXISTING_CONFIG_OUTPUT
             if args.write_config:
                 vollog.warning('Use of --write-config has been deprecated, replaced by --save-config <filename>')
                 args.save_config = 'config.json'

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -237,11 +237,14 @@ class VolShell(cli.CommandLine):
             constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
                                                    self.file_handler_class_factory())
 
+            backup_filename = True
             if args.write_config:
+                vollog.warning('Use of --write-config has been deprecated, replaced by --save-config <filename>')
                 args.save_config = 'config.json'
+                backup_filename = False
             if args.save_config:
                 vollog.debug("Writing out configuration data to {args.save_config}")
-                if os.path.exists(os.path.abspath(args.save_config)):
+                if os.path.exists(os.path.abspath(args.save_config)) and backup_filename:
                     # Backup existing file
                     backup_filename = self.find_backup_filename(args.save_config)
                     vollog.debug(f"Backing up existing file to {backup_filename}")

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -237,18 +237,13 @@ class VolShell(cli.CommandLine):
             constructed = plugins.construct_plugin(ctx, automagics, plugin, base_config_path, progress_callback,
                                                    self.file_handler_class_factory())
 
-            backup_filename = constants.BACKUP_EXISTING_CONFIG_OUTPUT
             if args.write_config:
                 vollog.warning('Use of --write-config has been deprecated, replaced by --save-config <filename>')
                 args.save_config = 'config.json'
-                backup_filename = False
             if args.save_config:
                 vollog.debug("Writing out configuration data to {args.save_config}")
-                if os.path.exists(os.path.abspath(args.save_config)) and backup_filename:
-                    # Backup existing file
-                    backup_filename = self.find_backup_filename(args.save_config)
-                    vollog.debug(f"Backing up existing file to {backup_filename}")
-                    os.rename(args.save_config, backup_filename)
+                if os.path.exists(os.path.abspath(args.save_config)):
+                    parser.error(f"Cannot write configuration: file {args.save_config} already exists")
                 with open(args.save_config, "w") as f:
                     json.dump(dict(constructed.build_configuration()), f, sort_keys = True, indent = 2)
         except exceptions.UnsatisfiedException as excp:

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -85,6 +85,10 @@ class VolShell(cli.CommandLine):
                             help = "Write configuration JSON file out to config.json",
                             default = False,
                             action = 'store_true')
+        parser.add_argument("--save-config",
+                            help = "Save configuration JSON file to a file",
+                            default = None,
+                            type = str)
         parser.add_argument("--clear-cache",
                             help = "Clears out all short-term cached items",
                             default = False,
@@ -234,8 +238,15 @@ class VolShell(cli.CommandLine):
                                                    self.file_handler_class_factory())
 
             if args.write_config:
-                vollog.debug("Writing out configuration data to config.json")
-                with open("config.json", "w") as f:
+                args.save_config = 'config.json'
+            if args.save_config:
+                vollog.debug("Writing out configuration data to {args.save_config}")
+                if os.path.exists(os.path.abspath(args.save_config)):
+                    # Backup existing file
+                    backup_filename = self.find_backup_filename(args.save_config)
+                    vollog.debug(f"Backing up existing file to {backup_filename}")
+                    os.rename(args.save_config, backup_filename)
+                with open(args.save_config, "w") as f:
                     json.dump(dict(constructed.build_configuration()), f, sort_keys = True, indent = 2)
         except exceptions.UnsatisfiedException as excp:
             self.process_unsatisfied_exceptions(excp)

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -9,7 +9,7 @@ volatility This includes default scanning block sizes, etc.
 import enum
 import os.path
 import sys
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 import volatility3.framework.constants.linux
 import volatility3.framework.constants.windows
@@ -80,6 +80,7 @@ ProgressCallback = Optional[Callable[[float, str], None]]
 
 OS_CATEGORIES = ['windows', 'mac', 'linux']
 
+
 class Parallelism(enum.IntEnum):
     """An enumeration listing the different types of parallelism applied to
     volatility."""
@@ -100,3 +101,6 @@ OFFLINE = False
 
 REMOTE_ISF_URL = None  # 'http://localhost:8000/banners.json'
 """Remote URL to query for a list of ISF addresses"""
+
+BACKUP_EXISTING_CONFIG_OUTPUT = True
+"""Whether existing files are backed up or overwritten when writing configuration output"""

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -101,6 +101,3 @@ OFFLINE = False
 
 REMOTE_ISF_URL = None  # 'http://localhost:8000/banners.json'
 """Remote URL to query for a list of ISF addresses"""
-
-BACKUP_EXISTING_CONFIG_OUTPUT = True
-"""Whether existing files are backed up or overwritten when writing configuration output"""


### PR DESCRIPTION
This obsoletes #664.

This adds the ability to specify a filename when writing a configuration.  In order to not confuse users too much, it adds a `--save-config` and changes `--write-config` to be equivalent to `--save-config config.json`.  I've leaned towards safety, because I was always a little uneasy as how the previous implementation would blat over a file (seems a bad idea for a forensics tool).  I have however made it a configuration option so that an installation can be configured not to produce endless backups if the configs are used in a feedback loop.

Not sure if we should set this to False (overwrite files) by default?