### PR TITLE
Configuration: Change unsatisfied response for Modules

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -19,7 +19,6 @@ import os
 import sys
 import tempfile
 import traceback
-from datetime import datetime
 from typing import Any, Dict, Type, Union
 from urllib import parse, request
 
@@ -453,16 +452,17 @@ class CommandLine:
 
             print(f"Unsatisfied requirement {config_path}: {excp.unsatisfied[config_path].description}")
 
-        if symbols_failed:
-            print("\nA symbol table requirement was not fulfilled.  Please verify that:\n"
-                  "\tYou have the correct symbol file for the requirement\n"
-                  "\tThe symbol file is under the correct directory or zip file\n"
-                  "\tThe symbol file is named appropriately or contains the correct banner\n")
         if translation_failed:
             print("\nA translation layer requirement was not fulfilled.  Please verify that:\n"
                   "\tA file was provided to create this layer (by -f, --single-location or by config)\n"
                   "\tThe file exists and is readable\n"
-                  "\tThe necessary symbols are present and identified by volatility3")
+                  "\tThe file is a valid memory image and was acquired cleanly")
+        if symbols_failed:
+            print("\nA symbol table requirement was not fulfilled.  Please verify that:\n"
+                  "\tThe associated translation layer requirement was fulfilled\n"
+                  "\tYou have the correct symbol file for the requirement\n"
+                  "\tThe symbol file is under the correct directory or zip file\n"
+                  "\tThe symbol file is named appropriately or contains the correct banner\n")
 
     def populate_config(self, context: interfaces.context.ContextInterface,
                         configurables_list: Dict[str, Type[interfaces.configuration.ConfigurableInterface]],

--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -10,7 +10,7 @@ expect to be in the context (such as particular layers or symboltables).
 """
 import abc
 import logging
-from typing import Any, ClassVar, List, Optional, Type, Dict, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type
 
 from volatility3.framework import constants, interfaces
 
@@ -303,7 +303,8 @@ class TranslationLayerRequirement(interfaces.configuration.ConstructableRequirem
         args = {"context": context, "config_path": config_path, "name": name}
 
         if any(
-            [subreq.unsatisfied(context, config_path) for subreq in self.requirements.values() if not subreq.optional]):
+                [subreq.unsatisfied(context, config_path) for subreq in self.requirements.values() if
+                 not subreq.optional]):
             return None
 
         obj = self._construct_class(context, config_path, args)
@@ -358,7 +359,8 @@ class SymbolTableRequirement(interfaces.configuration.ConstructableRequirementIn
         args = {"context": context, "config_path": config_path, "name": name}
 
         if any(
-            [subreq.unsatisfied(context, config_path) for subreq in self.requirements.values() if not subreq.optional]):
+                [subreq.unsatisfied(context, config_path) for subreq in self.requirements.values() if
+                 not subreq.optional]):
             return None
 
         # Fill out the parameter for class creation
@@ -462,6 +464,15 @@ class ModuleRequirement(interfaces.configuration.ConstructableRequirementInterfa
                        "TypeError - Module Requirement only accepts string labels: {}".format(repr(value)))
             return {config_path: self}
 
+        result = {}
+        for subreq in self._requirements:
+            req_unsatisfied = self._requirements[subreq].unsatisfied(context, config_path)
+            if req_unsatisfied:
+                result.update(req_unsatisfied)
+        if not result:
+            result = {config_path: self}
+        return result
+
         ### NOTE: This validate method has side effects (the dependencies can change)!!!
 
         self._validate_class(context, interfaces.configuration.parent_path(config_path))
@@ -482,7 +493,8 @@ class ModuleRequirement(interfaces.configuration.ConstructableRequirementInterfa
         args = {"context": context, "config_path": config_path, "name": name}
 
         if any(
-            [subreq.unsatisfied(context, config_path) for subreq in self.requirements.values() if not subreq.optional]):
+                [subreq.unsatisfied(context, config_path) for subreq in self.requirements.values() if
+                 not subreq.optional]):
             return None
 
         obj = self._construct_class(context, config_path, args)


### PR DESCRIPTION
This now ensures that a failed `ModuleRequirement` returns the failure of its requirements as a reason it failed.  It also reorders and tidies up the error messages slightly.

Fixes #697 