### PR TITLE
Core: Convert try/except/pass to contextlib.supress

### DIFF
--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -7,10 +7,11 @@ from loaded PE files.
 This module contains a standalone scanner, and also a :class:`~volatility3.framework.interfaces.layers.ScannerInterface`
 based scanner for use within the framework by calling :func:`~volatility3.framework.interfaces.layers.DataLayerInterface.scan`.
 """
+import contextlib
 import logging
 import math
 import os
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, Callable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from volatility3.framework import constants, exceptions, interfaces, layers
 from volatility3.framework.configuration import requirements
@@ -139,7 +140,8 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
                          vlayer: layers.intel.Intel,
                          progress_callback: constants.ProgressCallback = None) -> Optional[ValidKernelType]:
 
-        def test_virtual_kernel(physical_layer_name, virtual_layer_name: str, kernel: Dict[str, Any]) -> Optional[ValidKernelType]:
+        def test_virtual_kernel(physical_layer_name, virtual_layer_name: str, kernel: Dict[str, Any]) -> Optional[
+            ValidKernelType]:
             # It seems the kernel is loaded at a fixed mapping (presumably because the memory manager hasn't started yet)
             if kernel['mz_offset'] is None or not isinstance(kernel['mz_offset'], int):
                 # Rule out kernels that couldn't find a suitable MZ header
@@ -159,7 +161,8 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
                              vlayer: layers.intel.Intel,
                              progress_callback: constants.ProgressCallback = None) -> Optional[ValidKernelType]:
 
-        def test_physical_kernel(physical_layer_name:str , virtual_layer_name: str, kernel: Dict[str, Any]) -> Optional[ValidKernelType]:
+        def test_physical_kernel(physical_layer_name: str, virtual_layer_name: str, kernel: Dict[str, Any]) -> Optional[
+            ValidKernelType]:
             # It seems the kernel is loaded at a fixed mapping (presumably because the memory manager hasn't started yet)
             if kernel['mz_offset'] is None or not isinstance(kernel['mz_offset'], int):
                 # Rule out kernels that couldn't find a suitable MZ header
@@ -274,7 +277,7 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
         kernel_pdb_names = [bytes(name + ".pdb", "utf-8") for name in constants.windows.KERNEL_MODULE_NAMES]
 
         virtual_layer_name = vlayer.name
-        try:
+        with contextlib.suppress(exceptions.InvalidAddressException):
             if vlayer.read(address, 0x2) == b'MZ':
                 res = list(
                     PDBUtility.pdbname_scan(ctx = context,
@@ -286,8 +289,6 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
                                             end = address + self.max_pdb_size))
                 if res:
                     valid_kernel = (virtual_layer_name, address, res[0])
-        except exceptions.InvalidAddressException:
-            pass
         return valid_kernel
 
     # List of methods to be run, in order, to determine the valid kernels

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -6,6 +6,7 @@ interpreted values of data from a layer."""
 import abc
 import collections
 import collections.abc
+import contextlib
 import logging
 from typing import Any, Dict, List, Mapping, Optional
 
@@ -187,11 +188,9 @@ class ObjectInterface(metaclass = abc.ABCMeta):
         """
         if self.has_member(member_name):
             # noinspection PyBroadException
-            try:
+            with contextlib.suppress(Exception):
                 _ = getattr(self, member_name)
                 return True
-            except Exception:
-                pass
         return False
 
     def has_valid_members(self, member_names: List[str]) -> bool:

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -1,6 +1,7 @@
 # This file is Copyright 2021 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
+import contextlib
 import logging
 import struct
 from typing import Tuple, Optional
@@ -202,11 +203,9 @@ class WindowsCrashDumpStacker(interfaces.automagic.StackerLayerInterface):
               layer_name: str,
               progress_callback: constants.ProgressCallback = None) -> Optional[interfaces.layers.DataLayerInterface]:
         for layer in [WindowsCrashDump32Layer, WindowsCrashDump64Layer]:
-            try:
+            with contextlib.suppress(WindowsCrashDumpFormatException):
                 layer.check_header(context.layers[layer_name])
                 new_name = context.layers.free_layer_name(layer.__name__)
                 context.config[interfaces.configuration.path_join(new_name, "base_layer")] = layer_name
                 return layer(context, new_name, new_name)
-            except WindowsCrashDumpFormatException:
-                pass
         return None

--- a/volatility3/framework/layers/resources.py
+++ b/volatility3/framework/layers/resources.py
@@ -184,14 +184,12 @@ class ResourceAccessor(object):
             stop = False
             while not stop:
                 detected = None
-                try:
+                with contextlib.suppress(AttributeError, IOError):
                     # Detect the content
                     detected = magic.detect_from_fobj(curfile)
                     IMPORTED_MAGIC = True
                     # This is because python-magic and file provide a magic module
                     # Only file's python has magic.detect_from_fobj
-                except (AttributeError, IOError):
-                    pass
 
                 if detected:
                     if detected.mime_type == 'application/x-xz':

--- a/volatility3/framework/plugins/linux/check_syscall.py
+++ b/volatility3/framework/plugins/linux/check_syscall.py
@@ -3,11 +3,11 @@
 #
 """A module containing a collection of plugins that produce data typically
 found in Linux's /proc file system."""
