### PR TITLE
Improving object type_name resolution

### DIFF
--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -121,6 +121,7 @@ class ObjectInterface(metaclass = abc.ABCMeta):
             vol_info_dict["table_name"] = table_name
             vol_info_dict["short_name"] = struct_name
         else:
+            vol_info_dict["table_name"] = ""
             vol_info_dict["short_name"] = type_name
         
         self._vol = collections.ChainMap({}, vol_info_dict, object_info, kwargs)

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -170,11 +170,6 @@ class ObjectInterface(metaclass = abc.ABCMeta):
                                         size = object_template.size)
         return object_template(context = self._context, object_info = object_info)
 
-    def at_layer(self, new_layer_name) -> 'ObjectInterface':
-        """Returns the same object casted at a different layer.
-        """
-        return self._context.object(self.vol.type_name, offset=self.vol.offset, layer_name=new_layer_name)
-
     def has_member(self, member_name: str) -> bool:
         """Returns whether the object would contain a member called
         member_name.

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -116,14 +116,6 @@ class ObjectInterface(metaclass = abc.ABCMeta):
         normalized_offset = object_info.offset & mask
 
         vol_info_dict = {'type_name': type_name, 'offset': normalized_offset}
-        if constants.BANG in type_name:
-            table_name, struct_name = type_name.split(constants.BANG)
-            vol_info_dict["table_name"] = table_name
-            vol_info_dict["short_name"] = struct_name
-        else:
-            vol_info_dict["table_name"] = ""
-            vol_info_dict["short_name"] = type_name
-        
         self._vol = collections.ChainMap({}, vol_info_dict, object_info, kwargs)
         self._context = context
 
@@ -151,7 +143,7 @@ class ObjectInterface(metaclass = abc.ABCMeta):
         """
         if constants.BANG not in self.vol.type_name:
             raise ValueError(f"Unable to determine table for symbol: {self.vol.type_name}")
-        table_name = self.vol.table_name
+        table_name = self.vol.type_name[:self.vol.type_name.index(constants.BANG)]
         if table_name not in self._context.symbol_space:
             raise KeyError(f"Symbol table not found in context's symbol_space for symbol: {self.vol.type_name}")
         return table_name

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -167,6 +167,20 @@ class BaseSymbolTableInterface:
         """
         raise NotImplementedError("Abstract method set_type_class not implemented yet.")
 
+    def try_set_type_class(self, name: str, clazz: Type[objects.ObjectInterface]) -> bool:
+        """Calls the set_type_class function but does not throw an exception.
+        Returns whether setting the type class was successfull.
+        Args:
+            name: The name of the type to override the class for
+            clazz: The actual class to override for the provided type name
+        """
+        try:
+            self.set_type_class(name, clazz)
+            
+            return True
+        except ValueError:
+            return False
+
     def get_type_class(self, name: str) -> Type[objects.ObjectInterface]:
         """Returns the class associated with a Symbol type."""
         raise NotImplementedError("Abstract method get_type_class not implemented yet.")

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -167,7 +167,7 @@ class BaseSymbolTableInterface:
         """
         raise NotImplementedError("Abstract method set_type_class not implemented yet.")
 
