### PR TITLE
Symbols: Catch bad JSON files without metadata

### DIFF
--- a/volatility3/framework/symbols/intermed.py
+++ b/volatility3/framework/symbols/intermed.py
@@ -11,13 +11,13 @@ import os
 import pathlib
 import zipfile
 from abc import ABCMeta
-from typing import Any, Dict, Generator, Iterable, List, Optional, Type, Tuple, Mapping
+from typing import Any, Dict, Generator, Iterable, List, Mapping, Optional, Tuple, Type
 
 from volatility3 import schemas, symbols
 from volatility3.framework import class_subclasses, constants, exceptions, interfaces, objects
 from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import resources
-from volatility3.framework.symbols import native, metadata
+from volatility3.framework.symbols import metadata, native
 
 vollog = logging.getLogger(__name__)
 
@@ -112,6 +112,9 @@ class IntermediateSymbolTable(interfaces.symbols.SymbolTableInterface):
             raise exceptions.SymbolSpaceError(f"File does not pass version validation: {isf_url}")
 
         metadata = json_object.get('metadata', None)
+
+        if not metadata:
+            raise exceptions.SymbolSpaceError(f"Invalid ISF file attempted to be parsed: {isf_url}")
 
         # Determine the delegate or throw an exception
         self._delegate = self._closest_version(metadata.get('format', "0.0.0"),
@@ -540,7 +543,8 @@ class Version3Format(Version2Format):
         if 'type' in symbol:
             symbol_type = self._interdict_to_template(symbol['type'])
 
-        self._symbol_cache[name] = interfaces.symbols.SymbolInterface(name = name, address = address, type = symbol_type)
+        self._symbol_cache[name] = interfaces.symbols.SymbolInterface(name = name, address = address,
+                                                                      type = symbol_type)
         return self._symbol_cache[name]
 
 


### PR DESCRIPTION
Fixes #719

I went with SymbolSpaceError, like it throws if the schema validation is present but fails.  Probably gonna merge this straight off.