### PR TITLE
Fix: typo for `cli` exception message.

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -423,7 +423,7 @@ class CommandLine:
             detail = f"{excp}"
             caused_by = ["A required python module is not installed (install the module and re-run)"]
         else:
-            general = "Volatilty encountered an unexpected situation."
+            general = "Volatility encountered an unexpected situation."
             detail = ""
             caused_by = [
                 "Please re-run using with -vvv and file a bug with the output", f"at {constants.BUG_URL}"


### PR DESCRIPTION
Hello, everyone in the community! 🙂
I found typo analyzing the `cli` code.