### PR TITLE
Fix: typo for `.style.yapf` file.

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -107,7 +107,7 @@ each_dict_entry_on_separate_line=True
 i18n_comment=
 
 # The i18n function call names. The presence of this function stops
-# reformattting on that line, because the string it has cannot be moved
+# reformatting on that line, because the string it has cannot be moved
 # away from the i18n comment.
 i18n_function_call=
 


### PR DESCRIPTION
## Description

Hello, everyone in the community! 🙂
I found typo in `yapf` file, and I fixed it.