### PR TITLE
Check return value from is_valid

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -746,7 +746,10 @@ class LIST_ENTRY(objects.StructType, collections.abc.Iterable):
         trans_layer = self._context.layers[layer]
 
         try:
-            trans_layer.is_valid(self.vol.offset)
+            is_valid = trans_layer.is_valid(self.vol.offset)
+            if not is_valid:
+                return
+
             link = getattr(self, direction).dereference()
         except exceptions.InvalidAddressException:
             return
@@ -762,7 +765,9 @@ class LIST_ENTRY(objects.StructType, collections.abc.Iterable):
             obj_offset = link.vol.offset - relative_offset
 
             try:
-                trans_layer.is_valid(obj_offset)
+                is_valid = trans_layer.is_valid(obj_offset)
+                if not is_valid:
+                    return
             except exceptions.InvalidAddressException:
                 return
 

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -764,11 +764,7 @@ class LIST_ENTRY(objects.StructType, collections.abc.Iterable):
         while link.vol.offset not in seen:
             obj_offset = link.vol.offset - relative_offset
 
-            try:
-                is_valid = trans_layer.is_valid(obj_offset)
-                if not is_valid:
-                    return
-            except exceptions.InvalidAddressException:
+            if not trans_layer.is_valid(obj_offset):
                 return
 
             obj = self._context.object(symbol_type,


### PR DESCRIPTION
`is_valid` returns a `bool`. 
That `bool` is ignored in the `_LIST_ENTRY` parsing function causing invalid entries to be yielded.
