### PR TITLE
Fix: `JSON` renderer for `EOF` format.

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -345,7 +345,7 @@ class JsonRenderer(CLIRenderer):
 
     def output_result(self, outfd, result):
         """Outputs the JSON data to a file in a particular format"""
-        outfd.write(json.dumps(result, indent = 2, sort_keys = True))
+        outfd.write("{}\n".format(json.dumps(result, indent = 2, sort_keys = True)))
 
     def render(self, grid: interfaces.renderers.TreeGrid):
         outfd = sys.stdout


### PR DESCRIPTION
## Description
Hello, everyone in the community! 🙂

We have a wonderful ability to convert the results of plug-ins used in Volatility3 to `JSON`.
Using this function, some terminals such as `zsh`, did not have a newline(`\n`) indicating `EOF`, so it was confirmed that unnecessary data was printed on the output.
Other renderers may have already been processed during the rendering process or can be resolved using the `print` function, but we have used `outfd.write`, so I have fixed it accordingly.

```shell
            "Offset(V)": 2646155392,
            "PID": 2892,
            "PPID": 2860,
            "SessionId": 1,
            "Threads": 71,
            "Wow64": false,
            "__children": []
          }
        ]
      }
    ]
  }
]%
```

## Result

```shell
            "Offset(V)": 2646155392,
            "PID": 2892,
            "PPID": 2860,
            "SessionId": 1,
            "Threads": 71,
            "Wow64": false,
            "__children": []
          }
        ]
      }
    ]
  }
]
```

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