### PR TITLE
Feature: implement `DeviceTree` plugin.

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -40,7 +40,7 @@ BANG = "!"
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
 VERSION_MINOR = 0  # Number of changes that only add to the interface
-VERSION_PATCH = 2  # Number of changes that do not change the interface
+VERSION_PATCH = 3  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 # TODO: At version 2.0.0, remove the symbol_shift feature

--- a/volatility3/framework/plugins/windows/devicetree.py
+++ b/volatility3/framework/plugins/windows/devicetree.py
@@ -140,5 +140,9 @@ class DeviceTree(interfaces.plugins.PluginInterface):
 
     def run(self) -> renderers.TreeGrid:
         return renderers.TreeGrid([
-            ("Offset", format_hints.Hex), ("Type", str), ("DriverName", str), ("DeviceName", str), ("DeviceType", str),
+            ("Offset", format_hints.Hex),
+            ("Type", str),
+            ("DriverName", str),
+            ("DeviceName", str),
+            ("DeviceType", str),
         ], self._generator())

--- a/volatility3/framework/plugins/windows/devicetree.py
+++ b/volatility3/framework/plugins/windows/devicetree.py
@@ -77,7 +77,7 @@ vollog = logging.getLogger(__name__)
 class DeviceTree(interfaces.plugins.PluginInterface):
     """Listing tree based on drivers and attached devices in a particular windows memory image."""
 
-    _required_framework_version = (2, 0, 1)
+    _required_framework_version = (2, 0, 3)
     _version = (1, 0, 0)
 
     @classmethod
@@ -121,8 +121,7 @@ class DeviceTree(interfaces.plugins.PluginInterface):
                     for level, attached_device in enumerate(device.get_attached_devices(), start=2):
                         device_name = attached_device.get_device_name()
                         
-                        attached_device_name = "Unparsable Value" if isinstance(device_name, renderers.UnparsableValue) else device_name
-                        name = "{} - {}".format(attached_device_name, attached_device.DriverObject.DriverName.get_string())
+                        name = "{} - {}".format(device_name, attached_device.DriverObject.DriverName.get_string())
                         
                         attached_device_type = DEVICE_CODES.get(attached_device.DeviceType, "UNKNOWN")
 

