### PR TITLE
Report IRP entries that point inside a hidden module. This is a commo…

### DIFF
--- a/volatility3/framework/plugins/windows/driverirp.py
+++ b/volatility3/framework/plugins/windows/driverirp.py
@@ -48,7 +48,10 @@ class DriverIrp(interfaces.plugins.PluginInterface):
             for i, address in enumerate(driver.MajorFunction):
                 module_symbols = collection.get_module_symbols_by_absolute_location(address)
 
+                module_found = False
+
                 for module_name, symbol_generator in module_symbols:
+                    module_found = True
                     symbols_found = False
 
                     for symbol in symbol_generator:
@@ -59,6 +62,11 @@ class DriverIrp(interfaces.plugins.PluginInterface):
                     if not symbols_found:
                         yield (0, (format_hints.Hex(driver.vol.offset), driver_name, MAJOR_FUNCTIONS[i],
                                    format_hints.Hex(address), module_name, renderers.NotAvailableValue()))
+
+                if not module_found:
+                     yield (0, (format_hints.Hex(driver.vol.offset), driver_name, MAJOR_FUNCTIONS[i],
+                                format_hints.Hex(address), renderers.NotAvailableValue(), renderers.NotAvailableValue()))
+
 
     def run(self):
 


### PR DESCRIPTION
…n rootkit technique.

The current driverirp implementation only reports entries if they map back to a module. This completely misses IRP entries that are pointing to 'hidden' modules, which is a common technique used by rootkits.

The IRP entries will either be hijacked entries of existing modules or the actual entries for the hidden module's associated driver. The following is a diff of this plugin's output against a sample infected with the Ghost Emperor rootkit, with the 'before' output being the plugin as it is now, and the 'after' being with the PR code.

```
> * | 0xe38a8fc54de0 |              nsiproxy |           IRP_MJ_DEVICE_CONTROL | 0xe38a8ed14168 |             - |                        -
3381a3391,3418
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                   IRP_MJ_CREATE | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |        IRP_MJ_CREATE_NAMED_PIPE | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                    IRP_MJ_CLOSE | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                     IRP_MJ_READ | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                    IRP_MJ_WRITE | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |        IRP_MJ_QUERY_INFORMATION | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |          IRP_MJ_SET_INFORMATION | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                 IRP_MJ_QUERY_EA | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                   IRP_MJ_SET_EA | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |            IRP_MJ_FLUSH_BUFFERS | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 | IRP_MJ_QUERY_VOLUME_INFORMATION | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |   IRP_MJ_SET_VOLUME_INFORMATION | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |        IRP_MJ_DIRECTORY_CONTROL | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |      IRP_MJ_FILE_SYSTEM_CONTROL | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |           IRP_MJ_DEVICE_CONTROL | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |  IRP_MJ_INTERNAL_DEVICE_CONTROL | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                 IRP_MJ_SHUTDOWN | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |             IRP_MJ_LOCK_CONTROL | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                  IRP_MJ_CLEANUP | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |          IRP_MJ_CREATE_MAILSLOT | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |           IRP_MJ_QUERY_SECURITY | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |             IRP_MJ_SET_SECURITY | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                    IRP_MJ_POWER | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |           IRP_MJ_SYSTEM_CONTROL | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |            IRP_MJ_DEVICE_CHANGE | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |              IRP_MJ_QUERY_QUOTA | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                IRP_MJ_SET_QUOTA | 0xe38a8ed18278 |             - |                        -
> * | 0xe38a94f022e0 |     dump_audio_codec0 |                      IRP_MJ_PNP | 0xe38a8ed18278 |             - |                        -
```

There are two things to note:

1) The IRP_MJ_DEVICE_CONTROL entry of nsiproxy is hooked by the rootkit, so it points to a hidden module. The current vol3 plugin just does not report this entry.

2) `dump_audio_codec0` is the driver of the rootkit, and all its entries were hidden as they point inside the hidden kernel module. 

This PR makes it so that the plugin properly detects malicious and/or victim IRP handlers.