### PR TITLE
Add: JSON `EOF` for `config` file. (`cli`, `volshell`)

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -332,6 +332,7 @@ class CommandLine:
                     parser.error(f"Cannot write configuration: file {args.save_config} already exists")
                 with open(args.save_config, "w") as f:
                     json.dump(dict(constructed.build_configuration()), f, sort_keys = True, indent = 2)
+                    f.write("\n")
         except exceptions.UnsatisfiedException as excp:
             self.process_unsatisfied_exceptions(excp)
             parser.exit(1, f"Unable to validate the plugin requirements: {[x for x in excp.unsatisfied]}\n")

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -246,6 +246,7 @@ class VolShell(cli.CommandLine):
                     parser.error(f"Cannot write configuration: file {args.save_config} already exists")
                 with open(args.save_config, "w") as f:
                     json.dump(dict(constructed.build_configuration()), f, sort_keys = True, indent = 2)
+                    f.write("\n")
         except exceptions.UnsatisfiedException as excp:
             self.process_unsatisfied_exceptions(excp)
             parser.exit(1, f"Unable to validate the plugin requirements: {[x for x in excp.unsatisfied]}\n")


### PR DESCRIPTION
## Description

Hello, everyone in the community! 🙂
This PR is related to #736.
When I dump the config file in JSON form and read it on the terminal, I checked that EOF does not exist.
So I added EOF data for _volatility_ `cli` and `volshell`

```
  "kernel.symbol_table_name.class": "volatility3.framework.symbols.windows.WindowsKernelIntermedSymbols",
  "kernel.symbol_table_name.isf_url": "file:///Users/donghyunkim/Desktop/volatility3/volatility3/symbols/windows/ntkrpamp.pdb/78C36230DCC38A999E9C6C00C3EC5823-1.json.xz",
  "kernel.symbol_table_name.symbol_mask": 0,
  "physical": false,
  "pid": []
}%
```

## Result

```
  "kernel.symbol_table_name.class": "volatility3.framework.symbols.windows.WindowsKernelIntermedSymbols",
  "kernel.symbol_table_name.isf_url": "file:///Users/donghyunkim/Desktop/volatility3/volatility3/symbols/windows/ntkrpamp.pdb/78C36230DCC38A999E9C6C00C3EC5823-1.json.xz",
  "kernel.symbol_table_name.symbol_mask": 0,
  "physical": false,
  "pid": []
}
```
