### PR TITLE
Fix: operating system comparison syntax for create cache path constant.

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -11,7 +11,6 @@ import os.path
 import sys
 from typing import Optional, Callable
 
-import volatility3.framework.constants.linux
 import volatility3.framework.constants.windows
 
 PLUGINS_PATH = [
@@ -63,7 +62,7 @@ LOGLEVEL_VVVV = 6
 CACHE_PATH = os.path.join(os.path.expanduser("~"), ".cache", "volatility3")
 """Default path to store cached data"""
 
-if sys.platform == 'windows':
+if sys.platform == 'win32':
     CACHE_PATH = os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3")
 os.makedirs(CACHE_PATH, exist_ok = True)
 

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -11,6 +11,7 @@ import os.path
 import sys
 from typing import Optional, Callable
 
+import volatility3.framework.constants.linux
 import volatility3.framework.constants.windows
 
 PLUGINS_PATH = [


### PR DESCRIPTION
While analyzing the Constant code in Framework, I found that there was a problem with the comparison syntax for create cache path constant. The possible values from the **sys.platform** are limited as [follows](https://docs.python.org/3/library/sys.html#sys.platform):
In order for the code to work according to its intentions, it should be compared to **"win32"** instead of **"windows"**.