### PR TITLE
fix _do_get_path

### DIFF
--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -55,7 +55,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         ret_path: List[str] = []
 
         while dentry != rdentry or vfsmnt != rmnt:
-            dname = dentry.path()
+            dname = dentry.path().rsplit("/", 1)[-1]
             if dname == "":
                 break
 


### PR DESCRIPTION
_do_get_path() was written when dentry.path() returned *only* the d_name of dentry.
Now, dentry.path() actually returns the path, but _do_get_path() was unchanged.
This PR just makes _do_get_path() behave the same way as before, by extracting from dentry.path() only the last component in the path.