-    def try_set_type_class(self, name: str, clazz: Type[objects.ObjectInterface]) -> bool:
+    def optional_set_type_class(self, name: str, clazz: Type[objects.ObjectInterface]) -> bool:
         """Calls the set_type_class function but does not throw an exception.
         Returns whether setting the type class was successfull.
         Args:

--- a/volatility3/framework/symbols/windows/__init__.py
+++ b/volatility3/framework/symbols/windows/__init__.py
@@ -42,7 +42,7 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class('_IMAGE_NT_HEADERS', pe.IMAGE_NT_HEADERS)
         
         # Might not exist in 32-bit operating systems.
-        self.try_set_type_class('_IMAGE_NT_HEADERS64', pe.IMAGE_NT_HEADERS)
+        self.optional_set_type_class('_IMAGE_NT_HEADERS64', pe.IMAGE_NT_HEADERS)
 
         # This doesn't exist in very specific versions of windows
         try:
@@ -54,11 +54,11 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
             pass
 
         # these don't exist in windows XP
-        self.try_set_type_class('_MMADDRESS_NODE', extensions.MMVAD_SHORT)
+        self.optional_set_type_class('_MMADDRESS_NODE', extensions.MMVAD_SHORT)
         
         # these were introduced starting in windows 8
-        self.try_set_type_class('_MM_AVL_NODE', extensions.MMVAD_SHORT)
+        self.optional_set_type_class('_MM_AVL_NODE', extensions.MMVAD_SHORT)
         
         # these were introduced starting in windows 7
-        self.try_set_type_class('_RTL_BALANCED_NODE', extensions.MMVAD_SHORT)
+        self.optional_set_type_class('_RTL_BALANCED_NODE', extensions.MMVAD_SHORT)
         

--- a/volatility3/framework/symbols/windows/__init__.py
+++ b/volatility3/framework/symbols/windows/__init__.py
@@ -4,7 +4,7 @@
 
 from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.windows import extensions
-from volatility3.framework.symbols.windows.extensions import registry, pool
+from volatility3.framework.symbols.windows.extensions import registry, pool, pe
 
 
 class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
@@ -38,6 +38,11 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class('_SHARED_CACHE_MAP', extensions.SHARED_CACHE_MAP)
         self.set_type_class('_VACB', extensions.VACB)
         self.set_type_class('_POOL_TRACKER_BIG_PAGES', pool.POOL_TRACKER_BIG_PAGES)
+        self.set_type_class('_IMAGE_DOS_HEADER', pe.IMAGE_DOS_HEADER)
+        self.set_type_class('_IMAGE_NT_HEADERS', pe.IMAGE_NT_HEADERS)
+        
+        # Might not exist in 32-bit operating systems.
+        self.try_set_type_class('_IMAGE_NT_HEADERS64', pe.IMAGE_NT_HEADERS)
 
         # This doesn't exist in very specific versions of windows
         try:
@@ -49,19 +54,11 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
             pass
 
         # these don't exist in windows XP
-        try:
-            self.set_type_class('_MMADDRESS_NODE', extensions.MMVAD_SHORT)
-        except ValueError:
-            pass
-
+        self.try_set_type_class('_MMADDRESS_NODE', extensions.MMVAD_SHORT)
+        
         # these were introduced starting in windows 8
-        try:
-            self.set_type_class('_MM_AVL_NODE', extensions.MMVAD_SHORT)
-        except ValueError:
-            pass
-
+        self.try_set_type_class('_MM_AVL_NODE', extensions.MMVAD_SHORT)
+        
         # these were introduced starting in windows 7
-        try:
-            self.set_type_class('_RTL_BALANCED_NODE', extensions.MMVAD_SHORT)
-        except ValueError:
-            pass
+        self.try_set_type_class('_RTL_BALANCED_NODE', extensions.MMVAD_SHORT)
+        

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -574,13 +574,9 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
         proc_layer = self._context.layers[proc_layer_name]
         if not proc_layer.is_valid(self.Peb):
             raise exceptions.InvalidAddressException(proc_layer_name, self.Peb,
-                                                     f"Invalid address at {self.Peb:0x}")
+                                                     f"Invalid Peb address at {self.Peb:0x}")
 
-        sym_table = self.vol.type_name.split(constants.BANG)[0]
-        peb = self._context.object(f"{sym_table}{constants.BANG}_PEB",
-                                   layer_name = proc_layer_name,
-                                   offset = self.Peb)
-        return peb
+        return self.at_layer(proc_layer_name).Peb
 
     def load_order_modules(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Generator for DLLs in the order that they were loaded."""

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -576,7 +576,11 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
             raise exceptions.InvalidAddressException(proc_layer_name, self.Peb,
                                                      f"Invalid Peb address at {self.Peb:0x}")
 
-        return self.at_layer(proc_layer_name).Peb
+        sym_table = self.get_symbol_table_name()
+        peb = self._context.object(f"{sym_table}{constants.BANG}_PEB",
+                                   layer_name = proc_layer_name,
+                                   offset = self.Peb)
+        return peb
 
     def load_order_modules(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Generator for DLLs in the order that they were loaded."""


### PR DESCRIPTION
Getting the struct name or symbol table name for an object is mostly done by using `object.vol.type_name.split(constants.BANG)`, which is not ideal.

I have added 2 members to the vol dict in the object interface:
1) short_name: the actual struct name (_EPROCESS, _PEB, unsigned long long) 
1) table_name: `get_symbol_table_name()` does this but has a long name and has to perform the `split()` internally (it's still there for backwards compatibility).

Also added a util to "try except" for the type classes which appeared a few times in the code.

Finally, I added a util function for objects - `at_layer` - which casts said object to a different layer easily.
e.g see the `_EPROCESS` `get_peb()` function.

This PR is fully backwards compatible as only new APIs and members were added. Nothing was removed.
I personally think this could make the code simpler and more intuitive in the future (and change the `.split(constants.BANG)` convention that is prevalent).