### PR TITLE
Windows: When constructing a buffer, manually dereference onto the native layer

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -488,7 +488,7 @@ class UNICODE_STRING(objects.StructType):
         # We manually construct an object rather than casting a dereferenced pointer in case
         # the buffer length is 0 and the pointer is a NULL pointer
         return self._context.object(self.vol.type_name.split(constants.BANG)[0] + constants.BANG + 'string',
-                                    layer_name = self.Buffer.vol.layer_name,
+                                    layer_name = self.Buffer.vol.native_layer_name,
                                     offset = self.Buffer,
                                     max_length = self.Length, errors = 'replace', encoding = 'utf16')
 


### PR DESCRIPTION
We altered some code to manually dereference a buffer, rather than calling dereference, and forgot to construct the new object on the native_layer rather than the constructed layer.  This resolves the issue and should restore any plugins that used `get_string()` on a buffer found in a physical layer, rather than a virtual one.

Closes #829 