### PR TITLE
Remove: unused module for windows `extensions`, `objects` initialize code.

### DIFF
--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -9,7 +9,7 @@ import struct
 from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Type, Union as TUnion, overload
 
 from volatility3.framework import constants, interfaces
-from volatility3.framework.objects import templates, utility
+from volatility3.framework.objects import templates
 
 vollog = logging.getLogger(__name__)
 

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -14,7 +14,7 @@ from volatility3.framework.interfaces.objects import ObjectInterface
 from volatility3.framework.layers import intel
 from volatility3.framework.renderers import conversion
 from volatility3.framework.symbols import generic
-from volatility3.framework.symbols.windows.extensions import kdbg, pe, pool
+from volatility3.framework.symbols.windows.extensions import pool
 
 vollog = logging.getLogger(__name__)
 


### PR DESCRIPTION
Hello, everyone in the community! 🙂
I found a module that doesn't seem to be used in some codes. If we really don't use it, I think it's okay to remove it.