--- a/volatility3/framework/plugins/windows/devicetree.py
+++ b/volatility3/framework/plugins/windows/devicetree.py
@@ -1,0 +1,145 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+
+from typing import Iterator, List, Tuple
+
+from volatility3.framework import constants, renderers, exceptions, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import driverscan
+
+DEVICE_CODES = {
+    0x00000027 : "FILE_DEVICE_8042_PORT",
+    0x00000032 : "FILE_DEVICE_ACPI",
+    0x00000029 : "FILE_DEVICE_BATTERY",
+    0x00000001 : "FILE_DEVICE_BEEP",
+    0x0000002a : "FILE_DEVICE_BUS_EXTENDER",
+    0x00000002 : "FILE_DEVICE_CD_ROM",
+    0x00000003 : "FILE_DEVICE_CD_ROM_FILE_SYSTEM",
+    0x00000030 : "FILE_DEVICE_CHANGER",
+    0x00000004 : "FILE_DEVICE_CONTROLLER",
+    0x00000005 : "FILE_DEVICE_DATALINK",
+    0x00000006 : "FILE_DEVICE_DFS",
+    0x00000035 : "FILE_DEVICE_DFS_FILE_SYSTEM",
+    0x00000036 : "FILE_DEVICE_DFS_VOLUME",
+    0x00000007 : "FILE_DEVICE_DISK",
+    0x00000008 : "FILE_DEVICE_DISK_FILE_SYSTEM",
+    0x00000033 : "FILE_DEVICE_DVD",
+    0x00000009 : "FILE_DEVICE_FILE_SYSTEM",
+    0x0000003a : "FILE_DEVICE_FIPS",
+    0x00000034 : "FILE_DEVICE_FULLSCREEN_VIDEO",
+    0x0000000a : "FILE_DEVICE_INPORT_PORT",
+    0x0000000b : "FILE_DEVICE_KEYBOARD",
+    0x0000002f : "FILE_DEVICE_KS",
+    0x00000039 : "FILE_DEVICE_KSEC",
+    0x0000000c : "FILE_DEVICE_MAILSLOT",
+    0x0000002d : "FILE_DEVICE_MASS_STORAGE",
+    0x0000000d : "FILE_DEVICE_MIDI_IN",
+    0x0000000e : "FILE_DEVICE_MIDI_OUT",
+    0x0000002b : "FILE_DEVICE_MODEM",
+    0x0000000f : "FILE_DEVICE_MOUSE",
+    0x00000010 : "FILE_DEVICE_MULTI_UNC_PROVIDER",
+    0x00000011 : "FILE_DEVICE_NAMED_PIPE",
+    0x00000012 : "FILE_DEVICE_NETWORK",
+    0x00000013 : "FILE_DEVICE_NETWORK_BROWSER",
+    0x00000014 : "FILE_DEVICE_NETWORK_FILE_SYSTEM",
+    0x00000028 : "FILE_DEVICE_NETWORK_REDIRECTOR",
+    0x00000015 : "FILE_DEVICE_NULL",
+    0x00000016 : "FILE_DEVICE_PARALLEL_PORT",
+    0x00000017 : "FILE_DEVICE_PHYSICAL_NETCARD",
+    0x00000018 : "FILE_DEVICE_PRINTER",
+    0x00000019 : "FILE_DEVICE_SCANNER",
+    0x0000001c : "FILE_DEVICE_SCREEN",
+    0x00000037 : "FILE_DEVICE_SERENUM",
+    0x0000001a : "FILE_DEVICE_SERIAL_MOUSE_PORT",
+    0x0000001b : "FILE_DEVICE_SERIAL_PORT",
+    0x00000031 : "FILE_DEVICE_SMARTCARD",
+    0x0000002e : "FILE_DEVICE_SMB",
+    0x0000001d : "FILE_DEVICE_SOUND",
+    0x0000001e : "FILE_DEVICE_STREAMS",
+    0x0000001f : "FILE_DEVICE_TAPE",
+    0x00000020 : "FILE_DEVICE_TAPE_FILE_SYSTEM",
+    0x00000038 : "FILE_DEVICE_TERMSRV",
+    0x00000021 : "FILE_DEVICE_TRANSPORT",
+    0x00000022 : "FILE_DEVICE_UNKNOWN",
+    0x0000002c : "FILE_DEVICE_VDM",
+    0x00000023 : "FILE_DEVICE_VIDEO",
+    0x00000024 : "FILE_DEVICE_VIRTUAL_DISK",
+    0x00000025 : "FILE_DEVICE_WAVE_IN",
+    0x00000026 : "FILE_DEVICE_WAVE_OUT",
+}
+
+vollog = logging.getLogger(__name__)
+
+class DeviceTree(interfaces.plugins.PluginInterface):
+    """Listing tree based on drivers and attached devices in a particular windows memory image."""
+
+    _required_framework_version = (2, 0, 1)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(name = "kernel", description = "Windows kernel",
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = "driverscan", plugin = driverscan.DriverScan, version = (1, 0, 0)),
+        ]
+
+    def _generator(self) -> Iterator[Tuple]:
+        kernel = self.context.modules[self.config["kernel"]]
+
+        # Scan the Layer for drivers
+        for driver in driverscan.DriverScan.scan_drivers(self.context, kernel.layer_name, kernel.symbol_table_name):
+            try:
+                driver_name = driver.get_driver_name()
+
+                yield (0, (
+                    format_hints.Hex(driver.vol.offset),
+                    "DRV",
+                    driver_name,
+                    renderers.NotApplicableValue(),
+                    renderers.NotApplicableValue()
+                ))
+
+                # Scan to get the device information of driver.
+                for device in driver.get_devices():
+                    device_name = device.get_device_name()
+                    device_type = DEVICE_CODES.get(device.DeviceType, "UNKNOWN")
+
+                    yield (1, (
+                        format_hints.Hex(driver.vol.offset),
+                        "DEV",
+                        driver_name,
+                        device_name,
+                        device_type
+                    ))
+                    
+                    # Scan to get the attached devices information of device.
+                    for level, attached_device in enumerate(device.get_attached_devices(), start=2):
+                        device_name = attached_device.get_device_name()
+                        
+                        attached_device_name = "Unparsable Value" if isinstance(device_name, renderers.UnparsableValue) else device_name
+                        name = "{} - {}".format(attached_device_name, attached_device.DriverObject.DriverName.get_string())
+                        
+                        attached_device_type = DEVICE_CODES.get(attached_device.DeviceType, "UNKNOWN")
+
+                        yield (level, (
+                            format_hints.Hex(driver.vol.offset),
+                            "ATT",
+                            driver_name,
+                            name,
+                            attached_device_type
+                        ))
+                    
+            except(exceptions.PagedInvalidAddressException):
+                vollog.log(constants.LOGLEVEL_VVVV, f"Invalid address identified in drivers and devices: {format_hints.Hex(driver.vol.offset)}")
+                continue
+
+
+    def run(self) -> renderers.TreeGrid:
+        return renderers.TreeGrid([
+            ("Offset", format_hints.Hex), ("Type", str), ("DriverName", str), ("DeviceName", str), ("DeviceType", str),
+        ], self._generator())

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -358,7 +358,7 @@ class DEVICE_OBJECT(objects.StructType, pool.ExecutiveObject):
         return header.NameInfo.Name.String  # type: ignore
 
     def get_attached_devices(self) -> Generator[ObjectInterface, None, None]:
