### PR TITLE
refs #668 handle windows freed big pools more accurately

### DIFF
--- a/volatility3/framework/plugins/windows/bigpools.py
+++ b/volatility3/framework/plugins/windows/bigpools.py
@@ -33,7 +33,7 @@ class BigPools(interfaces.plugins.PluginInterface):
                                            description = "Comma separated list of pool tags to filter pools returned",
                                            optional = True,
                                            default = None),
-            requirements.BooleanRequirement(name = 'show_free',
+            requirements.BooleanRequirement(name = 'show-free',
                                             description = 'Show freed regions (otherwise only show allocations in use)',
                                             default = False,
                                             optional = True)
@@ -116,7 +116,7 @@ class BigPools(interfaces.plugins.PluginInterface):
                                             layer_name = kernel.layer_name,
                                             symbol_table = kernel.symbol_table_name,
                                             tags = tags,
-                                            show_free = self.config.get("show_free")):
+                                            show_free = self.config.get("show-free")):
 
             num_bytes = big_pool.get_number_of_bytes()
             if not isinstance(num_bytes, interfaces.renderers.BaseAbsentValue):

--- a/volatility3/framework/plugins/windows/bigpools.py
+++ b/volatility3/framework/plugins/windows/bigpools.py
@@ -21,7 +21,7 @@ class BigPools(interfaces.plugins.PluginInterface):
     """List big page pools."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 1)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/symbols/windows/extensions/pool.py
+++ b/volatility3/framework/symbols/windows/extensions/pool.py
@@ -233,7 +233,10 @@ class POOL_TRACKER_BIG_PAGES(objects.StructType):
 
     def is_valid(self) -> bool:
         return self.Key > 0
-        # return self.Va > 0x1
+
+    def is_free(self) -> bool:
+        """Returns if the allocation is freed (True) or in-use (False)"""
+        return self.Va & 1 == 1
 
     def get_key(self) -> str:
         """Returns the Key value as a 4 character string"""


### PR DESCRIPTION
This also adds a `--show-free` option, as freed regions are not listed by default.