### PR TITLE
Core: Add support to templates to get child templates

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -39,7 +39,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 2  # Number of changes that only add to the interface
+VERSION_MINOR = 3  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -243,6 +243,13 @@ class ObjectInterface(metaclass = abc.ABCMeta):
 
         @classmethod
         @abc.abstractmethod
+        def child_template(cls, template: 'Template', child: str) -> interfaces.objects.Template:
+            """Returns the template of the child member from the parent."""
+            raise KeyError(f"Template does not contain any children: {template.vol.type_name}")
+
+
+        @classmethod
+        @abc.abstractmethod
         def has_member(cls, template: 'Template', member_name: str) -> bool:
             """Returns whether the object would contain a member called
             member_name."""
@@ -304,6 +311,10 @@ class Template:
     def relative_child_offset(self, child: str) -> int:
         """Returns the relative offset of the `child` member from its parent
         offset."""
+
+    @abc.abstractmethod
+    def child_template(self, child: str) -> interfaces.objects.Template:
+        """Returns the `child` member template from its parent."""
 
     @abc.abstractmethod
     def replace_child(self, old_child: 'Template', new_child: 'Template') -> None:

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -605,7 +605,7 @@ class Array(interfaces.objects.ObjectInterface, collections.abc.Sequence):
         @classmethod
         def child_template(cls, template: interfaces.objects.Template, child: str) -> interfaces.objects.Template:
             """Returns the template of the child member."""
-            if 'subtype' in template.vol and child == 'subtype'@
+            if 'subtype' in template.vol and child == 'subtype':
                 return template.vol.subtype
             raise IndexError(f"Member not present in array template: {child}")
 

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -602,6 +602,14 @@ class Array(interfaces.objects.ObjectInterface, collections.abc.Sequence):
                 return 0
             raise IndexError(f"Member not present in array template: {child}")
 
+        @classmethod
+        def child_template(cls, template: interfaces.objects.Template, child: str) -> interfaces.objects.Template:
+            """Returns the template of the child member."""
+            if 'subtype' in template.vol and child == 'subtype'@
+                return template.vol.subtype
+            raise IndexError(f"Member not present in array template: {child}")
+
+
     @overload
     def __getitem__(self, i: int) -> interfaces.objects.Template:
         ...
@@ -714,6 +722,15 @@ class AggregateType(interfaces.objects.ObjectInterface):
             if retlist is None:
                 raise IndexError(f"Member not present in template: {child}")
             return retlist[0]
+
+        @classmethod
+        def child_template(cls, template: interfaces.objects.Template, child: str) -> interfaces.objects.Template:
+            """Returns the template of a child to its parent."""
+            retlist = template.vol.members.get(child, None)
+            if retlist is None:
+                raise IndexError(f"Member not present in template: {child}")
+            return retlist[1]
+
 
         @classmethod
         def has_member(cls, template: interfaces.objects.Template, member_name: str) -> bool:

--- a/volatility3/framework/objects/templates.py
+++ b/volatility3/framework/objects/templates.py
@@ -48,6 +48,12 @@ class ObjectTemplate(interfaces.objects.Template):
         plateProxy`)"""
         return self.vol.object_class.VolTemplateProxy.relative_child_offset(self, child)
 
+    def child_template(self, child: str) -> interfaces.objects.Template:
+        """Returns the template of a child of the templated object (see
+        :class:`~volatility3.framework.interfaces.objects.ObjectInterface.VolTem
+        plateProxy`)"""
+        return self.vol.object_class.VolTemplateProxy.child_template(self, child)
+
     def replace_child(self, old_child: interfaces.objects.Template, new_child: interfaces.objects.Template) -> None:
         """Replaces `old_child` for `new_child` in the templated object's child
         list (see :class:`~volatility3.framework.interfaces.objects.ObjectInterf
@@ -99,6 +105,7 @@ class ReferenceTemplate(interfaces.objects.Template):
     size: ClassVar[Any] = property(_unresolved)
     replace_child: ClassVar[Any] = _unresolved
     relative_child_offset: ClassVar[Any] = _unresolved
+    child_template: ClassVar[Any] = _unresolved
     has_member: ClassVar[Any] = _unresolved
 
     def __call__(self, context: interfaces.context.ContextInterface, object_info: interfaces.objects.ObjectInformation):


### PR DESCRIPTION
This adds a new call to the API to stop people rummaging around inside the internal state of volatility.