### PR TITLE
Fix: file close context manager (`__del__` to `__exit__`) for physical layers.

### DIFF
--- a/volatility3/framework/layers/physical.py
+++ b/volatility3/framework/layers/physical.py
@@ -191,7 +191,7 @@ class FileLayer(interfaces.layers.DataLayerInterface):
         """Closes the file handle."""
         self._file.close()
 
-    def __del__(self) -> None:
+    def __exit__(self) -> None:
         self.destroy()
 
     @classmethod


### PR DESCRIPTION
## Description

Hello, everyone in the community! 🙂

If we create a `config` file using `--write-config` and use it as a parameter (`-c`), the result of the plugin is normally performed, but we can see that an error occurs at the end.

### Command
```shell
> python3 vol.py -c config.json -f 32.vmem windows.info
```

### Result
I have experienced the same results and to all Windows and Mac OS X.
```shell
Traceback (most recent call last):
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/layers/physical.py", line 196, in __del__
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/layers/physical.py", line 192, in destroy
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/layers/physical.py", line 110, in _file
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/layers/resources.py", line 102, in open
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 601, in build_opener
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 1400, in __init__
ImportError: sys.meta_path is None, Python is likely shutting down
```

I saw the same error in this issue (#627), so I thought it was an error related to UNC Path.
But as a result of debugging, I thought there was a problem elsewhere.

### Solution

Especially after reviewing the various [documents](https://stackoverflow.com/questions/67902926/python-importerror-in-del-how-to-solve-this), and issues (https://github.com/SeleniumHQ/selenium/issues/8571) for large projects,
I could guess that we had a problem with the context manager to close the file handler.

The key to these is that `__del__` is not reliable. The situation may cause the above error due to a different call point.
Therefore, we have a variety of solutions, such as how to make a separate fix or device to follow the order of terminating the file handler, or ignore errors.

- Add `try`/`except` and `pass` on close method
- Using [`atexit`](https://docs.python.org/3/library/atexit.html) register
- Change context manager `__del__` to `__exit__`

But I'm going to take the most stable method at this moment.
If you know any preference or other good ways, please leave your comments!

## Credit
Thank you for my friend Eungchang Lee (@tobecert) for reporting this issue.