### PR TITLE
Add: python virtual environments, memory dump on `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ dist
 env/
 venv/
 ENV/
-env.bak/
-venv.bak/
 
 # Memory dump files
 *.dmp

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,16 @@ config*.json
 # Pyinstaller files
 build
 dist
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Memory dump files
+*.dmp
+*.vmem


### PR DESCRIPTION
Hello, everyone in the community! 🙂

When we develop or use Volatility3, it is sometimes difficult because git tracks unintended changes.

A case in point is as follows.
- Use `venv` for install modules
- We can also put the memory dump files to analyze into the volatility folder or create them through plugins.

I've seen cases where contributors who develop Volatility3, including myself, set up and develop themselves in `.gitignore` or accidentally reflect them in PR.
I think updating `.gitignore` will reduce the effort of various users.

I also reflected Python's basic `.gitignore` data officially provided by Github to reflect the most common case.

What do you think of this PR?


