### PR TITLE
Check layer dependency list based on a bool

### DIFF
--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -576,7 +576,7 @@ class LayerContainer(collections.abc.Mapping):
                     layer.name, f"Layer {layer.name} has unmet dependencies: {', '.join(missing_list)}")
         self._layers[layer.name] = layer
 
-    def del_layer(self, name: str) -> None:
+    def del_layer(self, name: str, verify: bool = True) -> None:
         """Removes the layer called name.
 
         This will throw an exception if other layers depend upon this layer
@@ -584,12 +584,13 @@ class LayerContainer(collections.abc.Mapping):
         Args:
             name: The name of the layer to delete
         """
-        for layer in self._layers:
-            depend_list = [superlayer for superlayer in self._layers if name in self._layers[layer].dependencies]
-            if depend_list:
-                raise exceptions.LayerException(
-                    self._layers[layer].name,
-                    f"Layer {self._layers[layer].name} is depended upon: {', '.join(depend_list)}")
+        if verify:
+            for layer in self._layers:
+                depend_list = [superlayer for superlayer in self._layers if name in self._layers[layer].dependencies]
+                if depend_list:
+                    raise exceptions.LayerException(
+                        self._layers[layer].name,
+                        f"Layer {self._layers[layer].name} is depended upon: {', '.join(depend_list)}")
         self._layers[name].destroy()
         del self._layers[name]
 

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -583,6 +583,7 @@ class LayerContainer(collections.abc.Mapping):
 
         Args:
             name: The name of the layer to delete
+            verify: A bool that determines whether we check the dependency list or not
         """
         if verify:
             for layer in self._layers:


### PR DESCRIPTION
In my code I had to explicitly call the `del_layer` function to remove a python reference count to an object saved in the layer.
In the runtime of the plugin many process layers were created and checking the `depend_list` each time I wanted to deleted my layer (not the process ones) took a LOT of time.
I used cProfile to determine what caused it to be that slow and 75% of my plugin's runtime was in the list comprehension line.
To address this issue I have added a flag which is defaulted to True (IE verify dependencies ) which in turn can disable this verification.

Currently no one uses the `del_layer` function.
