### PR TITLE
add linux.bash_hash and linux.bash_env plugins

### DIFF
--- a/volatility3/framework/plugins/linux/bash_env.py
+++ b/volatility3/framework/plugins/linux/bash_env.py
@@ -1,0 +1,203 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import datetime
+import struct
+from typing import List
+
+from volatility3.framework import constants, renderers, symbols, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.layers import scanners
+from volatility3.framework.objects import utility
+from volatility3.framework.symbols.linux.hash import HashIntermedSymbols
+from volatility3.plugins.linux import pslist
+from volatility3.framework import objects
+
+class Var(plugins.PluginInterface):
+    """Recovers a process' dynamic environment variables."""
+
+    _required_framework_version = (2, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.ListRequirement(name = 'pid',
+                                         element_type = int,
+                                         description = "Process IDs to include (all other processes are excluded)",
+                                         optional = True)
+        ]
+
+    def _generator(self, tasks):
+        vmlinux = self.context.modules[self.config["kernel"]]
+        is_32bit = not symbols.symbol_table_is_64bit(self.context, vmlinux.symbol_table_name)
+        if is_32bit:
+            pack_format = "I"
+            hash_json_file = "hash32"
+        else:
+            pack_format = "Q"
+            hash_json_file = "hash64"
+        for task in tasks:
+            proc_layer_name = task.add_process_layer()
+            if not proc_layer_name:
+                yield(0, (task.pid, utility.array_to_string(task.comm), ""))
+                continue
+            varstr=""
+            for (key, val) in self.bash_environment(task, pack_format, hash_json_file, proc_layer_name):
+                if key != "" or val != "":
+                    varstr = varstr + key + "=" + val + " "
+            yield(0, (task.pid, utility.array_to_string(task.comm), varstr))
+
+    def bash_environment(self, task, pack_format, hash_json_file, proc_layer_name):
+        for (key, val) in self.dynamic_env(task, pack_format, proc_layer_name):
+            yield (key, val)
+
+        for (key, val) in self.shell_variables(task, pack_format, hash_json_file, proc_layer_name):
+            yield (key, val)
+
+    def dynamic_env(self, task, pack_format, proc_layer_name):
+        proc_layer = self.context.layers[proc_layer_name]
+        addr_cache = {0 :1}
+        addr_sz = 8
+        if pack_format == "I":
+            addr_sz = 4
+        for vma in task.mm.get_mmap_iter():
+            if not (vma.vm_file and vma.get_protection() == "rw-"):
+                continue
+            fname = vma.get_name(self.context, task)
+            if fname.find("ld") == -1 and (not fname.endswith(("/bin/bash", "/bin/dash", "/bin/sh"))):
+                continue
+            env_start = 0
+            vma_start = int(vma.vm_start)
+            vma_end = int(vma.vm_end)
+            vma_len = vma_end - vma_start
+            vma_data = proc_layer.read(vma_start, vma_len, pad = True)
+
+            for off in range(0, vma_len - addr_sz, addr_sz):
+                addrstr = vma_data[off:off+addr_sz]
+                addr = struct.unpack(pack_format, addrstr)[0]
+
+                if addr in addr_cache:
+                    continue
+                addr_cache[addr] = 1
+
+                if addr:
+                    firstaddrstr = proc_layer.read(addr, addr_sz, pad = True)
+                    if not firstaddrstr or len(firstaddrstr) != addr_sz:
+                        continue
+                    firstaddr = struct.unpack(pack_format, firstaddrstr)[0]
+                    buf = proc_layer.read(firstaddr, 64, pad = True)
+                    if not buf:
+                        continue
+                    eqidx = buf.find(b"=")
+                    if eqidx > 0:
+                        nullidx = buf.find(b"\x00")
+                        if nullidx >= eqidx:
+                            env_start = addr
+
+            if env_start == 0:
+                continue
+            vmlinux = self.context.modules[self.config["kernel"]]
+            envars = self.context.object(vmlinux.symbol_table_name + constants.BANG + "array",
+                                         layer_name = proc_layer_name,
+                                         offset = env_start,
+                                         subtype = self.context.symbol_space.get_type(vmlinux.symbol_table_name + constants.BANG + "pointer"),
+                                         count = 256)
+            for var in envars:
+                if var:
+                    sizes = [8, 16, 32, 64, 128, 256, 384, 512, 1024, 2048, 4096]
+                    good_varstr = None
+                    for size in sizes:
+                        try:
+                            varstr = proc_layer.read(var, size)
+                        except:
+                            continue
+                        if not varstr:
+                            continue
+                        eqidx = varstr.find(b"=")
+                        idx = varstr.find(b"\x00")
+                        if idx == -1 or eqidx == -1 or idx < eqidx:
+                            continue
+                        good_varstr = varstr
+                        break
+                    if good_varstr:
+                        try:
+                            good_varstr = str(good_varstr[:idx], 'utf-8')
+                            key = good_varstr[:eqidx]
+                            val = good_varstr[eqidx+1:]
+                            yield(key, val)
+                        except:
+                            continue
+                    else:
+                        break
+
+
+    def shell_variables(self, task, pack_format, hash_json_file, proc_layer_name):
+        proc_layer = self.context.layers[proc_layer_name]
+        addr_sz = 8
+        if pack_format == "I":
+            addr_sz = 4
+        ptr_cache = {0 : 1}
+        bash_was_last = False
+
+        for vma in task.mm.get_mmap_iter():
+            try:
+                if vma.vm_file:
+                    fname = vma.get_name(self.context, task)
+                    if fname.endswith(("/bin/bash", "/bin/dash", "/bin/sh")):
+                        bash_was_last = True
+                    else:
+                        bash_was_last = False
+
+                if vma.vm_file or vma.get_protection() != "rw-":
+                    continue
+            except:
+                continue
+
+            if bash_was_last == False:
+                continue
+            vma_start = int(vma.vm_start)
+            vma_end = int(vma.vm_end)
+            vma_len = vma_end - vma_start
+            vma_data = proc_layer.read(vma_start, vma_len, pad = True)
+            for off in range(0, vma_len - addr_sz, addr_sz):
+                ptr_test = vma_data[off:off+addr_sz]
+                ptr = struct.unpack(pack_format, ptr_test)[0]
+                if ptr in ptr_cache:
+                    continue
+                try:
+                    ptr_cache[ptr] = 1
+                    ptr_test2 = proc_layer.read(ptr + 20, addr_sz)
+                    if not ptr_test2:
+                        continue
+                except:
+                    continue
+
+                ptr2 = struct.unpack(pack_format, ptr_test2)[0]
+                try:
+                    test = proc_layer.read(ptr2 + 4, 4), 'utf-8'
+                except:
+                    continue
+                if not test or test != b"\x40\x00\x00\x00":
+                    continue
+                hash_table_name = HashIntermedSymbols.create(self.context, self.config_path, "linux", hash_json_file)
+                htable = self.context.object(hash_table_name + constants.BANG + "bash_hash_table", layer_name = proc_layer_name, offset = ptr2)
+                for ent in htable:
+                    key = utility.array_to_string(ent.key.dereference())
+                    val = utility.array_to_string(ent.data.value.dereference())
+                    yield (key, val)
+            bash_was_last = False
+
+
+    def run(self):
+        filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
+
+        return renderers.TreeGrid([("PID", int), ("Process", str), ("Vars", str)],
+                                  self._generator(
+                                      pslist.PsList.list_tasks(self.context,
+                                                               self.config['kernel'],
+                                                               filter_func = filter_func)))

