### PR TITLE
Fix: typo for `API_CHANGES`.

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -6,7 +6,7 @@ When an API feature or function is removed or changed, the major version is bump
 
 2.1.0
 =====
-Add in the linux `task.get_threads` method added to rhe API.
+Add in the linux `task.get_threads` method added to the API.
 
 2.0.3
 =====


### PR DESCRIPTION
Hello, everone in the community! 🙂
A typo was found in the process of updating `API_CHANGES`.