### PR TITLE
Fix: typo for code comment, requirements name (`windows.modscan`).

### DIFF
--- a/volatility3/framework/interfaces/configuration.py
+++ b/volatility3/framework/interfaces/configuration.py
@@ -523,7 +523,7 @@ class ConstructableRequirementInterface(RequirementInterface):
     must happen after the class configuration value has been provided).
     These values are then provided to the object's constructor by name
     as arguments (as well as the standard `context` and `config_path`
-    arguments.
+    arguments).
     """
 
     def __init__(self, *args, **kwargs) -> None:

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -307,7 +307,7 @@ class DataLayerInterface(interfaces.configuration.ConfigurableInterface, metacla
             while length > 0:
                 chunk_size = min(length, scanner.chunk_size + scanner.overlap)
                 yield [(layer_name, mapped_offset, chunk_size)], offset + chunk_size
-                # It we've got more than the scanner's chunk_size, only move up by the chunk_size
+                # If we've got more than the scanner's chunk_size, only move up by the chunk_size
                 if chunk_size > scanner.chunk_size:
                     chunk_size -= scanner.overlap
                 length -= chunk_size
@@ -517,7 +517,7 @@ class TranslationLayerInterface(DataLayerInterface, metaclass = ABCMeta):
                         yield output, chunk_position
                         output = []
                         chunk_position = chunk_start
-                    # Take from chunk_position as far as far as the block can go,
+                    # Take from chunk_position as far as the block can go,
                     # or as much left of a scanner chunk as we can
                     chunk_size = min(block_end - chunk_position,
                                      scanner.chunk_size + scanner.overlap - (chunk_position - chunk_start))

--- a/volatility3/framework/plugins/mac/kevents.py
+++ b/volatility3/framework/plugins/mac/kevents.py
@@ -74,7 +74,7 @@ class Kevents(interfaces.plugins.PluginInterface):
     @classmethod
     def _walk_klist_array(cls, kernel, fdp, array_pointer_member, array_size_member):
         """
-        Convience wrapper for walking an array of lists of kernel events
+        Convenience wrapper for walking an array of lists of kernel events
         Handles invalid address references
         """
         try:

--- a/volatility3/framework/plugins/windows/modscan.py
+++ b/volatility3/framework/plugins/windows/modscan.py
@@ -25,7 +25,7 @@ class ModScan(interfaces.plugins.PluginInterface):
         return [
             requirements.ModuleRequirement(name = 'kernel', description = 'Windows kernel',
                                                      architectures = ["Intel32", "Intel64"]),
-            requirements.VersionRequirement(name = 'poolerscanner',
+            requirements.VersionRequirement(name = 'poolscanner',
                                             component = poolscanner.PoolScanner,
                                             version = (1, 0, 0)),
             requirements.VersionRequirement(name = 'pslist', component = pslist.PsList, version = (2, 0, 0)),


### PR DESCRIPTION
## Description
Hello, everyone in the community 🙂

I fixed typo of code comments.
And fixed name `VersionRequirements` of `windows.modscan` plugin.
Even if the name is different, it does not affect the result, but we revised it for uniformity.