### PR TITLE
Bugfix: Improve scan via the pdbname_scan

### DIFF
--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -212,8 +212,7 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
                                           start = start_scan_address,
                                           page_size = vlayer.page_size,
                                           pdb_names = kernel_pdb_names,
-                                          progress_callback = progress_callback,
-                                          maximum_invalid_count = constants.windows.PE_MAX_EXTRACTION_SIZE // 0x1000)
+                                          progress_callback = progress_callback)
         for kernel in kernels:
             valid_kernel = test_kernel(physical_layer_name, virtual_layer_name, kernel)
             if valid_kernel is not None:

--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -212,7 +212,8 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
                                           start = start_scan_address,
                                           page_size = vlayer.page_size,
                                           pdb_names = kernel_pdb_names,
-                                          progress_callback = progress_callback)
+                                          progress_callback = progress_callback,
+                                          maximum_invalid_count = constants.windows.PE_MAX_EXTRACTION_SIZE // 0x1000)
         for kernel in kernels:
             valid_kernel = test_kernel(physical_layer_name, virtual_layer_name, kernel)
             if valid_kernel is not None:

--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -292,7 +292,7 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
             for i in range(sig_pfn, min_pfn, -1):
                 if current_invalid_counter > maximum_invalid_count:
                     break
-                
+
                 if not ctx.layers[layer_name].is_valid(i * page_size, 2):
                     current_invalid_counter += 1
                     continue

--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -264,6 +264,14 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
 
         The UI should always provide the user an opportunity to specify the
         appropriate types and PDB values themselves
+        Args:
+            layer_name: The layer name to scan
+            page_size: Size of page constant
+            pdb_names: List of pdb names to scan
+            progress_callback: Means of providing the user with feedback during long processes
+            start: Start address to start scanning from the pdb_names
+            end: Minimum address to scan the pdb_names
+            maximum_invalid_count: Amount of pages that can be invalid during scanning before aborting signature search
         """
         min_pfn = 0
 


### PR DESCRIPTION
I had a case where the `PdbSignatureScanner` did find the right pdb. However due to a single paged out address in the kernel module the `is_valid` check failed which caused volatility not to work on my memory dump.
By adding `maximum_invalid_count` we allow ourselves to continue iterating downwards even if some pages were invalid.
The `maximum_invalid_count` is currently defaulted to 100 which was enough to to fix my issue, however we could increase it if is needed.
Otherwise functionality is the same.
Without this extra code I could not run volatility3 on my Win10 1809 memory dump (2GB ram)