### PR TITLE
Feature: implement `VADWalk` plugin.

### DIFF
--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -199,6 +199,16 @@ def test_windows_callbacks(image, volatility, python):
     assert out.count(b"KeBugCheckReasonCallbackListHead	") > 5
     assert rc == 0
 
+def test_windows_vadwalk(image, volatility, python):
+    rc, out, err = runvol_plugin("windows.vadwalk.VadWalk", image, volatility, python)
+
+    assert out.find(b"Vad") != -1
+    assert out.find(b"VadS") != -1
+    assert out.find(b"Vadl") != -1
+    assert out.find(b"VadF") != -1
+    assert out.find(b"0x0") != -1
+    assert rc == 0
+
 # LINUX
 
 def test_linux_pslist(image, volatility, python):

--- a/volatility3/framework/plugins/windows/vadwalk.py
+++ b/volatility3/framework/plugins/windows/vadwalk.py
@@ -40,7 +40,7 @@ class VadWalk(interfaces.plugins.PluginInterface):
                     yield(0, (proc.UniqueProcessId,
                                 utility.array_to_string(proc.ImageFileName),
                                 format_hints.Hex(vad.vol.offset),
-                                format_hints.Hex(vad.get_parent()),
+                                format_hints.Hex(vad.get_parent() & self.context.layers[vad.vol.layer_name].address_mask),
                                 format_hints.Hex(vad.get_left_child()),
                                 format_hints.Hex(vad.get_right_child()),
                                 format_hints.Hex(vad.get_start()),

--- a/volatility3/framework/plugins/windows/vadwalk.py
+++ b/volatility3/framework/plugins/windows/vadwalk.py
@@ -15,7 +15,7 @@ vollog = logging.getLogger(__name__)
 
 
 class VadWalk(interfaces.plugins.PluginInterface):
-    """Walk the VAD tree"""
+    """Walk the VAD tree."""
 
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)
@@ -41,8 +41,8 @@ class VadWalk(interfaces.plugins.PluginInterface):
                                 utility.array_to_string(proc.ImageFileName),
                                 format_hints.Hex(vad.vol.offset),
                                 format_hints.Hex(vad.get_parent()),
-                                format_hints.Hex(vad.get_right_child()),
                                 format_hints.Hex(vad.get_left_child()),
+                                format_hints.Hex(vad.get_right_child()),
                                 format_hints.Hex(vad.get_start()),
                                 format_hints.Hex(vad.get_end()),
                                 vad.get_tag()))
@@ -55,8 +55,8 @@ class VadWalk(interfaces.plugins.PluginInterface):
                                     ('Process', str),
                                     ('Offset', format_hints.Hex),
                                     ('Parent', format_hints.Hex),
-                                    ('Right', format_hints.Hex),
                                     ('Left', format_hints.Hex),
+                                    ('Right', format_hints.Hex),
                                     ('Start', format_hints.Hex),
                                     ('End', format_hints.Hex),
                                     ('Tag', str)],

--- a/volatility3/framework/plugins/windows/vadwalk.py
+++ b/volatility3/framework/plugins/windows/vadwalk.py
@@ -3,7 +3,7 @@
 #
 
 import logging
-from typing import Iterator, List, Tuple
+from typing import Generator, Iterator, List, Tuple
 
 from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
@@ -33,7 +33,7 @@ class VadWalk(interfaces.plugins.PluginInterface):
                                          optional = True)
         ]
 
-    def _generator(self, procs) -> Iterator[Tuple]: 
+    def _generator(self, procs: Generator[interfaces.objects.ObjectInterface, None, None]) -> Iterator[Tuple]: 
         for proc in procs:
             for vad in vadinfo.VadInfo.list_vads(proc):
                 if(vad):

--- a/volatility3/framework/plugins/windows/vadwalk.py
+++ b/volatility3/framework/plugins/windows/vadwalk.py
@@ -1,0 +1,68 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import Iterator, List, Tuple
+
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import pslist, vadinfo
+
+vollog = logging.getLogger(__name__)
+
+
+class VadWalk(interfaces.plugins.PluginInterface):
+    """Walk the VAD tree"""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
+                                                     architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.PluginRequirement(name = 'vadinfo', plugin = vadinfo.VadInfo, version = (2, 0, 0)),
+            requirements.ListRequirement(name = 'pid',
+                                         element_type = int,
+                                         description = "Process IDs to include (all other processes are excluded)",
+                                         optional = True)
+        ]
+
+    def _generator(self, procs) -> Iterator[Tuple]: 
+        for proc in procs:
+            for vad in vadinfo.VadInfo.list_vads(proc):
+                if(vad):
+                    yield(0, (proc.UniqueProcessId,
+                                utility.array_to_string(proc.ImageFileName),
+                                format_hints.Hex(vad.vol.offset),
+                                format_hints.Hex(vad.get_parent()),
+                                format_hints.Hex(vad.get_right_child()),
+                                format_hints.Hex(vad.get_left_child()),
+                                format_hints.Hex(vad.get_start()),
+                                format_hints.Hex(vad.get_end()),
+                                vad.get_tag()))
+
+    def run(self) -> renderers.TreeGrid:
+        kernel = self.context.modules[self.config['kernel']]
+        filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
+
+        return renderers.TreeGrid([('PID', int),
+                                    ('Process', str),
+                                    ('Offset', format_hints.Hex),
+                                    ('Parent', format_hints.Hex),
+                                    ('Right', format_hints.Hex),
+                                    ('Left', format_hints.Hex),
+                                    ('Start', format_hints.Hex),
+                                    ('End', format_hints.Hex),
+                                    ('Tag', str)],
+                                    self._generator(
+                                        pslist.PsList.list_processes(
+                                            context = self.context,
+                                            layer_name = kernel.layer_name,
+                                            symbol_table = kernel.symbol_table_name,
+                                            filter_func = filter_func)))


