### PR TITLE
Fix: `key_path` and `top_key` compare logic bug for `Certificates` plugin.

### DIFF
--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -6,7 +6,6 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.symbols.windows.extensions.registry import RegValueTypes
 from volatility3.plugins.windows.registry import hivelist, printkey
 
-
 class Certificates(interfaces.plugins.PluginInterface):
     """Lists the certificates in the registry's Certificate Store."""
 
@@ -52,7 +51,7 @@ class Certificates(interfaces.plugins.PluginInterface):
                          node) in printkey.PrintKey.key_iterator(hive, node_path, recurse = True):
                         if not is_key and RegValueTypes(node.Type).name == "REG_BINARY":
                             name, certificate_data = self.parse_data(node.decode_data())
-                            unique_key_offset = key_path.index(top_key) + len(top_key) + 1
+                            unique_key_offset = key_path.casefold().index(top_key.casefold()) + len(top_key) + 1
                             reg_section = key_path[unique_key_offset:key_path.index("\\", unique_key_offset)]
                             key_hash = key_path[key_path.rindex("\\") + 1:]
 

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -6,6 +6,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.symbols.windows.extensions.registry import RegValueTypes
 from volatility3.plugins.windows.registry import hivelist, printkey
 
+
 class Certificates(interfaces.plugins.PluginInterface):
     """Lists the certificates in the registry's Certificate Store."""
 


### PR DESCRIPTION
## Description
Hello, everyone in the community! 🙂
An error was detected while using `Certificates`, a plugin useful for obtaining certificate data from the registry.

### Commands
```shell
> python3 vol.py -f case.vmem -r pretty  windows.registry.certificates
Volatility 3 Framework 2.2.0
Formatting...0.00		PDB scanning finished
```

### Error Log
```shell
Traceback (most recent call last):
  File "/Users/donghyunkim/Desktop/volatility3/vol.py", line 10, in <module>
    volatility3.cli.main()
    ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/__init__.py", line 635, in main
    CommandLine().run()
    ^^^^^^^^^^^^^^^^^^^
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/__init__.py", line 342, in run
    renderers[args.renderer]().render(constructed.run())
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/text_renderer.py", line 177, in render
    grid.populate(visitor, outfd)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/renderers/__init__.py", line 212, in populate
    for (level, item) in self._generator:
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/plugins/windows/registry/certificates.py", line 58, in _generator
    unique_key_offset = key_path.index(top_key) + len(top_key) + 1
                        ^^^^^^^^^^^^^^^^^^^^^^^
ValueError: substring not found
```

As a result of tracking the error, the `key_path` and `top_key` extracted from the memory dump were not properly compared. (substring not found)

```
Level 7  volatility3.plugins.windows.registry.certificates: key_path(\??\C:\Users\dhyun\NTUSER.dat\SOFTWARE\Microsoft\SystemCertificates\Root\ProtectedRoots), top_key(Software\Microsoft\SystemCertificates)
Level 7  volatility3.plugins.windows.registry.certificates: key_path(\??\C:\Users\dhyun\ntuser.dat\SOFTWARE\Microsoft\SystemCertificates\Root\ProtectedRoots), top_key(Software\Microsoft\SystemCertificates)
```

We checked a little more and found that we could not consider the case where `key_path` and `top_key` are written differently in upper and lower case for `SOFTWARE` Hive.
(`Software\Microsoft\SystemCertificates` vs `SOFTWARE\Microsoft\SystemCertificates`)

So, I strengthened the comparison logic through the `casefold` method, which converts all of the data to lowercase only at the time of comparison.

## Result

After the patch, we were able to confirm that the certificate data was loaded normally.

```shell
> python3 vol.py -f case.vmem -r pretty  windows.registry.certificates
Volatility 3 Framework 2.2.0
Formatting...0.00		PDB scanning finished
  |                      Certificate path |            Certificate section |                           Certificate ID |                                          Certificate name
* |          Microsoft\SystemCertificates |                       AuthRoot |                               AutoUpdate |                                                         -
* |          Microsoft\SystemCertificates |                       AuthRoot |                               AutoUpdate |                                                         -
* |          Microsoft\SystemCertificates |                       AuthRoot |                               AutoUpdate |                                                         -
* |          Microsoft\SystemCertificates |                       AuthRoot |                               AutoUpdate |                                                         -
* |          Microsoft\SystemCertificates |                       AuthRoot |                               AutoUpdate |                                                         -
* |          Microsoft\SystemCertificates |                       AuthRoot | 4F65566336DB6598581D584A596C87934D5F2AB4 |                               VeriSign Class 3 Primary CA
* |          Microsoft\SystemCertificates |                       AuthRoot | 51501FBFCE69189D609CFAF140C576755DCC1FDF |                            Hotspot 2.0 Trust Root CA - 03
* |          Microsoft\SystemCertificates |                       AuthRoot | 742C3192E607E424EB4549542BE1BBC53E6174E2 |                        VeriSign Class 3 Public Primary CA
```

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