### PR TITLE
Fix: typo for mac plugin licenses, document (`simple-plugin`).

### DIFF
--- a/doc/source/simple-plugin.rst
+++ b/doc/source/simple-plugin.rst
@@ -196,7 +196,7 @@ The plugin then defaults the ``BaseDllName`` and ``FullDllName`` variables to an
 which is a way of indicating to the user interface that the value couldn't be read for some reason (but that it isn't fatal).
 There are currently four different reasons a value may be unreadable:
 
-* **Unredble**: values which are empty because the data cannot be read
+* **Unreadable**: values which are empty because the data cannot be read
 * **Unparsable**: values which are empty because the data cannot be interpreted correctly
 * **NotApplicable**: values which are empty because they don't make sense for this particular entry
 * **NotAvailable**: values which cannot be provided now (but might in a future run, via new symbols or an updated plugin)

--- a/doc/source/simple-plugin.rst
+++ b/doc/source/simple-plugin.rst
@@ -196,7 +196,7 @@ The plugin then defaults the ``BaseDllName`` and ``FullDllName`` variables to an
 which is a way of indicating to the user interface that the value couldn't be read for some reason (but that it isn't fatal).
 There are currently four different reasons a value may be unreadable:
 
-* **Unreadble**: values which are empty because the data cannot be read
+* **Unredble**: values which are empty because the data cannot be read
 * **Unparsable**: values which are empty because the data cannot be interpreted correctly
 * **NotApplicable**: values which are empty because they don't make sense for this particular entry
 * **NotAvailable**: values which cannot be provided now (but might in a future run, via new symbols or an updated plugin)

--- a/volatility3/framework/plugins/mac/kauth_scopes.py
+++ b/volatility3/framework/plugins/mac/kauth_scopes.py
@@ -1,4 +1,4 @@
-# This file is opyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
+# This file is Copyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging

--- a/volatility3/framework/plugins/mac/kevents.py
+++ b/volatility3/framework/plugins/mac/kevents.py
@@ -1,4 +1,4 @@
-# This file is opyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
+# This file is Copyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 

--- a/volatility3/framework/plugins/mac/vfsevents.py
+++ b/volatility3/framework/plugins/mac/vfsevents.py
@@ -1,4 +1,4 @@
-# This file is opyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
+# This file is Copyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 


### PR DESCRIPTION
Hello, everyone in the community! 😃
I checked the source code file for missing some license spelling and corrected the error in the docs.