### PR TITLE
Automagic: Check file datetime to determine whether to recache

### DIFF
--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -2,6 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import base64
+import datetime
 import json
 import logging
 import os
@@ -170,6 +171,7 @@ class SqliteCache(CacheManagerInterface):
     def _connect_storage(self, path: str) -> sqlite3.Connection:
         database = sqlite3.connect(path)
         database.row_factory = sqlite3.Row
+
         database.cursor().execute(
             f'CREATE TABLE IF NOT EXISTS database_info (schema_version INT DEFAULT {constants.CACHE_SQLITE_SCHEMA_VERSION})')
         schema_version = database.cursor().execute('SELECT schema_version FROM database_info').fetchone()
@@ -259,10 +261,31 @@ class SqliteCache(CacheManagerInterface):
         cache_update = set()
         files_to_timestamp = on_disk_locations.intersection(cached_locations)
         if files_to_timestamp:
-            result = self._database.cursor().execute("SELECT location FROM cache WHERE local = 1 "
+            result = self._database.cursor().execute("SELECT location, cached FROM cache WHERE local = 1 "
                                                      f"AND cached < date('now', '{self.cache_period}');")
             for row in result:
-                if row['location'] in files_to_timestamp:
+                location = row['location']
+                stored_timestamp = datetime.datetime.fromisoformat(row['cached'])
+                timestamp = stored_timestamp # Default to requiring update
+
+                # See if the file is a local URL type we can handle:
+                parsed = urllib.parse.urlparse(location)
+                pathname = None
+                if parsed.scheme == 'file':
+                    pathname = urllib.request.url2pathname(parsed.path)
+                if parsed.scheme == 'jar':
+                    inner_url = urllib.parse.urlparse(parsed.path)
+                    if inner_url.scheme == 'file':
+                        pathname = inner_url.path.split('!')[0]
+
+                if pathname:
+                    timestamp = datetime.datetime.fromtimestamp(os.stat(pathname).st_mtime)
+                else:
+                    vollog.log(constants.LOGLEVEL_VVVV,
+                               "File location in database classed as local but not file/jar URL")
+
+                # If we're supposed to include it, and our last check is older than (or equal to) the file timestamp
+                if row['location'] in files_to_timestamp and stored_timestamp < timestamp:
                     cache_update.add(row['location'])
 
         idextractors = list(framework.class_subclasses(IdentifierProcessor))

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -63,7 +63,7 @@ LOGLEVEL_VVVV = 6
 CACHE_PATH = os.path.join(os.path.expanduser("~"), ".cache", "volatility3")
 """Default path to store cached data"""
 
-SQLITE_CACHE_PERIOD = '-1 month'
+SQLITE_CACHE_PERIOD = '-3 days'
 """SQLite time modifier for how long each item is valid in the cache for"""
 
 if sys.platform == 'win32':


### PR DESCRIPTION
This doesn't completely fix issue851, but should go a long way to addressing concerns with the time taken for recaching.  Now, the cache period has been reset to 3 days, but also the file timestamp is checked.  If the file hasn't been changed since before the cache expiry time, then it won't get reindexed.  This may mean that files that have changed, but had their timestamps reset, or systems (or filesystems) that don't store accurate modification timestamps may run into issues.  The cache expiry timeout has been left in the code to allow people to still tune how often such files are checked.

This should handle zip files that change as well, but do please kick the tires on this.  If there's no complaints I'll probably merge it in 3-4 days.