### PR TITLE
Fix: typo for `API_CHANGES`, code comment.

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -6,15 +6,15 @@ When an API feature or function is removed or changed, the major version is bump
 
 2.1.0
 =====
-Add in the linux `task.get_threads` method added to the API.
+Add in the linux `task.get_threads` method to the API.
 
 2.0.3
 =====
-Add in the windows `DEVICE_OBJECT.get_attached_devices` and `DRIVER_OBJECT.get_devices` method added to the API.
+Add in the windows `DEVICE_OBJECT.get_attached_devices` and `DRIVER_OBJECT.get_devices` methods to the API.
 
 2.0.2
 =====
-Fix the behavior of the offsets returned by the PDB scanner.
+Fix the behaviour of the offsets returned by the PDB scanner.
 
 2.0.0
 =====

--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -10,11 +10,11 @@ Add in the linux `task.get_threads` method added to the API.
 
 2.0.3
 =====
-`DEVICE_OBJECT.get_attached_devices` and `DRIVER_OBJECT.get_devices` added to the API.
+Add in the windows `DEVICE_OBJECT.get_attached_devices` and `DRIVER_OBJECT.get_devices` method added to the API.
 
 2.0.2
 =====
-Fix the behaviour of the offsets returned by the PDB scanner.
+Fix the behavior of the offsets returned by the PDB scanner.
 
 2.0.0
 =====

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -719,7 +719,7 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
             env = envar[:split_index]
             var = envar[split_index + 1:]
 
-            # Exlude parse problem with some types of env
+            # Exclude parse problem with some types of env
             if env and var:
                 yield env, var
 


### PR DESCRIPTION
Hello, everyone in the community 🙂
I found some typo while analyze documents and codes.
And I updated `API_CHANEGS` comment for unification.