### PR TITLE
Add: license comment (`VSL`) for missing files. 

### DIFF
--- a/volatility3/framework/automagic/module.py
+++ b/volatility3/framework/automagic/module.py
@@ -1,3 +1,7 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
 from volatility3.framework import interfaces, constants, configuration
 
 

--- a/volatility3/framework/layers/avml.py
+++ b/volatility3/framework/layers/avml.py
@@ -1,3 +1,7 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
 """Functions that read AVML files.
 
 The user of the file doesn't have to worry about the compression,

--- a/volatility3/framework/layers/codecs/__init__.py
+++ b/volatility3/framework/layers/codecs/__init__.py
@@ -1,3 +1,7 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
 """Codecs used for encoding or decoding data should live here
 
 

--- a/volatility3/framework/layers/leechcore.py
+++ b/volatility3/framework/layers/leechcore.py
@@ -1,3 +1,7 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
 import io
 import logging
 import urllib.parse

--- a/volatility3/framework/layers/linear.py
+++ b/volatility3/framework/layers/linear.py
@@ -1,3 +1,7 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
 import functools
 from typing import List, Optional, Tuple, Iterable
 

--- a/volatility3/framework/plugins/frameworkinfo.py
+++ b/volatility3/framework/plugins/frameworkinfo.py
@@ -1,3 +1,7 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
 from typing import List
 
 from volatility3 import framework


### PR DESCRIPTION
## Description
Hello, everyone in the community! 🙂
A separate license exists called VSL, to qualify for the work of the Volatility Foundation community.
I found that the license statement was missing in some files.
I added it to ensure uniformity and rights among the files.