### PR TITLE
Fix off by 1 in Filelayer MaximumAddress

### DIFF
--- a/volatility3/framework/layers/physical.py
+++ b/volatility3/framework/layers/physical.py
@@ -118,7 +118,7 @@ class FileLayer(interfaces.layers.DataLayerInterface):
         with self._lock:
             orig = self._file.tell()
             self._file.seek(0, 2)
-            self._size = self._file.tell()
+            self._size = self._file.tell() - 1
             self._file.seek(orig)
         return self._size
 

--- a/volatility3/framework/layers/physical.py
+++ b/volatility3/framework/layers/physical.py
@@ -88,6 +88,7 @@ class FileLayer(interfaces.layers.DataLayerInterface):
         self._accessor = resources.ResourceAccessor()
         self._file_: Optional[IO[Any]] = None
         self._size: Optional[int] = None
+        self._maximum_address: Optional[int] = None
         # Construct the lock now (shared if made before threading) in case we ever need it
         self._lock: Union[DummyLock, threading.Lock] = DummyLock()
         if constants.PARALLELISM == constants.Parallelism.Threading:

--- a/volatility3/framework/layers/physical.py
+++ b/volatility3/framework/layers/physical.py
@@ -113,14 +113,15 @@ class FileLayer(interfaces.layers.DataLayerInterface):
     def maximum_address(self) -> int:
         """Returns the largest available address in the space."""
         # Zero based, so we return the size of the file minus 1
-        if self._size:
-            return self._size
+        if self._maximum_address
+            return self._maximum_address
         with self._lock:
             orig = self._file.tell()
             self._file.seek(0, 2)
-            self._size = self._file.tell() - 1
+            self._size = self._file.tell()
             self._file.seek(orig)
-        return self._size
+            self._maximum_address = self._size - 1
+        return self._maximum_address
 
     @property
     def minimum_address(self) -> int:

--- a/volatility3/framework/layers/physical.py
+++ b/volatility3/framework/layers/physical.py
@@ -113,7 +113,7 @@ class FileLayer(interfaces.layers.DataLayerInterface):
     def maximum_address(self) -> int:
         """Returns the largest available address in the space."""
         # Zero based, so we return the size of the file minus 1
-        if self._maximum_address
+        if self._maximum_address:
             return self._maximum_address
         with self._lock:
             orig = self._file.tell()


### PR DESCRIPTION
https://github.com/volatilityfoundation/volatility3/blob/9bfa7187daed41791217e29afb828a5a5ab58e5b/volatility3/framework/layers/physical.py#L115

Closely related to #713.
Maximum address is the last valid address.
File size was returned and not file size minus 1.