-        """Enumerate the device's attaches"""
+        """Enumerate the attached device's objects"""
         device = self.AttachedDevice.dereference()
         while device:
             yield device

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -352,13 +352,10 @@ class EX_FAST_REF(objects.StructType):
 class DEVICE_OBJECT(objects.StructType, pool.ExecutiveObject):
     """A class for kernel device objects."""
 
-    def get_device_name(self) -> Union[str, interfaces.renderers.BaseAbsentValue]:
+    def get_device_name(self) -> str:
         """Get device's name from the object header."""
-        try:
-            header = self.get_object_header()
-            return header.NameInfo.Name.String  # type: ignore
-        except(ValueError):
-            return renderers.UnparsableValue()
+        header = self.get_object_header()
+        return header.NameInfo.Name.String  # type: ignore
 
     def get_attached_devices(self) -> Generator[ObjectInterface, None, None]:
         """Enumerate the device's attaches"""
@@ -370,13 +367,10 @@ class DEVICE_OBJECT(objects.StructType, pool.ExecutiveObject):
 class DRIVER_OBJECT(objects.StructType, pool.ExecutiveObject):
     """A class for kernel driver objects."""
 
-    def get_driver_name(self) -> Union[str, interfaces.renderers.BaseAbsentValue]:
+    def get_driver_name(self) -> str:
         """Get driver's name from the object header."""
-        try:
-            header = self.get_object_header()
-            return header.NameInfo.Name.String  # type: ignore
-        except(ValueError):
-            return renderers.UnparsableValue()
+        header = self.get_object_header()
+        return header.NameInfo.Name.String  # type: ignore
 
     def get_devices(self) -> Generator[ObjectInterface, None, None]:
         """Enumerate the driver's device objects"""

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -351,17 +351,38 @@ class EX_FAST_REF(objects.StructType):
 class DEVICE_OBJECT(objects.StructType, pool.ExecutiveObject):
     """A class for kernel device objects."""
 
-    def get_device_name(self) -> str:
-        header = self.get_object_header()
-        return header.NameInfo.Name.String  # type: ignore
+    def get_device_name(self) -> Union[str, interfaces.renderers.BaseAbsentValue]:
+        """Get device's name from the object header."""
+        try:
+            header = self.get_object_header()
+            return header.NameInfo.Name.String  # type: ignore
+        except(ValueError):
+            return renderers.UnparsableValue()
 
+    def get_attached_devices(self) -> interfaces.objects.ObjectInterface:
+        """Enumerate the device's attaches"""
+        device = self.AttachedDevice.dereference()
+        while device:
+            yield device
+            device = device.AttachedDevice.dereference()
 
 class DRIVER_OBJECT(objects.StructType, pool.ExecutiveObject):
     """A class for kernel driver objects."""
 
