### PR TITLE
Refactor: simplify comparision syntax.

### DIFF
--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -148,7 +148,7 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
 
         vollog.debug("Kernel base determination - optimized scan virtual layer")
         valid_kernel = self._method_layer_pdb_scan(context, vlayer, test_virtual_kernel, True, False, progress_callback)
-        if valid_kernel != None:
+        if valid_kernel is not None:
             return valid_kernel
 
         vollog.debug("Kernel base determination - slow scan virtual layer")

--- a/volatility3/framework/plugins/windows/ldrmodules.py
+++ b/volatility3/framework/plugins/windows/ldrmodules.py
@@ -71,14 +71,14 @@ class LdrModules(interfaces.plugins.PluginInterface):
                 mem_mod = mem_order_mod.get(base, None)
 
                 yield (0, [int(proc.UniqueProcessId),
-                            str(proc.ImageFileName.cast("string",
+                           str(proc.ImageFileName.cast("string",
                                                 max_length = proc.ImageFileName.vol.count,
                                                 errors = 'replace')),
-                            format_hints.Hex(base),
-                            load_mod != None,
-                            init_mod != None,
-                            mem_mod != None,
-                            mapped_files[base]])
+                           format_hints.Hex(base),
+                           load_mod is not None,
+                           init_mod is not None,
+                           mem_mod is not None,
+                           mapped_files[base]])
 
     def run(self):
         filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))

--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -132,7 +132,7 @@ class VadInfo(interfaces.plugins.PluginInterface):
             vollog.debug("Unable to find the starting/ending VPN member")
             return None
 
-        if maxsize > 0 and (vad_end - vad_start) > maxsize:
+        if 0 < maxsize < (vad_end - vad_start):
             vollog.debug(f"Skip VAD dump {vad_start:#x}-{vad_end:#x} due to maxsize limit")
             return None
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -409,7 +409,7 @@ class vm_area_struct(objects.StructType):
             fname = linux.LinuxUtilities.path_for_file(context, task, self.vm_file)
         elif self.vm_start <= task.mm.start_brk and self.vm_end >= task.mm.brk:
             fname = "[heap]"
-        elif self.vm_start <= task.mm.start_stack and self.vm_end >= task.mm.start_stack:
+        elif self.vm_start <= task.mm.start_stack <= self.vm_end:
             fname = "[stack]"
         elif self.vm_mm.context.has_member("vdso") and self.vm_start == self.vm_mm.context.vdso:
             fname = "[vdso]"


### PR DESCRIPTION
## Description
Hello, everyone in the community! 🙂

I did some refactoring on comparison syntax.
I have modified the comparison that can be improved to make it more intuitive and easier for users to understand.
And `None` type of comparison use [recommend](https://peps.python.org/pep-0008/#programming-recommendations) to `is` or `is not`.