### PR TITLE
Fix: `find_namepsace_packages` method for `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(name = "volatility3",
                      '': ['development', 'development.*'],
                      'development': ['*']
                  },
-                 packages = setuptools.find_packages(exclude = ["development", "development.*"]),
+                 packages = setuptools.find_namespace_packages(exclude = ["development", "development.*"]),
                  entry_points = {
                      'console_scripts': [
                          'vol = volatility3.cli:main',


### PR DESCRIPTION
## Description
Hello, everyone in the community! 🙂

I found a message during the build test.
As described in the message, `setuptools` provides a method for flexible processing of items (for example, symbol files) that are not real packages. The method was replaced according to the message, and the test was successful.

```
############################
# Package would be ignored #
############################
Python recognizes 'volatility3.framework.symbols.windows.netscan' as an importable package,
but it is not listed in the `packages` configuration of setuptools.

'volatility3.framework.symbols.windows.netscan' has been automatically added to the distribution only
because it may contain data files, but this behavior is likely to change
in future versions of setuptools (and therefore is considered deprecated).

Please make sure that 'volatility3.framework.symbols.windows.netscan' is included as a package by using
the `packages` configuration field or the proper discovery methods
(for example by using `find_namespace_packages(...)`/`find_namespace:`
instead of `find_packages(...)`/`find:`).

You can read more about "package discovery" and "data files" on setuptools
documentation page.
```

If you are interested in or have any comments on this PR, please feel free to leave a thread! 🙌
