### PR TITLE
Bugfix: Calling with --cache-path now updates Several variables depen…

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -193,7 +193,7 @@ class CommandLine:
                                             for p in partial_args.symbol_dirs.split(";")] + constants.SYMBOL_BASEPATHS
 
         if partial_args.cache_path:
-            constants.CACHE_PATH = partial_args.cache_path
+            constants.update_cache_path(partial_args.cache_path)
 
         if partial_args.log:
             file_logger = logging.FileHandler(partial_args.log)

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -60,21 +60,24 @@ LOGLEVEL_VVV = 7
 LOGLEVEL_VVVV = 6
 """Logging level for -vvvv"""
 
-CACHE_PATH = os.path.join(os.path.expanduser("~"), ".cache", "volatility3")
-"""Default path to store cached data"""
+def update_cache_path(cache_path):
+    CACHE_PATH = cache_path
+    """Default path to store cached data"""
 
-if sys.platform == 'win32':
-    CACHE_PATH = os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3")
-os.makedirs(CACHE_PATH, exist_ok = True)
+    if sys.platform == 'win32':
+        CACHE_PATH = os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3")
+    os.makedirs(CACHE_PATH, exist_ok = True)
 
-LINUX_BANNERS_PATH = os.path.join(CACHE_PATH, "linux_banners.cache")
-"""Default location to record information about available linux banners"""
+    LINUX_BANNERS_PATH = os.path.join(CACHE_PATH, "linux_banners.cache")
+    """Default location to record information about available linux banners"""
 
-MAC_BANNERS_PATH = os.path.join(CACHE_PATH, "mac_banners.cache")
-"""Default location to record information about available mac banners"""
+    MAC_BANNERS_PATH = os.path.join(CACHE_PATH, "mac_banners.cache")
+    """Default location to record information about available mac banners"""
 
-IDENTIFIERS_PATH = os.path.join(CACHE_PATH, "identifiers.cache")
-"""Default location to record information about available identifiers"""
+    IDENTIFIERS_PATH = os.path.join(CACHE_PATH, "identifiers.cache")
+    """Default location to record information about available identifiers"""
+
+update_cache_path(os.path.join(os.path.expanduser("~"), ".cache", "volatility3"))
 
 CACHE_SQLITE_SCEMA_VERSION = 1
 """Version for the sqlite3 cache schema"""

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -61,6 +61,8 @@ LOGLEVEL_VVVV = 6
 """Logging level for -vvvv"""
 
 def update_cache_path(cache_path):
+    global CACHE_PATH, LINUX_BANNERS_PATH, MAC_BANNERS_PATH, IDENTIFIERS_PATH
+
     CACHE_PATH = cache_path
     """Default path to store cached data"""
 


### PR DESCRIPTION
fixes #803
The problem was that several variables in constants/__init__.py are computed based on constants.CACHE_PATH. One example is LINUX_BANNERS_PATH. Without this patch, if you're doing volatility3 development related to the banner code, you may want to run ./vol.py --cache-path /tmp/volatility-development so you don't have to `rm -rf $VOLATILITY_CACHE_DIR.

Before my patch, constants/__init__.py sets the default value of constants.CACHE_PATH, then computes LINUX_BANNERS_PATH based on that default value. Later, cli/__init__.py updates constants.CACHE_PATH to the value passed as --cache-path, but it doesn't update LINUX_BANNERS_PATH.

My fix moves all initialization that depends on constants.CACHE_PATH into a function (update_cache_path). Then, constants/__init__.py calls this function with the default CACHE_PATH value, so all initialization happens like before. But now, cli/__init__.py can call constants.update_cache_path() to re-do all those CACHE_PATH-related initialization steps based on the new value of CACHE_PATH, thus propagating the value the user asked vol.py to use.

Thanks for your hard work on this useful tool!