### PR TITLE
Fix: unverified retrieval SSL Error for Python `3.7`.

### DIFF
--- a/volatility3/framework/layers/resources.py
+++ b/volatility3/framework/layers/resources.py
@@ -120,11 +120,7 @@ class ResourceAccessor(object):
             fp = urllib.request.urlopen(url, context = self._context)
         except error.URLError as excp:
             if excp.args:
-                # TODO: As of python3.7 this can be removed
-                unverified_retrieval = (hasattr(ssl, "SSLCertVerificationError") and isinstance(
-                    excp.args[0], ssl.SSLCertVerificationError)) or (isinstance(excp.args[0], ssl.SSLError) and
-                                                                     excp.args[0].reason == "CERTIFICATE_VERIFY_FAILED")
-                if unverified_retrieval:
+                if isinstance(excp.args[0], ssl.SSLCertVerificationError):
                     vollog.warning("SSL certificate verification failed: attempting UNVERIFIED retrieval")
                     non_verifying_ctx = ssl.SSLContext()
                     non_verifying_ctx.check_hostname = False


### PR DESCRIPTION
## Description
Hello, everyone in the community! 🙂
We can see that recently we are trying to work on the minimum python version of `volatility3`.
- #838 

I've seen comments related to python version `3.7` before, and I thought it would be good to solve them before the release.
With reference to the past PR, I believe that we can use the relatively simple conditional statement originally intended in python version `3.7`.

- #171 

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