--- a/volatility3/framework/plugins/linux/bash_hash.py
+++ b/volatility3/framework/plugins/linux/bash_hash.py
@@ -1,0 +1,77 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import datetime
+import struct
+from typing import List
+
+from volatility3.framework import constants, renderers, symbols, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.layers import scanners
+from volatility3.framework.objects import utility
+from volatility3.framework.symbols.linux.hash import HashIntermedSymbols
+from volatility3.plugins.linux import pslist
+from volatility3.framework import objects
+
+class Hash(plugins.PluginInterface):
+    """Recovers bash hash table from bash process memory."""
+
+    _required_framework_version = (2, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(name = 'kernel', description = 'Linux kernel',
+                                           architectures = ["Intel32", "Intel64"]),
+            requirements.PluginRequirement(name = 'pslist', plugin = pslist.PsList, version = (2, 0, 0)),
+            requirements.ListRequirement(name = 'pid',
+                                         element_type = int,
+                                         description = "Process IDs to include (all other processes are excluded)",
+                                         optional = True)
+        ]
+
+    def _generator(self, tasks):
+
+        vmlinux = self.context.modules[self.config["kernel"]]
+        is_32bit = not symbols.symbol_table_is_64bit(self.context, vmlinux.symbol_table_name)
+        if is_32bit:
+            pack_format = "I"
+            hash_json_file = "hash32"
+        else:
+            pack_format = "Q"
+            hash_json_file = "hash64"
+        hash_table_name = HashIntermedSymbols.create(self.context, self.config_path, "linux", hash_json_file)
+
+        for task in tasks:
+            task_name = utility.array_to_string(task.comm)
+            if not task_name == "bash":
+                continue
+
+            proc_layer_name = task.add_process_layer()
+            if not proc_layer_name:
+                continue
+
+            for ent in self.bash_hash_entries(task, proc_layer_name, hash_table_name):
+                yield(0, (task.pid, task_name, ent.times_found, utility.array_to_string(ent.key.dereference()), utility.array_to_string(ent.data.path.dereference())))
+
+    def bash_hash_entries(self, task, proc_layer_name, hash_table_name):
+
+        nbuckets_offset = self.context.symbol_space.get_type(hash_table_name + constants.BANG + "bash_hash_table").relative_child_offset("nbuckets")
+        proc_layer = self.context.layers[proc_layer_name]
+
+        for off in proc_layer.scan(self.context, scanners.BytesScanner(b"\x40\x00\x00\x00"), sections = task.get_process_memory_sections(heap_only = True)):
+            htable = self.context.object(hash_table_name + constants.BANG + "bash_hash_table", offset = off - nbuckets_offset, layer_name = proc_layer_name)
+            for ent in htable:
+                yield ent
+
+    def run(self):
+        filter_func = pslist.PsList.create_pid_filter(self.config.get('pid', None))
+
+        return renderers.TreeGrid([("PID", int), ("Name", str), ("Hits", int),
+                                   ("Command", str), ("Full Path", str)],
+                                  self._generator(
+                                      pslist.PsList.list_tasks(self.context,
+                                                               self.config['kernel'],
+                                                               filter_func = filter_func)))

