### PR TITLE
Plugin: update plugin version, logger, dump options of `Certificates` plugin.

### DIFF
--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -1,6 +1,6 @@
 import logging
 import struct
-from typing import List, Iterator, Tuple, Type
+from typing import List, Iterator, Optional, Tuple, Type
 
 from volatility3.framework import constants, exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
@@ -45,7 +45,7 @@ class Certificates(interfaces.plugins.PluginInterface):
     def dump_certificate(cls, certificate_data: bytes, hive_offset: int,
                         reg_section: str, key_hash: str,
                         open_method: Type[interfaces.plugins.FileHandlerInterface]) -> \
-                        interfaces.plugins.FileHandlerInterface:
+                        Optional[interfaces.plugins.FileHandlerInterface]:
         try:
             if not isinstance(certificate_data, interfaces.renderers.BaseAbsentValue):
                 dump_name = "{} - {} - {}.crt".format(hive_offset, reg_section, key_hash)

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -90,9 +90,6 @@ class Certificates(interfaces.plugins.PluginInterface):
                 except exceptions.SwappedInvalidAddressException as exp:
                     vollog.log(constants.LOGLEVEL_VVVV, f"Required memory at {exp.invalid_address:#x} is inaccessible (swapped)")
                     pass
-                except exceptions.PagedInvalidAddressException as exp:
-                    vollog.log(constants.LOGLEVEL_VVVV, f"Required memory at {exp.invalid_address:#x} is not valid (process exited?)")
-                    pass
 
     def run(self) -> renderers.TreeGrid:
         return renderers.TreeGrid([("Certificate path", str), ("Certificate section", str), ("Certificate ID", str),

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -47,7 +47,7 @@ class Certificates(interfaces.plugins.PluginInterface):
                         Optional[interfaces.plugins.FileHandlerInterface]:
         try:
             if not isinstance(certificate_data, interfaces.renderers.BaseAbsentValue):
-                dump_name = "{} - {} - {}.crt".format(hive_offset, reg_section, key_hash)
+                dump_name = "{}-{}-{}.crt".format(hive_offset, reg_section, key_hash)
                 file_handle = open_method(dump_name)
                 file_handle.write(certificate_data)
                 return file_handle

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -1,8 +1,8 @@
 import logging
 import struct
-from typing import List, Iterator, Tuple
+from typing import List, Iterator, Tuple, Type
 
-from volatility3.framework import constants, interfaces, renderers
+from volatility3.framework import constants, exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.symbols.windows.extensions.registry import RegValueTypes
 from volatility3.plugins.windows.registry import hivelist, printkey
@@ -13,7 +13,6 @@ class Certificates(interfaces.plugins.PluginInterface):
     """Lists the certificates in the registry's Certificate Store."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -42,11 +41,20 @@ class Certificates(interfaces.plugins.PluginInterface):
                 certificate_data = cvalue
         return (name, certificate_data)
     
-    def dump_data(self, certificate_data: bytes, hive_offset: int, reg_section: str, key_hash: str):
-        if not isinstance(certificate_data, interfaces.renderers.BaseAbsentValue):
-            dump_name = "{} - {} - {}.crt".format(hive_offset, reg_section, key_hash)
-            with self.open(dump_name) as file_data:
-                file_data.write(certificate_data)
+    @classmethod
+    def dump_certificate(cls, certificate_data: bytes, hive_offset: int,
+                        reg_section: str, key_hash: str,
+                        open_method: Type[interfaces.plugins.FileHandlerInterface]) -> \
+                        interfaces.plugins.FileHandlerInterface:
+        try:
+            if not isinstance(certificate_data, interfaces.renderers.BaseAbsentValue):
+                dump_name = "{} - {} - {}.crt".format(hive_offset, reg_section, key_hash)
+                with open_method(dump_name) as file_data:
+                    file_data.write(certificate_data)
+        except exceptions.InvalidAddressException:
+            vollog.debug(f"Unable to certificate file at {hive_offset:#x}")
+            return None
+
 
     def _generator(self) -> Iterator[Tuple[int, Tuple[str, str, str, str]]]:
         for hive in hivelist.HiveList.list_hives(self.context,
@@ -61,7 +69,7 @@ class Certificates(interfaces.plugins.PluginInterface):
                 try:
                     # Walk it
                     node_path = hive.get_key(top_key, return_list = True)
-                    for (_, is_key, _, key_path, _, node) in printkey.PrintKey.key_iterator(hive, node_path, recurse = True):
+                    for (_depth, is_key, _last_write_time, key_path, _volatility, node) in printkey.PrintKey.key_iterator(hive, node_path, recurse = True):
                         if not is_key and RegValueTypes(node.Type).name == "REG_BINARY":
                             name, certificate_data = self.parse_data(node.decode_data())
                             unique_key_offset = key_path.casefold().index(top_key.casefold()) + len(top_key) + 1
@@ -69,10 +77,9 @@ class Certificates(interfaces.plugins.PluginInterface):
                             key_hash = key_path[key_path.rindex("\\") + 1:]
 
                             if self.config['dump']:
-                                self.dump_data(certificate_data, hive.hive_offset, reg_section, key_hash)
-                            else:
-                                vollog.warning("Certificates plugin is no longer support automatically dumped, please use the dump option.")
-                                self.dump_data(certificate_data, hive.hive_offset, reg_section, key_hash)
+                                file_handle = self.dump_certificate(certificate_data, hive.hive_offset, reg_section, key_hash, self.open)
+                                if file_handle:
+                                    file_handle.close()
                             
                             yield (0, (top_key, reg_section, key_hash, name))
                 except KeyError:

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -49,8 +49,9 @@ class Certificates(interfaces.plugins.PluginInterface):
         try:
             if not isinstance(certificate_data, interfaces.renderers.BaseAbsentValue):
                 dump_name = "{} - {} - {}.crt".format(hive_offset, reg_section, key_hash)
-                with open_method(dump_name) as file_data:
-                    file_data.write(certificate_data)
+                file_handle = open_method(dump_name)
+                file_handle.write(certificate_data)
+                return file_handle
         except exceptions.InvalidAddressException:
             vollog.debug(f"Unable to certificate file at {hive_offset:#x}")
             return None

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -42,7 +42,7 @@ class Certificates(interfaces.plugins.PluginInterface):
                 certificate_data = cvalue
         return (name, certificate_data)
     
-    def dump_data(self, certificate_data: bytes, hive_offset: int, reg_section: str, key_hash: str) -> str:
+    def dump_data(self, certificate_data: bytes, hive_offset: int, reg_section: str, key_hash: str):
         if not isinstance(certificate_data, interfaces.renderers.BaseAbsentValue):
             dump_name = "{} - {} - {}.crt".format(hive_offset, reg_section, key_hash)
             with self.open(dump_name) as file_data:

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -68,7 +68,7 @@ class Certificates(interfaces.plugins.PluginInterface):
                     "Microsoft\\SystemCertificates",
                     "Software\\Microsoft\\SystemCertificates",
             ]:
-                with contextlib.suppress(KeyError, exceptions.SwappedInvalidAddressException):
+                with contextlib.suppress(KeyError, exceptions.InvalidAddressException):
                     # Walk it
                     node_path = hive.get_key(top_key, return_list = True)
                     for (_depth, is_key, _last_write_time, key_path, _volatility, node) in printkey.PrintKey.key_iterator(hive, node_path, recurse = True):


### PR DESCRIPTION
## Description

As I modified this PR (#734), I checked and updated some improvements to this plugin.

-  Most plugins of Volatility3 can choose the `dump` option if they have data that can be dumped or if they write it to a local file system. However, the `Certificates` plugin does not match the plugin's description that when it runs, it automatically dumps and simply lists against our intentions. So I added the dump option.
- However, given existing plugin improvements, radical changes to certain features and commands can be a problem for other current users and systems. So I added a warning log and encouraged you to use the option. This will be removed one day. (Please let me know if you don't need this step, and I will modify it.)
- The plugin does not have a `KeyError`, so I added it because does not show a log for the case that went over.
- I changed the value to underscore (`_`) for the unused value in the iterator statement.