### PR TITLE
Fix: create `tcpip_symbol_table` error handling for Windows `netstat` plugin.

### DIFF
--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -434,7 +434,6 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 kernel.layer_name, "tcpip.pdb", tcpip_module.DllBase, tcpip_module.SizeOfImage)
         except exceptions.VolatilityException:
             vollog.error("Unable to locate symbols for the memory image's tcpip module")
-            return
 
         for netw_obj in self.list_sockets(self.context, kernel.layer_name, kernel.symbol_table_name,
                                           netscan_symbol_table, tcpip_module.DllBase, tcpip_symbol_table):

--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -434,7 +434,7 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 kernel.layer_name, "tcpip.pdb", tcpip_module.DllBase, tcpip_module.SizeOfImage)
         except exceptions.VolatilityException:
             vollog.error("Unable to locate symbols for the memory image's tcpip module")
-            raise
+            return
 
         for netw_obj in self.list_sockets(self.context, kernel.layer_name, kernel.symbol_table_name,
                                           netscan_symbol_table, tcpip_module.DllBase, tcpip_symbol_table):

--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -433,7 +433,8 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 self.context, interfaces.configuration.path_join(self.config_path, 'tcpip'),
                 kernel.layer_name, "tcpip.pdb", tcpip_module.DllBase, tcpip_module.SizeOfImage)
         except exceptions.VolatilityException:
-            vollog.warning("Unable to locate symbols for the memory image's tcpip module")
+            vollog.error("Unable to locate symbols for the memory image's tcpip module")
+            raise
 
         for netw_obj in self.list_sockets(self.context, kernel.layer_name, kernel.symbol_table_name,
                                           netscan_symbol_table, tcpip_module.DllBase, tcpip_symbol_table):


### PR DESCRIPTION
## Description

Hello, everyone in the community! 🙂

We can sometimes encounter errors in unexpected situations while using the program.
And the program only shows relatively human-friendly sentences, rather than showing errors that occur in real compilers or programs, so as not to confuse users.

I have corrected the error processing smoothly in the netstat plugin that we use for networking in a Windows environment.
If the symbol table for the `tcpip.pdb` module is not loaded normally, the logic below will not work, so I thought it was close to an error.

Also, the resulting error log was returned not to be output from the cli environment.

### Command
```
> python3 vol.py -f case.vmem -vvvv windows.netstat
```

### Issue
```
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
WARNING  volatility3.plugins.windows.netstat: Unable to locate symbols for the memory image's tcpip module
Traceback (most recent call last):
  File "/Users/donghyunkim/Desktop/volatility3/vol.py", line 10, in <module>
    volatility3.cli.main()
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/__init__.py", line 636, in main
    CommandLine().run()
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/__init__.py", line 343, in run
    renderers[args.renderer]().render(constructed.run())
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/text_renderer.py", line 177, in render
    grid.populate(visitor, outfd)
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/renderers/__init__.py", line 212, in populate
    for (level, item) in self._generator:
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/plugins/windows/netstat.py", line 439, in _generator
    netscan_symbol_table, tcpip_module.DllBase, tcpip_symbol_table):
UnboundLocalError: local variable 'tcpip_symbol_table' referenced before assignment
```

### Result
```
> python3 vol.py -f case.vmem windows.netstat

Volatility 3 Framework 2.3.0
Progress:  100.00		PDB scanning finished
Offset	Proto	LocalAddr	LocalPort	ForeignAddr	ForeignPort	State	PID	Owner	Created
ERROR    volatility3.plugins.windows.netstat: Unable to locate symbols for the memory image's tcpip module
```

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