### PR TITLE
Fix: typo for `Disassembly` rendering code comment.

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -101,7 +101,7 @@ def display_disassembly(disasm: interfaces.renderers.Disassembly) -> str:
         disasm: Input disassembly objects
 
     Returns:
-        A string as rendererd by capstone where available, otherwise output as if it were just bytes
+        A string as rendered by capstone where available, otherwise output as if it were just bytes
     """
 
     if CAPSTONE_PRESENT:


### PR DESCRIPTION
I found typo error while looking at the rendering module!