### PR TITLE
Fix: typo for method comments (`hash`, `optional_set_type_class`).

### DIFF
--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -321,7 +321,7 @@ class SizedModule(Module):
 
         The mapping should be sorted and should be quicker than reading
         the data We turn it into JSON to make a common string and use a
-        quick hash, because collissions are unlikely
+        quick hash, because collisions are unlikely
         """
         layer = self._context.layers[self.layer_name]
         if not isinstance(layer, interfaces.layers.TranslationLayerInterface):

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -169,7 +169,7 @@ class BaseSymbolTableInterface:
 
     def optional_set_type_class(self, name: str, clazz: Type[objects.ObjectInterface]) -> bool:
         """Calls the set_type_class function but does not throw an exception.
-        Returns whether setting the type class was successfull.
+        Returns whether setting the type class was successful.
         Args:
             name: The name of the type to override the class for
             clazz: The actual class to override for the provided type name


### PR DESCRIPTION
Hello, everyone in the community! 🙂
I found some typo for code comments.