### PR TITLE
correct ImageFileName

### DIFF
--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -323,7 +323,7 @@ class Handles(interfaces.plugins.PluginInterface):
                         obj_name = item.file_name_with_device()
                     elif obj_type == "Process":
                         item = entry.Body.cast("_EPROCESS")
-                        obj_name = f"{utility.array_to_string(proc.ImageFileName)} Pid {item.UniqueProcessId}"
+                        obj_name = f"{utility.array_to_string(item.ImageFileName)} Pid {item.UniqueProcessId}"
                     elif obj_type == "Thread":
                         item = entry.Body.cast("_ETHREAD")
                         obj_name = f"Tid {item.Cid.UniqueThread} Pid {item.Cid.UniqueProcess}"


### PR DESCRIPTION
Trying windows.handles plugin, found a possible bug not to show Names correctly for the entries whose type are Process.

Current windows.handles shows as shown below.
```
PID     Process Offset  HandleValue     Type    GrantedAccess   Name
4       System  0xc58d2d262200  0x4     Process 0x1fffff        System Pid 4
4       System  0xc58d2d2e5080  0x50    Process 0x1fffff        System Pid 88
4       System  0xc58d302a4040  0x104   Process 0x102a  System Pid 288
4       System  0xc58d302a4040  0x118   Process 0x1fffff        System Pid 288
4       System  0xc58d32376080  0x164   Process 0x102a  System Pid 3108
4       System  0xc58d302a4040  0x168   Process 0x102a  System Pid 288
4       System  0xc58d302a4040  0x170   Process 0x102a  System Pid 288
```
With this modification, it shows as show below.
```
PID     Process Offset  HandleValue     Type    GrantedAccess   Name
4       System  0xc58d2d262200  0x4     Process 0x1fffff        System Pid 4
4       System  0xc58d2d2e5080  0x50    Process 0x1fffff        Registry Pid 88
4       System  0xc58d302a4040  0x104   Process 0x102a  smss.exe Pid 288
4       System  0xc58d302a4040  0x118   Process 0x1fffff        smss.exe Pid 288
4       System  0xc58d32376080  0x164   Process 0x102a  svchost.exe Pid 3108
4       System  0xc58d302a4040  0x168   Process 0x102a  smss.exe Pid 288
4       System  0xc58d302a4040  0x170   Process 0x102a  smss.exe Pid 288
```
If this fix seems OK, would you merge it, please?