-    def get_driver_name(self) -> str:
-        header = self.get_object_header()
-        return header.NameInfo.Name.String  # type: ignore
+    def get_driver_name(self) -> Union[str, interfaces.renderers.BaseAbsentValue]:
+        """Get driver's name from the object header."""
+        try:
+            header = self.get_object_header()
+            return header.NameInfo.Name.String  # type: ignore
+        except(ValueError):
+            return renderers.UnparsableValue()
+
+    def get_devices(self) -> interfaces.objects.ObjectInterface:
+        """Enumerate the driver's device objects"""
+        device =  self.DeviceObject.dereference()
+        while device:
+            yield device
+            device = device.NextDevice.dereference()
 
     def is_valid(self) -> bool:
         """Determine if the object is valid."""

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -7,9 +7,10 @@ import datetime
 import functools
 import logging
 import math
-from typing import Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Generator, Iterable, Iterator, List, Optional, Tuple, Union
 
 from volatility3.framework import constants, exceptions, interfaces, objects, renderers, symbols
+from volatility3.framework.interfaces.objects import ObjectInterface
 from volatility3.framework.layers import intel
 from volatility3.framework.renderers import conversion
 from volatility3.framework.symbols import generic
@@ -359,7 +360,7 @@ class DEVICE_OBJECT(objects.StructType, pool.ExecutiveObject):
         except(ValueError):
             return renderers.UnparsableValue()
 
-    def get_attached_devices(self) -> interfaces.objects.ObjectInterface:
+    def get_attached_devices(self) -> Generator[ObjectInterface, None, None]:
         """Enumerate the device's attaches"""
         device = self.AttachedDevice.dereference()
         while device:
@@ -377,7 +378,7 @@ class DRIVER_OBJECT(objects.StructType, pool.ExecutiveObject):
         except(ValueError):
             return renderers.UnparsableValue()
 
-    def get_devices(self) -> interfaces.objects.ObjectInterface:
+    def get_devices(self) -> Generator[ObjectInterface, None, None]:
         """Enumerate the driver's device objects"""
         device =  self.DeviceObject.dereference()
         while device:


### PR DESCRIPTION
## Description

Hello, everyone in the community! 😃
There are some plugins that have not been implemented as they are updated from Volatility 2 to 3.
After reviewing this  #118, I found that DeviceTree plugin has not yet migrated to 3.
So I'm implemented (or porting) of DeviceTree plugin according to the Volatility 3 structure.

It was implemented so that the same results as Volatility 2 can be obtained by referring to the [existing code](https://github.com/volatilityfoundation/volatility/blob/master/volatility/plugins/malware/devicetree.py).

## Command
Help Command

```
> python3 vol.py -h
windows.devicetree.DeviceTree Listing tree based on drivers and attached devices in a particular windows memory image.
```

Run Command

`python3 vol.py -f case.vmem windows.devicetree`

## Output Example
```shell
Volatility 3 Framework 2.0.2
Progress:  100.00               PDB scanning finished                        
Offset  Type    DriverName      DeviceName      DeviceType
0x97065bd32e20  DRV     HDAudBus        N/A     N/A
* 0x97065bd32e20        DEV     HDAudBus        00000070        FILE_DEVICE_SOUND
** 0x97065bd32e20       ATT     HDAudBus        00000071 - \Driver\HdAudAddService      FILE_DEVICE_KS
*** 0x97065bd32e20      ATT     HDAudBus        00000072 - \Driver\ksthunk      FILE_DEVICE_KS
0x97065bd36060  DRV     usbehci N/A     N/A
* 0x97065bd36060        DEV     usbehci USBPDO-2        FILE_DEVICE_BUS_EXTENDER
** 0x97065bd36060       ATT     usbehci 0000006f - \Driver\usbhub       UNKNOWN
0x97065bd369c0  DRV     gencounter      N/A     N/A
* 0x97065bd369c0        DEV     gencounter      VmGenerationCounter     FILE_DEVICE_UNKNOWN
0x97065bd5a300  DRV     e1i65x64        N/A     N/A
* 0x97065bd5a300        DEV     e1i65x64        INTELPRO_{2CF4C691-FB21-4D9A-8CEA-F5AD9232FC61} FILE_DEVICE_NETWORK
```

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