--- a/volatility3/framework/symbols/linux/extensions/hash.py
+++ b/volatility3/framework/symbols/linux/extensions/hash.py
@@ -1,0 +1,85 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+from typing import Dict, Tuple
+
+from volatility3.framework import exceptions, constants
+from volatility3.framework import objects, interfaces
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import conversion
+
+class bash_hash_table(objects.StructType):
+
+    def __init__(self, context: interfaces.context.ContextInterface, type_name: str,
+                 object_info: interfaces.objects.ObjectInformation, size: int,
+                 members: Dict[str, Tuple[int, interfaces.objects.Template]]) -> None:
+
+        super().__init__(context = context,
+                         type_name = type_name,
+                         object_info = object_info,
+                         size = size,
+                         members = members)
+        self.context = context
+        self.layer_name = self.vol.layer_name
+        self.symbol_table_name = self.get_symbol_table_name()
+
+    def is_valid(self):
+        try:
+            bucket_array = self.bucket_array
+            nbuckets = self.nbuckets
+            nentries = self.nentries
+        except exceptions.InvalidAddressException:
+            return False
+
+        if not bucket_array:
+            return False
+
+        if not nbuckets or nbuckets != 64:
+            return False
+
+        if not nentries or nentries <= 1:
+            return False
+
+        return True
+
+    def __iter__(self):
+        if self.is_valid():
+
+            seen = {}
+            bucket_array = self.context.object(self.symbol_table_name + constants.BANG + "array",
+                                               layer_name = self.layer_name,
+                                               offset = self.bucket_array,
+                                               subtype = self.context.symbol_space.get_type(self.symbol_table_name + constants.BANG + "pointer"),
+                                               count = self.nbuckets)
+
+            for i in range(len(bucket_array)):
+                try:
+                    bucket_ptr = bucket_array[i]
+                except:
+                    continue
+                if bucket_ptr == 0:
+                    continue
+                try:
+                    bucket_contents = bucket_ptr.dereference().cast(self.symbol_table_name + constants.BANG + "bucket_contents")
+                    while bucket_contents.times_found > 0 or bucket_contents.next != 0:
+                        try:
+                            if bucket_contents in seen:
+                                break
+                            seen[bucket_contents] = 1
+                            pdata = bucket_contents.data
+                            if (0 <= pdata.flags <= 2 and bucket_contents.times_found > 0):
+                                try:
+                                    times_found = bucket_contents.times_found
+                                    key = utility.array_to_string(bucket_contents.key.dereference())
+                                    path = utility.array_to_string(bucket_contents.data.path.dereference())
+                                    if path.startswith("/"):
+                                        yield (bucket_contents)
+                                except:
+                                    continue
+                        
+                            bucket_contents = bucket_contents.next
+                        except:
+                            continue
+                except Exception as e:
+                    continue