+import contextlib
 import logging
 from typing import List
 
-from volatility3.framework import exceptions, interfaces
-from volatility3.framework import renderers, constants
+from volatility3.framework import constants, exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.renderers import format_hints
@@ -40,11 +40,9 @@ class Check_syscall(plugins.PluginInterface):
 
         symbol_list = []
         for sn in vmlinux.symbols:
-            try:
+            with contextlib.suppress(exceptions.SymbolError):
                 # When requesting the symbol from the module, a full resolve is performed
                 symbol_list.append((vmlinux.get_symbol(sn).address, sn))
-            except exceptions.SymbolError:
-                pass
         sorted_symbols = sorted(symbol_list)
 
         sym_address = 0

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -1,7 +1,7 @@
 # This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-
+import contextlib
 import datetime
 import logging
 
@@ -56,7 +56,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         # Scan the layer for Raw MFT records and parse the fields
         for offset, _rule_name, _name, _value in layer.scan(context = self.context,
                                                             scanner = yarascan.YaraScanner(rules = rules)):
-            try:
+            with contextlib.suppress(exceptions.PagedInvalidAddressException):
                 mft_record = self.context.object(mft_object, offset = offset, layer_name = layer.name)
                 # We will update this on each pass in the next loop and use it as the new offset.
                 attr_base_offset = mft_record.FirstAttrOffset
@@ -130,9 +130,6 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                     attr_header = self.context.object(header_object,
                                                       offset = offset + attr_base_offset,
                                                       layer_name = layer.name)
-
-            except exceptions.PagedInvalidAddressException:
-                pass
 
     def generate_timeline(self):
         for row in self._generator():

--- a/volatility3/framework/renderers/conversion.py
+++ b/volatility3/framework/renderers/conversion.py
@@ -1,7 +1,7 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-
+import contextlib
 import datetime
 import ipaddress
 import socket
