### PR TITLE
Remove: unreachable code (`UnsatisfiedExceptions` Message) of `volshell`. 

### DIFF
--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -257,7 +257,6 @@ class VolShell(cli.CommandLine):
                 constructed.run()
         except exceptions.VolatilityException as excp:
             self.process_exceptions(excp)
-            parser.exit(1, f"Unable to validate the plugin requirements: {[x for x in excp.unsatisfied]}\n")
 
 
 def main():


### PR DESCRIPTION
## Descriptions
Hello, everyone in the community 🙂

While I was looking at the code in the `volshell`, I found a code that could not be reached (code that would not be used) due to error processing. This message should be used as a message for `UnsatisfiedException`, but `process_exception` method has its own call termination function, so subsequent code will not be executed. It has the [same error handling syntax ](https://github.com/volatilityfoundation/volatility3/blob/baf92254afac52d6304bdb4fa1acc65aaced7239/volatility3/cli/__init__.py#L345)as `vol-cli`, but there is no code to output the message, so it probably not removed from the `volshell` (mistake?).