### PR TITLE
CLI: Add support for a configuration options file

### DIFF
--- a/doc/source/vol-cli.rst
+++ b/doc/source/vol-cli.rst
@@ -143,3 +143,18 @@ Options
     `hivescan` would match `windows.registry.hivescan.HiveScan`, but
     `pslist` is ambiguous because it could match `windows.pslist` or
     `linux.pslist`.
+
+Overriding options
+------------------
+
+The default values for the command line interface are defined by constants within the code,
+but can be overridden by creating a JSON file (`%APPDATA%/volatility3/vol.json` for Windows
+systems, or `~/.config/volatility3/vol.json` or `volshell.json` for all others).
+
+The format of this file is a JSON dictionary, containing the options above and their value.
+It should be noted that the ordering is (`<` means is overridden by):
+
+`in-built default value < config file value < command line parameter`
+
+It should also be noted that boolean flags (such as `offline`) that are overridden as true will
+not be unset by not specifying the command line flag.

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -106,7 +106,7 @@ class CommandLine:
         )
 
         # Load up system defaults
-        delayed_logs, default_config = self.load_system_defaults('vol.json')
+        delayed_logs, default_config = self.load_system_defaults("vol.json")
 
         parser = volargparse.HelpfulArgParser(
             add_help=False,
@@ -280,7 +280,7 @@ class CommandLine:
 
         if partial_args.cache_path:
             constants.CACHE_PATH = partial_args.cache_path
-        
+
         vollog.info(f"Volatility plugins path: {volatility3.plugins.__path__}")
         vollog.info(f"Volatility symbols path: {volatility3.symbols.__path__}")
 
@@ -473,28 +473,47 @@ class CommandLine:
         )
         return requirements.URIRequirement.location_from_file(filename)
 
-    def load_system_defaults(self, filename: str) -> Tuple[List[Tuple[int, str]], Dict[str, Any]]:
+    def load_system_defaults(
+        self, filename: str
+    ) -> Tuple[List[Tuple[int, str]], Dict[str, Any]]:
         """Modify the main configuration based on the default configuration override"""
         # Build the config path
-        default_config_path = os.path.join(os.path.expanduser("~"), ".config", "volatility3", filename)
-        if sys.platform == 'win32':
-            default_config_path = os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3",
-                                               filename)
+        default_config_path = os.path.join(
+            os.path.expanduser("~"), ".config", "volatility3", filename
+        )
+        if sys.platform == "win32":
+            default_config_path = os.path.join(
+                os.environ.get("APPDATA", os.path.expanduser("~")),
+                "volatility3",
+                filename,
+            )
 
         delayed_logs = []
 
         # Process it if the files exist
         if os.path.exists(default_config_path):
-            with open(default_config_path, 'rb') as config_json:
+            with open(default_config_path, "rb") as config_json:
                 result = json.load(config_json)
             if not isinstance(result, dict):
-                delayed_logs.append((logging.INFO,
-                                     f'Default configuration file {default_config_path} does not contain a dictionary'))
+                delayed_logs.append(
+                    (
+                        logging.INFO,
+                        f"Default configuration file {default_config_path} does not contain a dictionary",
+                    )
+                )
             else:
                 delayed_logs.append(
-                    (logging.INFO, f"Loading default configuration options from {default_config_path}"))
-                delayed_logs.append((logging.DEBUG,
-                                     f"Loaded configuration: {json.dumps(result, indent = 2, sort_keys = True)}"))
+                    (
+                        logging.INFO,
+                        f"Loading default configuration options from {default_config_path}",
+                    )
+                )
+                delayed_logs.append(
+                    (
+                        logging.DEBUG,
+                        f"Loaded configuration: {json.dumps(result, indent = 2, sort_keys = True)}",
+                    )
+                )
                 return delayed_logs, result
         return delayed_logs, {}
 

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -388,7 +388,8 @@ class CommandLine:
 
         # Process it if the files exist
         if os.path.exists(default_config_path):
-            result = json.load(open(default_config_path, 'rb'))
+            with open(default_config_path, 'rb') as config_json:
+                result = json.load(config_json)
             if not isinstance(result, dict):
                 delayed_logs.append((logging.INFO,
                                      f'Default configuration file {default_config_path} does not contain a dictionary'))

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -19,7 +19,7 @@ import os
 import sys
 import tempfile
 import traceback
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, List, Tuple, Type, Union
 from urllib import parse, request
 
 import volatility3.plugins
@@ -91,6 +91,9 @@ class CommandLine:
         volatility3.framework.require_interface_version(2, 0, 0)
 
         renderers = dict([(x.name.lower(), x) for x in framework.class_subclasses(text_renderer.CLIRenderer)])
+
+        # Load up system defaults
+        delayed_logs, default_config = self.load_system_defaults('vol.json')
 
         parser = volargparse.HelpfulArgParser(add_help = False,
                                               prog = self.CLI_NAME,
@@ -174,6 +177,8 @@ class CommandLine:
                             default = False,
                             action = 'store_true')
 
+        parser.set_defaults(**default_config)
+
         # We have to filter out help, otherwise parse_known_args will trigger the help message before having
         # processed the plugin choice or had the plugin subparser added.
         known_args = [arg for arg in sys.argv if arg != '--help' and arg != '-h']
@@ -184,17 +189,7 @@ class CommandLine:
             banner_output = sys.stderr
         banner_output.write(f"Volatility 3 Framework {constants.PACKAGE_VERSION}\n")
 
