### PR TITLE
BUGFIX - layer given by lower layer is not returned from the stacker

### DIFF
--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -215,7 +215,7 @@ class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
                 config_path, "page_map_offset")] = base_layer.metadata['page_map_offset']
             layer = layer_type(context, config_path = config_path, name = new_layer_name, metadata = {'os': 'Windows'})
             page_map_offset = context.config[interfaces.configuration.path_join(config_path, "page_map_offset")]
-            vollog.debug(f"DTB was given to as by base layer: {hex(page_map_offset)}")
+            vollog.debug(f"DTB was given to us by base layer: {hex(page_map_offset)}")
             return layer
 
         # Self Referential finder

--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -214,6 +214,9 @@ class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
             context.config[interfaces.configuration.path_join(
                 config_path, "page_map_offset")] = base_layer.metadata['page_map_offset']
             layer = layer_type(context, config_path = config_path, name = new_layer_name, metadata = {'os': 'Windows'})
+            page_map_offset = context.config[interfaces.configuration.path_join(config_path, "page_map_offset")]
+            vollog.debug(f"DTB was given to as by base layer: {hex(page_map_offset)}")
+            return layer
 
         # Self Referential finder
         for description, tests, sections in cls.test_sets:


### PR DESCRIPTION
A `return layer` was missing in the stacker which caused the stacker to scan either way.
I have added a log to indicate that the layer was given to us by the lower layer and return it instead of scanning which was not the intended behavior.