### PR TITLE
Fix: `__init__` and description of mac environment plugins.

### DIFF
--- a/volatility3/framework/plugins/mac/__init__.py
+++ b/volatility3/framework/plugins/mac/__init__.py
@@ -1,0 +1,8 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+"""All core mac plugins.
+
+These modules should only be imported from volatility3.plugins NOT
+volatility3.framework.plugins
+"""

--- a/volatility3/framework/plugins/mac/ifconfig.py
+++ b/volatility3/framework/plugins/mac/ifconfig.py
@@ -9,7 +9,7 @@ from volatility3.framework.symbols import mac
 
 
 class Ifconfig(plugins.PluginInterface):
-    """Lists loaded kernel modules"""
+    """ Lists network interface information for all devices """
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/mac/ifconfig.py
+++ b/volatility3/framework/plugins/mac/ifconfig.py
@@ -9,7 +9,7 @@ from volatility3.framework.symbols import mac
 
 
 class Ifconfig(plugins.PluginInterface):
-    """ Lists network interface information for all devices """
+    """Lists network interface information for all devices"""
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/mac/mount.py
+++ b/volatility3/framework/plugins/mac/mount.py
@@ -12,7 +12,7 @@ from volatility3.framework.symbols import mac
 
 class Mount(plugins.PluginInterface):
     """A module containing a collection of plugins that produce data typically
-    founding Mac's mount command"""
+    found in Mac's mount command"""
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/mac/mount.py
+++ b/volatility3/framework/plugins/mac/mount.py
@@ -12,7 +12,7 @@ from volatility3.framework.symbols import mac
 
 class Mount(plugins.PluginInterface):
     """A module containing a collection of plugins that produce data typically
-    foundin Mac's mount command"""
+    founding Mac's mount command"""
 
     _required_framework_version = (2, 0, 0)
 


### PR DESCRIPTION
The plugin description for the mac environment is incorrect or the contents of the init file are not present.
So I added this. 🙂