### PR TITLE
Fix a bug with _get_do_path() in LinuxUtilities

### DIFF
--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -55,7 +55,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         ret_path: List[str] = []
 
         while dentry != rdentry or vfsmnt != rmnt:
-            dname = dentry.path()
+            dname = dentry.path().rsplit("/", 1)[-1]
             if dname == "":
                 break
 


### PR DESCRIPTION
_do_get_path uses dentry.path(), which returned the name of dentry (d_name). Later, dentry.path() was changed to return a full path, but _do_get_path wasn't altered accordignly.

This PR just extract the last component from the path returned by dentry.path(), so it will behave the same way as before.
