### PR TITLE
Fix: ubuntu `runs-on` version for workflow error.

### DIFF
--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.6.7"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -25,6 +25,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -15,18 +15,16 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6.7"]
+        python-version: ["3.6"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-      env:
-        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -16,13 +16,15 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6"]
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,13 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6.7"]
+        python-version: ["3.6"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.6.7"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,10 +3,10 @@ on: [push, pull_request]
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6.7"]
+        python-version: ["3.6"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-      env:
-        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,13 +4,16 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6"]
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: ${{ matrix.python-version }}
+
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,14 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.6.7"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Description
Hello, everyone in the community! :)
A while ago, I saw a test error occurring during the PR (#656) of another contributor.
After analyzing the error log and the user's commit, I checked that there was a problem with our workflow script.
```
> Run actions/setup-python@v2
Version 3.6 was not found in the local cache
Error: Version 3.[6](https://github.com/volatilityfoundation/volatility3/actions/runs/3573910567/jobs/6008531558#step:3:7) with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```
Follow the [link](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) that guides you through to find Python `3.6` and you will see that `ubuntu-20.04` is the last supported version.

However, the `runs-on` version we specified in [workflow](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) is `ubuntu-latest`, which means it can also work on `ubuntu-22.04`.

In conclusion, it is assumed that the test, which was originally operated at `ubuntu-20.04`, was changed to `ubuntu-22.04` at some point inside Github. That's probably why an error occurs because Python `3.6` cannot be found for `ubuntu-22.04` environment.

We attempt to update Python's version to `3.7`, which is the minimum required by the recent project, so there is a way to upload the Python version, but given the direction of the project I am currently watching, the project seems not ready yet.

Therefore, I considered lowering the version of ubuntu to be tested in a safe way, which works normally.