--- a/volatility3/framework/symbols/linux/hash.py
+++ b/volatility3/framework/symbols/linux/hash.py
@@ -1,0 +1,13 @@
+# This file is Copyright 2022 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+from volatility3.framework.symbols import intermed
+from volatility3.framework.symbols.linux.extensions import hash
+
+class HashIntermedSymbols(intermed.IntermediateSymbolTable):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.set_type_class('bash_hash_table', hash.bash_hash_table)

--- a/volatility3/framework/symbols/linux/hash32.json
+++ b/volatility3/framework/symbols/linux/hash32.json
@@ -1,0 +1,172 @@
+{
+    "symbols": {}, 
+    "enums": {}, 
+    "base_types": {
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "pathdata": {
+            "fields": {
+                "path": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "flags": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 4
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "envdata": {
+            "fields": {
+                "name": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "value": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 4
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "bucket_contents": {
+            "fields": {
+                "next": {
+                    "type": {
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "bucket_contents"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "key": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 4
+                },
+                "data": {
+                    "type": {
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "pathdata"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 8
+                },
+                "times_found": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 16
+                }
+            },
+            "kind": "struct",
+            "size": 20
+        },
+        "bash_hash_table": {
+            "fields": {
+                "bucket_array": {
+                    "type": {
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "bucket_contents"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "nbuckets": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 4
+                },
+                "nentries": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 12
+        }
+    }, 
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "/mnt/hgfs/volshared/vtypes_to_json.py", 
+            "datetime": "2018-12-03T09:57:47.343730"
+        }, 
+        "format": "4.1.0"
+    }
+}

--- a/volatility3/framework/symbols/linux/hash64.json
+++ b/volatility3/framework/symbols/linux/hash64.json
@@ -1,0 +1,172 @@
+{
+    "symbols": {}, 
+    "enums": {}, 
+    "base_types": {
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 8, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "pathdata": {
+            "fields": {
+                "path": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "flags": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 12
+        },
+        "envdata": {
+            "fields": {
+                "name": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "value": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "bucket_contents": {
+            "fields": {
+                "next": {
+                    "type": {
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "bucket_contents"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "key": {
+                    "type": {
+                        "subtype": {
+                            "count": 1024,
+                            "subtype": {
+                                "kind": "base",
+                                "name": "unsigned char"
+                            },
+                            "kind": "array"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 8
+                },
+                "data": {
+                    "type": {
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "pathdata"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 16
+                },
+                "times_found": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 28
+                }
+            },
+            "kind": "struct",
+            "size": 32
+        },
+        "bash_hash_table": {
+            "fields": {
+                "bucket_array": {
+                    "type": {
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "bucket_contents"
+                        },
+                        "kind": "pointer"
+                    },
+                    "offset": 0
+                },
+                "nbuckets": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 8
+                },
+                "nentries": {
+                    "type": {
+                        "kind": "base",
+                        "name": "int"
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "/mnt/hgfs/volshared/vtypes_to_json.py", 
+            "datetime": "2018-12-03T09:55:34.880766"
+        }, 
+        "format": "4.1.0"
+    }
+}


### PR DESCRIPTION
Hello

I've just added 2 plugins, linux.bash_hash and linux.bash_env.
Below are the usage examples.

```
$ python3 vol.py -f ../../mem/ubuntu64.lime linux.bash_hash
Volatility 3 Framework 2.4.1
Progress:  100.00               Stacking attempts finished
PID     Name    Hits    Command Full Path

1416    bash    1       sudo    /usr/bin/sudo
1416    bash    1       ls      /usr/bin/ls
1476    bash    1       insmod  /usr/sbin/insmod
1476    bash    1       rmmod   /usr/sbin/rmmod
1476    bash    2       swapoff /usr/sbin/swapoff
1476    bash    3       swapon  /usr/sbin/swapon
```

```
$ python3 vol.py -f ../../mem/ubuntu64.lime linux.bash_env
Volatility 3 Framework 2.4.1
Progress:  100.00               Stacking attempts finished
PID     Process Vars

1       systemd
2       kthreadd
3       rcu_gp
4       rcu_par_gp
5       kworker/0:0
6       kworker/0:0H
7       kworker/0:1
8       kworker/u256:0
9       mm_percpu_wq
10      ksoftirqd/0
11      rcu_sched
12      migration/0
13      idle_inject/0
14      cpuhp/0

..snip..

```

The former was developed based on volatility2's linux_bash_hash plugin and has the same functionality, and the latter is based on linux_bash_env. So these are more of re-implementation for volatility3 rather than new-development.

I am not quite sure if pull-request is an appropreate way to request for plugin addition like this, but if there is no problem about this, would you add these  please?