### PR TITLE
Fix: typo for documents (`symbol-tables`, `volshell`).

### DIFF
--- a/doc/source/symbol-tables.rst
+++ b/doc/source/symbol-tables.rst
@@ -63,7 +63,7 @@ To determine the string for a particular memory image, use the `banners` plugin.
 try to locate that exact kernel debugging package for the operating system.  Unfortunately each distribution provides
 its debugging packages under different package names and there are so many that the distribution may not keep all old
 versions of the debugging symbols, and therefore **it may not be possible to find the right symbols to analyze a linux
-memory image with volatlity**.  With Macs there are far fewer kernels and only one distribution, making it easier to
+memory image with volatility**.  With Macs there are far fewer kernels and only one distribution, making it easier to
 ensure that the right symbols can be found.
 
 Once a kernel with debugging symbols/appropriate DWARF file has been located, `dwarf2json <https://github.com/volatilityfoundation/dwarf2json>`_ will convert it into an

--- a/doc/source/volshell.rst
+++ b/doc/source/volshell.rst
@@ -110,7 +110,7 @@ This means that pointers do not need to be explicitly dereferenced to access und
 Running plugins
 ---------------
 
-It's possible to run any plugin by importing it appropriately and passing it to the `display_plugin_ouptut` or `dpo`
+It's possible to run any plugin by importing it appropriately and passing it to the `display_plugin_output` or `dpo`
 method.  In the following example we'll provide no additional parameters.  Volatility will show us which parameters
 were required:
 


### PR DESCRIPTION
Hello, everyone in the community! 🙂
I found some typo reading the documents.