-        if partial_args.plugin_dirs:
-            volatility3.plugins.__path__ = [os.path.abspath(p)
-                                            for p in partial_args.plugin_dirs.split(";")] + constants.PLUGINS_PATH
-
-        if partial_args.symbol_dirs:
-            volatility3.symbols.__path__ = [os.path.abspath(p)
-                                            for p in partial_args.symbol_dirs.split(";")] + constants.SYMBOL_BASEPATHS
-
-        if partial_args.cache_path:
-            constants.CACHE_PATH = partial_args.cache_path
-
+        ### Start up logging
         if partial_args.log:
             file_logger = logging.FileHandler(partial_args.log)
             file_logger.setLevel(1)
@@ -209,6 +204,21 @@ class CommandLine:
             console.setLevel(30 - (partial_args.verbosity * 10))
         else:
             console.setLevel(10 - (partial_args.verbosity - 2))
+
+        for level, msg in delayed_logs:
+            vollog.log(level, msg)
+
+        ### Alter constants if necessary
+        if partial_args.plugin_dirs:
+            volatility3.plugins.__path__ = [os.path.abspath(p)
+                                            for p in partial_args.plugin_dirs.split(";")] + constants.PLUGINS_PATH
+
+        if partial_args.symbol_dirs:
+            volatility3.symbols.__path__ = [os.path.abspath(p)
+                                            for p in partial_args.symbol_dirs.split(";")] + constants.SYMBOL_BASEPATHS
+
+        if partial_args.cache_path:
+            constants.CACHE_PATH = partial_args.cache_path
 
         vollog.info(f"Volatility plugins path: {volatility3.plugins.__path__}")
         vollog.info(f"Volatility symbols path: {volatility3.symbols.__path__}")
@@ -365,6 +375,30 @@ class CommandLine:
                     raise ValueError("File URL looks incorrect (potentially missing /)")
                 raise ValueError(f"File does not exist: {filename}")
         return parse.urlunparse(single_location)
+
+    def load_system_defaults(self, filename: str) -> Tuple[List[Tuple[int, str]], Dict[str, Any]]:
+        """Modify the main configuration based on the default configuration override"""
+        # Build the config path
+        default_config_path = os.path.join(os.path.expanduser("~"), ".config", "volatility3", filename)
+        if sys.platform == 'win32':
+            default_config_path = os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3",
+                                               filename)
+
+        delayed_logs = []
+
+        # Process it if the files exist
+        if os.path.exists(default_config_path):
+            result = json.load(open(default_config_path, 'rb'))
+            if not isinstance(result, dict):
+                delayed_logs.append((logging.INFO,
+                                     f'Default configuration file {default_config_path} does not contain a dictionary'))
+            else:
+                delayed_logs.append(
+                    (logging.INFO, f"Loading default configuration options from {default_config_path}"))
+                delayed_logs.append((logging.DEBUG,
+                                     f"Loaded configuration: {json.dumps(result, indent = 2, sort_keys = True)}"))
+                return delayed_logs, result
+        return delayed_logs, {}
 
     def process_exceptions(self, excp):
         """Provide useful feedback if an exception occurs during a run of a plugin."""

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -56,7 +56,7 @@ class VolShell(cli.CommandLine):
         framework.require_interface_version(2, 0, 0)
 
         # Load up system defaults
-        delayed_logs, default_config = self.load_system_defaults('volshell.json')
+        delayed_logs, default_config = self.load_system_defaults("volshell.json")
 
         parser = argparse.ArgumentParser(
             prog=self.CLI_NAME,
@@ -151,10 +151,12 @@ class VolShell(cli.CommandLine):
             default=constants.CACHE_PATH,
             type=str,
         )
-        parser.add_argument("--offline",
-                            help = "Do not search online for additional JSON files",
-                            default = False,
-                            action = 'store_true')
+        parser.add_argument(
+            "--offline",
+            help="Do not search online for additional JSON files",
+            default=False,
+            action="store_true",
+        )
 
         # Volshell specific flags
         os_specific = parser.add_mutually_exclusive_group(required=False)

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -15,12 +15,14 @@ from volatility3.cli.volshell import generic, linux, mac, windows
 from volatility3.framework import automagic, constants, contexts, exceptions, interfaces, plugins
 
 # Make sure we log everything
+
+rootlog = logging.getLogger()
 vollog = logging.getLogger()
 vollog.setLevel(0)
-# Trim the console down by default
 console = logging.StreamHandler()
 console.setLevel(logging.WARNING)
 formatter = logging.Formatter('%(levelname)-8s %(name)-12s: %(message)s')
+# Trim the console down by default
 console.setFormatter(formatter)
 vollog.addHandler(console)
 


### PR DESCRIPTION
This adds support for creating a `~/.config/volatility3/vol.json` or `volshell.json` file to handle standard command line parameters.  The ordering will go:

Command line parameter else
JSON command line parameter else
`Constants.py` file else
Hard coded default

The last two may be slightly conflated, since the hard coded default might be the value from the `constants.py` file.

I'd considered adding the CLI config to the volatility context config, but I think that might muddy the waters, with the UI variables accessible to plugins.  Plugins should not need to be interrogating the UI, the UI should tell the plugin everything it needs to know upfront.

This doesn't immediately deal with parameters that aren't exposed by the CLI, but it does offer the ability for the JSON to store additional options that could be used by other features (such as renderers).  I still feel these options should be exposed programmatically, so different UIs can offer means of setting them (since not all other UIs will use the config file).  I still think this is a reasonable solution, slots in cleanly to the UI and provides expansion capability with a bit more consideration.  JSON might be a little too descriptive, given the CLI technically only takes specific types, but I think it will help with future expansion, and we've got space for type checking on load.