### PR TITLE
refs #713 add a vad.get_size() method and fix several off-by-one issues with calculating vad size

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -4,6 +4,10 @@ API Changes
 When an addition to the existing API is made, the minor version is bumped.
 When an API feature or function is removed or changed, the major version is bumped.
 
+2.4.0
+=====
+Add a `get_size()` method to Windows VAD structures and fix several off-by-one issues when calculating VAD sizes.
+
 2.3.0
 =====
 Add in `child_template` to template class

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -40,7 +40,7 @@ BANG = "!"
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
 VERSION_MINOR = 4  # Number of changes that only add to the interface
-VERSION_PATCH = 1  # Number of changes that do not change the interface
+VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 # TODO: At version 2.0.0, remove the symbol_shift feature

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -39,7 +39,7 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 3  # Number of changes that only add to the interface
+VERSION_MINOR = 4  # Number of changes that only add to the interface
 VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/plugins/windows/malfind.py
+++ b/volatility3/framework/plugins/windows/malfind.py
@@ -17,7 +17,7 @@ vollog = logging.getLogger(__name__)
 class Malfind(interfaces.plugins.PluginInterface):
     """Lists process memory ranges that potentially contain injected code."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 4, 0)
 
     @classmethod
     def get_requirements(cls):

--- a/volatility3/framework/plugins/windows/malfind.py
+++ b/volatility3/framework/plugins/windows/malfind.py
@@ -56,7 +56,7 @@ class Malfind(interfaces.plugins.PluginInterface):
         all_zero_page = b"\x00" * CHUNK_SIZE
 
         offset = 0
-        vad_length = vad.get_end() - vad.get_start()
+        vad_length = vad.get_size()
 
         while offset < vad_length:
             next_addr = vad.get_start() + offset

--- a/volatility3/framework/plugins/windows/skeleton_key_check.py
+++ b/volatility3/framework/plugins/windows/skeleton_key_check.py
@@ -41,7 +41,7 @@ vollog = logging.getLogger(__name__)
 class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
     """ Looks for signs of Skeleton Key malware """
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 4, 0)
 
     @classmethod
     def get_requirements(cls):

--- a/volatility3/framework/plugins/windows/skeleton_key_check.py
+++ b/volatility3/framework/plugins/windows/skeleton_key_check.py
@@ -262,7 +262,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
 
             if isinstance(filename, str) and filename.lower().endswith("cryptdll.dll"):
                 base = vad.get_start()
-                return base, vad.get_end() - base
+                return base, vad.get_size()
 
         return None, None
 

--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -33,7 +33,7 @@ winnt_protections = {
 class VadInfo(interfaces.plugins.PluginInterface):
     """Lists process memory ranges."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 4, 0)
     _version = (2, 0, 0)
     MAXSIZE_DEFAULT = 1024 * 1024 * 1024  # 1 Gb
 

--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -132,7 +132,7 @@ class VadInfo(interfaces.plugins.PluginInterface):
             vollog.debug("Unable to find the starting/ending VPN member")
             return None
 
-        if 0 < maxsize < (vad_end - vad_start):
+        if 0 < maxsize < vad.get_size():
             vollog.debug(f"Skip VAD dump {vad_start:#x}-{vad_end:#x} due to maxsize limit")
             return None
 
@@ -151,8 +151,9 @@ class VadInfo(interfaces.plugins.PluginInterface):
             file_handle = open_method(file_name)
             chunk_size = 1024 * 1024 * 10
             offset = vad_start
-            while offset < vad_end:
-                to_read = min(chunk_size, vad_end - offset)
+            vad_size = vad.get_size()
+            while offset < vad_start + vad_size:
+                to_read = min(chunk_size, vad_start + vad_size - offset)
                 data = proc_layer.read(offset, to_read, pad = True)
                 if not data:
                     break

--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -82,9 +82,7 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
         """
         vad_root = task.get_vad_root()
         for vad in vad_root.traverse():
-            end = vad.get_end()
-            start = vad.get_start()
-            yield (start, end - start)
+            yield (vad.get_start(), vad.get_size())
 
     def run(self):
         return renderers.TreeGrid([('Offset', format_hints.Hex), ('PID', int), ('Rule', str), ('Component', str),

--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -17,7 +17,7 @@ vollog = logging.getLogger(__name__)
 class VadYaraScan(interfaces.plugins.PluginInterface):
     """Scans all the Virtual Address Descriptor memory maps using yara."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 4, 0)
     _version = (1, 0, 0)
 
     @classmethod

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -197,8 +197,8 @@ class MMVAD_SHORT(objects.StructType):
 
         raise AttributeError("Unable to find the parent member")
 
-    def get_start(self):
-        """Get the VAD's starting virtual address."""
+    def get_start(self) -> int:
+        """Get the VAD's starting virtual address. This is the first accessible byte in the range."""
 
         if self.has_member("StartingVpn"):
 
@@ -216,8 +216,8 @@ class MMVAD_SHORT(objects.StructType):
 
         raise AttributeError("Unable to find the starting VPN member")
 
-    def get_end(self):
-        """Get the VAD's ending virtual address."""
+    def get_end(self) -> int:
+        """Get the VAD's ending virtual address. This is the last accessible byte in the range."""
 
         if self.has_member("EndingVpn"):
 
@@ -233,6 +233,10 @@ class MMVAD_SHORT(objects.StructType):
                 return ((self.Core.EndingVpn + 1) << 12) - 1
 
         raise AttributeError("Unable to find the ending VPN member")
+
+    def get_size(self) -> int:
+        """Get the size of the VAD region. The OS ensures page granularity."""
+        return (self.get_end() - self.get_start()) + 1
 
     def get_commit_charge(self):
         """Get the VAD's commit charge (number of committed pages)"""


### PR DESCRIPTION
See the comments in #713, in particular this description of the changes:

Historically, even back to vol2, the `get_end()` function has returned the last accessible byte in the range, so I'm keeping that unchanged. I added a `get_size()` method that calculates the total size in bytes and fixed a number of plugins that had off-by-one issues. Anyone relying on `get_end()` to calculate size in custom plugins (outside of the core code base) will still have one-by-one issues, but they can fix it by using the new `get_size()` - IMO that is better than changing the behavior of `get_end()` and potentially breaking things "silently."