@@ -27,10 +27,8 @@ def unixtime_to_datetime(unixtime: int) -> Union[interfaces.renderers.BaseAbsent
     ret: Union[interfaces.renderers.BaseAbsentValue, datetime.datetime] = renderers.UnparsableValue()
 
     if unixtime > 0:
-        try:
+        with contextlib.suppress(ValueError):
             ret = datetime.datetime.utcfromtimestamp(unixtime)
-        except ValueError:
-            pass
 
     return ret
 

--- a/volatility3/framework/symbols/windows/__init__.py
+++ b/volatility3/framework/symbols/windows/__init__.py
@@ -1,10 +1,11 @@
 # This file is Copyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
+import contextlib
 
 from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.windows import extensions
-from volatility3.framework.symbols.windows.extensions import registry, pool, pe
+from volatility3.framework.symbols.windows.extensions import pe, pool, registry
 
 
 class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
@@ -39,26 +40,23 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class('_VACB', extensions.VACB)
         self.set_type_class('_POOL_TRACKER_BIG_PAGES', pool.POOL_TRACKER_BIG_PAGES)
         self.set_type_class('_IMAGE_DOS_HEADER', pe.IMAGE_DOS_HEADER)
-        
+
         # Might not necessarily defined in every version of windows
         self.optional_set_type_class('_IMAGE_NT_HEADERS', pe.IMAGE_NT_HEADERS)
         self.optional_set_type_class('_IMAGE_NT_HEADERS64', pe.IMAGE_NT_HEADERS)
 
         # This doesn't exist in very specific versions of windows
-        try:
+        with contextlib.suppress(ValueError):
             if self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("PoolType"):
                 self.set_type_class('_POOL_HEADER', pool.POOL_HEADER_VISTA)
             else:
                 self.set_type_class('_POOL_HEADER', pool.POOL_HEADER)
-        except ValueError:
-            pass
 
         # these don't exist in windows XP
         self.optional_set_type_class('_MMADDRESS_NODE', extensions.MMVAD_SHORT)
-        
+
         # these were introduced starting in windows 8
         self.optional_set_type_class('_MM_AVL_NODE', extensions.MMVAD_SHORT)
-        
+
         # these were introduced starting in windows 7
         self.optional_set_type_class('_RTL_BALANCED_NODE', extensions.MMVAD_SHORT)
-        

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -3,6 +3,7 @@
 #
 
 import collections.abc
+import contextlib
 import datetime
 import functools
 import logging
@@ -305,7 +306,7 @@ class MMVAD(MMVAD_SHORT):
 
         file_name = renderers.NotApplicableValue()
 
-        try:
+        with contextlib.suppress(exceptions.InvalidAddressException):
             # this is for xp and 2003
             if self.has_member("ControlArea"):
                 filename_obj = self.ControlArea.FilePointer.FileName
@@ -317,9 +318,6 @@ class MMVAD(MMVAD_SHORT):
 
             if filename_obj.Length > 0:
                 file_name = filename_obj.get_string()
-
-        except exceptions.InvalidAddressException:
-            pass
 
         return file_name
 
@@ -364,6 +362,7 @@ class DEVICE_OBJECT(objects.StructType, pool.ExecutiveObject):
             yield device
             device = device.AttachedDevice.dereference()
 
+
 class DRIVER_OBJECT(objects.StructType, pool.ExecutiveObject):
     """A class for kernel driver objects."""
 
@@ -374,7 +373,7 @@ class DRIVER_OBJECT(objects.StructType, pool.ExecutiveObject):
 
     def get_devices(self) -> Generator[ObjectInterface, None, None]:
         """Enumerate the driver's device objects"""
-        device =  self.DeviceObject.dereference()
+        device = self.DeviceObject.dereference()
         while device:
             yield device
             device = device.NextDevice.dereference()
@@ -413,15 +412,11 @@ class FILE_OBJECT(objects.StructType, pool.ExecutiveObject):
         # this pointer needs to be checked against native_layer_name because the object may
         # be instantiated from a primary (virtual) layer or a memory (physical) layer.
         if self._context.layers[self.vol.native_layer_name].is_valid(self.DeviceObject):
-            try:
+            with contextlib.suppress(ValueError):
                 name = f"\\Device\\{self.DeviceObject.get_device_name()}"
-            except ValueError:
-                pass
 
-        try:
+        with contextlib.suppress(TypeError, exceptions.InvalidAddressException):
             name += self.FileName.String
-        except (TypeError, exceptions.InvalidAddressException):
-            pass
 
         return name
 
@@ -1114,12 +1109,10 @@ class SHARED_CACHE_MAP(objects.StructType):
         iterval = 0
         while (iterval < full_blocks) and (full_blocks <= 4):
             vacb_obj = self.InitialVacbs[iterval]
-            try:
+            with contextlib.suppress(exceptions.InvalidAddressException):
                 # Make sure that the SharedCacheMap member of the VACB points back to the parent object.
                 if vacb_obj.SharedCacheMap == self.vol.offset:
                     self.save_vacb(vacb_obj, vacb_list)
-            except exceptions.InvalidAddressException:
-                pass
             iterval += 1
 
         # We also have to account for the spill over data that is not found in the full blocks.

--- a/volatility3/framework/symbols/windows/extensions/registry.py
+++ b/volatility3/framework/symbols/windows/extensions/registry.py
@@ -1,7 +1,7 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-
+import contextlib
 import enum
 import logging
 import struct
@@ -75,12 +75,10 @@ class CMHIVE(objects.StructType):
         """
 
         for attr in ["FileFullPath", "FileUserName", "HiveRootPath"]:
-            try:
+            with contextlib.suppress(AttributeError, exceptions.InvalidAddressException):
                 name = getattr(self, attr)
                 if name.Length > 0:
                     return name.get_string()
-            except (AttributeError, exceptions.InvalidAddressException):
-                pass
 
         return None
 


### PR DESCRIPTION
This is based on a recommendation from @utkonos in #776 to consider using `contextlib.suppress` for exceptions that simply pass.  Note there's a few cases where this hasn't been applied:
* Where multiple exceptions are caught and not all pass.
* Where the UI removes imports (such as smb) when attempting to suppress import errors.