### PR TITLE
Fix: return value data (not tuple) of `_modtable_from_pdb` method.

### DIFF
--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -315,8 +315,8 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
         Returns:
             The name of the constructed and loaded symbol table
         """
-        _, symbol_table_name = cls._modtable_from_pdb(context, config_path, layer_name, pdb_name, module_offset,
-                                                      module_size)
+        symbol_table_name = cls._modtable_from_pdb(context, config_path, layer_name, pdb_name, module_offset,
+                                                   module_size)
         return symbol_table_name
 
     @classmethod


### PR DESCRIPTION
## Description

Hello, everyone in the community! 🙂
While I was checking the issue, I noticed that an error occurred in one of our important plugins, `netstat`.
The same situation was checked to me, and after testing with various images, I found that this was a common bug.
Fortunately, this situation has not been detected in our last release version, `2.0.1`.

In order to understand what the issue is, I checked how the release version and the current development version bring up the symbol table. 

As a result of checking the history, I have checked that there have been some changes in the way symbol tables have been loaded, and some methods have now disappeared.

The previously attempted method (`_modtable_from_pdb` https://github.com/volatilityfoundation/volatility3/commit/db3408bdaa978de5b23eecd2d4411df8a6de1f16) returned data in the form of a tuple, and as it disappeared, the returned data used had to be changed, but it was found to be missing from the method causing the problem.

- Resolves #799 

## Issue

```shell
> python3 vol.py -f case.vmem windows.netstat
Volatility 3 Framework 2.3.1
Progress:  100.00               PDB scanning finished                        
Offset  Proto   LocalAddr       LocalPort       ForeignAddr     ForeignPort     State   PID     Owner   Created
Traceback (most recent call last):
  File "/Users/donghyunkim/Desktop/volatility3/vol.py", line 10, in <module>
    volatility3.cli.main()
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/__init__.py", line 636, in main
    CommandLine().run()
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/__init__.py", line 343, in run
    renderers[args.renderer]().render(constructed.run())
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/cli/text_renderer.py", line 177, in render
    grid.populate(visitor, outfd)
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/renderers/__init__.py", line 212, in populate
    for (level, item) in self._generator:
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/plugins/windows/netstat.py", line 432, in _generator
    tcpip_symbol_table = pdbutil.PDBUtility.symbol_table_from_pdb(
  File "/Users/donghyunkim/Desktop/volatility3/volatility3/framework/symbols/windows/pdbutil.py", line 318, in symbol_table_from_pdb
    _, symbol_table_name = cls._modtable_from_pdb(context, config_path, layer_name, pdb_name, module_offset,
ValueError: too many values to unpack (expected 2)
```

## Result
```shell
> python3 vol.py -f case.vmem windows.netstat 
Volatility 3 Framework 2.3.1
Progress:  100.00               PDB scanning finished                        
Offset  Proto   LocalAddr       LocalPort       ForeignAddr     ForeignPort     State   PID     Owner   Created

0x97065ebfe050  TCPv4   0.0.0.0 135     0.0.0.0 0       LISTENING       888     svchost.exe     2021-07-14 17:02:29.000000 
0x97065ebfe050  TCPv6   ::      135     ::      0       LISTENING       888     svchost.exe     2021-07-14 17:02:29.000000 
0x97065ebff0d0  TCPv4   0.0.0.0 135     0.0.0.0 0       LISTENING       888     svchost.exe     2021-07-14 17:02:29.000000 
0x97065aca2050  TCPv4   0.0.0.0 445     0.0.0.0 0       LISTENING       4       System  2021-07-14 17:02:32.000000 
0x97065aca2050  TCPv6   ::      445     ::      0       LISTENING       4       System  2021-07-14 17:02:32.000000 
```

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