### PR TITLE
Bugfix CSV format line terminator

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -224,7 +224,7 @@ class CSVRenderer(CLIRenderer):
             # Ignore the type because namedtuples don't realize they have accessible attributes
             header_list.append(f"{column.name}")
 
-        writer = csv.DictWriter(outfd, header_list)
+        writer = csv.DictWriter(outfd, header_list, lineterminator='\n')
         writer.writeheader()
 
         def visitor(node: interfaces.renderers.TreeNode, accumulator):


### PR DESCRIPTION
In my windows system formatting to csv via the `-r csv` yielded extra new line feeds when output was redirected to a file.
I found a stackoverflow issue which showed the solution here.