### PR TITLE
Fix: typo for code comments (`templates`, `timeliner`, `linux plugins`).

### DIFF
--- a/volatility3/framework/objects/templates.py
+++ b/volatility3/framework/objects/templates.py
@@ -63,7 +63,7 @@ class ObjectTemplate(interfaces.objects.Template):
                  object_info: interfaces.objects.ObjectInformation) -> interfaces.objects.ObjectInterface:
         """Constructs the object.
 
-        Returns: an object adhereing to the :class:`~volatility3.framework.interfaces.objects.ObjectInterface`
+        Returns: an object adhering to the :class:`~volatility3.framework.interfaces.objects.ObjectInterface`
         """
         arguments: Dict[str, Any] = {}
         for arg in self.vol:

--- a/volatility3/framework/plugins/linux/psaux.py
+++ b/volatility3/framework/plugins/linux/psaux.py
@@ -40,7 +40,7 @@ class PsAux(plugins.PluginInterface):
             name: string name of the process (from task.comm)
         """
 
-        # kernel theads never have an mm as they do not have userland mappings
+        # kernel threads never have an mm as they do not have userland mappings
         try:
             mm = task.mm
         except exceptions.InvalidAddressException:

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -19,7 +19,7 @@ class PsTree(pslist.PsList):
         """Finds how deep the PID is in the tasks hierarchy.
 
         Args:
-            pid: PID to find the level in the hierachy
+            pid: PID to find the level in the hierarchy
         """
         seen = set([pid])
         level = 0

--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -101,7 +101,7 @@ class Timeliner(interfaces.plugins.PluginInterface):
 
         return [sortable(timestamp) for timestamp in data[2:]]
 
-    def _generator(self, runable_plugins: List[TimeLinerInterface]) -> Optional[Iterable[Tuple[int, Tuple]]]:
+    def _generator(self, runnable_plugins: List[TimeLinerInterface]) -> Optional[Iterable[Tuple[int, Tuple]]]:
         """Takes a timeline, sorts it and output the data from each relevant
         row from each plugin."""
         # Generate the results for each plugin
@@ -115,9 +115,9 @@ class Timeliner(interfaces.plugins.PluginInterface):
             file_data = None
             fp = None
 
-        for plugin in runable_plugins:
+        for plugin in runnable_plugins:
             plugin_name = plugin.__class__.__name__
-            self._progress_callback((runable_plugins.index(plugin) * 100) // len(runable_plugins),
+            self._progress_callback((runnable_plugins.index(plugin) * 100) // len(runnable_plugins),
                                     f"Running plugin {plugin_name}...")
             try:
                 vollog.log(logging.INFO, f"Running {plugin_name}")


### PR DESCRIPTION
## Description
Hello, everyone in the community 🙂

I fixed typo of code comments.