### PR TITLE
Fix: cache path for python of `Microsoft Store` version.

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -64,7 +64,7 @@ CACHE_PATH = os.path.join(os.path.expanduser("~"), ".cache", "volatility3")
 """Default path to store cached data"""
 
 if sys.platform == 'win32':
-    CACHE_PATH = os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3")
+    CACHE_PATH = os.path.realpath(os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3"))
 os.makedirs(CACHE_PATH, exist_ok = True)
 
 LINUX_BANNERS_PATH = os.path.join(CACHE_PATH, "linux_banners.cache")


### PR DESCRIPTION
## Description

Hello, everyone in the community! 🙂
I found something interesting while working on the symbol cache path in a `Windows` environment.
We are using cache so that `volatility3` can quickly find information about `Symbol`.
And it is usually stored according to the path stored in the `constants`.

We can see through the log that we use the cache file. (using `-vvvv`)

```shell
DEBUG    volatility3.framework.layers.resources: Using already cached file at: C:\Users\dhyun\AppData\Roaming\volatility3\data_a6f12d9c7c10398e8291aa0f048fc263e301c9d1c7eb3090bd65778d6130915c0e5a3beeaaf5f3be2a57866a49b6343d9eb4aee2b1dc7663dd39138736f3f7c0.cache
```

However, I could not find the `data_*.cache` file that the log points to in the local storage.
As a result of this investigation, the folder where the `data_*.cache` was stored was located elsewhere.
Nevertheless, there was no problem with the operation of `volatility3`.

## Solution

A detailed study of this phenomenon confirmed that the `Microsoft Store` version of `Python` treats `Windows` internal folders differently for their access and use. (like symbolic link)

- https://github.com/python-poetry/poetry/issues/5331

Therefore, there was no problem with using it, but the log informed me of other folders and files.
I have patched this so that other contributors and users do not experience confusion in their work.

This was also present in `Python`'s [official](https://docs.python.org/3/using/windows.html#redirection-of-local-data-registry-and-temporary-paths
) documents, and I borrowed a solution.

### Result
```shell
DEBUG    volatility3.framework.layers.resources: Using already cached file at: C:\Users\dhyun\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\LocalCache\Roaming\volatility3\data_a6f12d9c7c10398e8291aa0f048fc263e301c9d1c7eb3090bd65778d6130915c0e5a3beeaaf5f3be2a57866a49b6343d9eb4aee2b1dc7663dd39138736f3f7c0.cache
```