### PR DESCRIPTION
## Description

Hello, everyone in the community! 😃
There are some plugins that have not been implemented as they are updated from [Volatility2](https://github.com/volatilityfoundation/volatility/wiki/Command-Reference#vadwalk) to 3.
I found that `VADWalk` plugin has not yet migrated to 3.
So I'm implemented (or porting) of `VADWalk` plugin according to the Volatility3 structure.

It was implemented so that the same results as Volatility 2 can be obtained by referring to the [existing code](https://github.com/volatilityfoundation/volatility/blob/master/volatility/plugins/vadinfo.py#L345).

## Command
Help Command

```
> python3 vol.py -h
windows.vadwalk.VadWalk Walk the VAD tree.
```

Run Command

`python3 vol.py -f case.vmem windows.vadwalk`

## Output Example
```shell
> python3 vol.py -f case.vmem -r pretty windows.vadwalk --pid=4708  
Volatility 3 Framework 2.1.0
Formatting...0.00               PDB scanning finished                        
  |  PID |      Process |     Offset |     Parent |       Left |      Right |      Start |        End |  Tag
* | 4708 | rundll32.exe | 0x9db10a00 |        0x0 | 0x9db10168 | 0x9db110e0 | 0x75df0000 | 0x76001fff | Vad 
* | 4708 | rundll32.exe | 0x9db10168 | 0x9db10a00 | 0x9db10110 | 0x9d0c14a0 |   0xa70000 |   0xa83fff | Vad 
* | 4708 | rundll32.exe | 0x9db10110 | 0x9db10168 | 0x9db10bb8 | 0x9654d6a0 |   0x890000 |   0x893fff | Vad 
* | 4708 | rundll32.exe | 0x9db10bb8 | 0x9db10110 | 0x9db10b08 | 0xa1ccaaf0 |   0x830000 |   0x84cfff | Vad 
* | 4708 | rundll32.exe | 0x9db10b08 | 0x9db10bb8 |        0x0 | 0xa1ccb0c0 |   0x810000 |   0x81ffff | Vad 
* | 4708 | rundll32.exe | 0xa1ccb0c0 | 0x9db10b08 |        0x0 |        0x0 |   0x820000 |   0x823fff | VadS
* | 4708 | rundll32.exe | 0xa1ccaaf0 | 0x9db10bb8 |        0x0 |        0x0 |   0x850000 |   0x88ffff | VadS
* | 4708 | rundll32.exe | 0x9654d6a0 | 0x9db10110 | 0x9d0c1448 | 0xa0550020 |   0x9d0000 |   0x9d0fff | Vad 
* | 4708 | rundll32.exe | 0x9d0c1448 | 0x9654d6a0 | 0xa1ccb270 | 0x9d0c1a20 |   0x990000 |   0x992fff | Vad 
* | 4708 | rundll32.exe | 0xa1ccb270 | 0x9d0c1448 | 0x9db10848 | 0x9db10d18 |   0x8b0000 |   0x8b1fff | VadS
* | 4708 | rundll32.exe | 0x9db10848 | 0xa1ccb270 |        0x0 |        0x0 |   0x8a0000 |   0x8a0fff | Vad 
* | 4708 | rundll32.exe | 0x9db10d18 | 0xa1ccb270 |        0x0 |        0x0 |   0x8c0000 |   0x988fff | Vad 
* | 4708 | rundll32.exe | 0x9d0c1a20 | 0x9d0c1448 | 0x9d0c19c8 | 0x9d0c1bd8 |   0x9b0000 |   0x9b0fff | Vad 
* | 4708 | rundll32.exe | 0x9d0c19c8 | 0x9d0c1a20 |        0x0 |        0x0 |   0x9a0000 |   0x9a7fff | Vad 
```

However, in the case of `vaddump`, it seems to have been absorbed by the dump option of `vadinfo`.
In this PR, `vadwalk` is provided in a separate form of information from `vadinfo`, so we separated it into a separate plugin, but if you have any intention or policy in mind, please let me know 🤔

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