### PR TITLE
Feature/snappy ctypes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,3 @@ jsonschema>=2.3.0
 
 # This is required for memory acquisition via leechcore/pcileech.
 leechcorepyc>=2.4.0
-
-# This is required for analyzing Linux samples compressed using AVMLs native
-# compression format.  It is not required for AVML's standard LiME compression.
-python-snappy==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,3 @@ pycryptodome
 
 # This is required for memory acquisition via leechcore/pcileech.
 leechcorepyc>=2.4.0
-
-# This is required for analyzing Linux samples compressed using AVMLs native
-# compression format.  It is not required for AVML's standard LiME compression.
-python-snappy==0.6.0

--- a/volatility3/framework/layers/avml.py
+++ b/volatility3/framework/layers/avml.py
@@ -6,6 +6,7 @@
 
 The user of the file doesn't have to worry about the compression,
 but random access is not allowed."""
+import ctypes
 import logging
 import struct
 from typing import Tuple, List, Optional
@@ -16,11 +17,33 @@ from volatility3.framework.layers import segmented
 vollog = logging.getLogger(__name__)
 
 try:
-    import snappy
+    from ctypes import cdll
+
+    # TODO: Find library for windows if needed
+    lib_snappy = cdll.LoadLibrary("libsnappy.so.1")
+    __snappy_uncompress = lib_snappy.snappy_uncompress
+    __snappy_uncompressed_length = lib_snappy.snappy_uncompressed_length
 
     HAS_SNAPPY = True
-except ImportError:
+except OSError:
     HAS_SNAPPY = False
+
+
+class SnappyException(Exception):
+    pass
+
+
+def uncompress(s):
+    """Uncompress a snappy compressed string."""
+    ulen = ctypes.c_int(0)
+    cresult = __snappy_uncompressed_length(s, len(s), ctypes.byref(ulen))
+    if cresult != 0:
+        raise SnappyException(f"Error in snappy_uncompressed_length: {cresult}")
+    ubuf = ctypes.create_string_buffer(ulen.value)
+    __snappy_uncompress(s, len(s), ubuf, ctypes.byref(ulen))
+    if cresult != 0:
+        raise SnappyException(f"Error in snappy_uncompress: {cresult}")
+    return ubuf.raw
 
 
 class AVMLLayer(segmented.NonLinearlySegmentedLayer):
@@ -44,9 +67,7 @@ class AVMLLayer(segmented.NonLinearlySegmentedLayer):
         if magic not in [0x4C4D5641] or version != 2:
             raise exceptions.LayerException("File not completely in AVML format")
         if not HAS_SNAPPY:
-            vollog.warning(
-                "AVML file detected, but snappy python library not installed"
-            )
+            vollog.warning("AVML file detected, but snappy library could not be found")
             raise exceptions.LayerException(
                 "AVML format dependencies not satisfied (snappy)"
             )
@@ -131,7 +152,7 @@ class AVMLLayer(segmented.NonLinearlySegmentedLayer):
                     ]
                     if frame_type == 0x00:
                         # Compressed data
-                        frame_data = snappy.decompress(frame_data)
+                        frame_data = uncompress(frame_data)
                     # TODO: Verify CRC
                     segments.append(
                         (
@@ -156,7 +177,7 @@ class AVMLLayer(segmented.NonLinearlySegmentedLayer):
     ) -> bytes:
         start_offset, _, _, _ = self._find_segment(offset)
         if self._compressed[mapped_offset]:
-            decoded_data = snappy.decompress(data)
+            decoded_data = uncompress(data)
         else:
             decoded_data = data
         decoded_data = decoded_data[offset - start_offset :]

--- a/volatility3/framework/layers/avml.py
+++ b/volatility3/framework/layers/avml.py
@@ -17,25 +17,23 @@ from volatility3.framework.layers import segmented
 vollog = logging.getLogger(__name__)
 
 try:
-    from ctypes import cdll
-
     # TODO: Find library for windows if needed
     try:
         # Linux/Mac
-        lib_snappy = cdll.LoadLibrary("libsnappy.so.1")
+        lib_snappy = ctypes.cdll.LoadLibrary("libsnappy.so.1")
     except OSError:
         lib_snappy = None
 
     try:
         if not lib_snappy:
             # Windows 64
-            lib_snappy = cdll.LoadLibrary("snappy64")
+            lib_snappy = ctypes.cdll.LoadLibrary("snappy64")
     except OSError:
         lib_snappy = None
 
     if lib_snappy:
         # Windows 32
-        lib_snappy = cdll.LoadLibrary("snappy32")
+        lib_snappy = ctypes.cdll.LoadLibrary("snappy32")
 
     __snappy_uncompress = lib_snappy.snappy_uncompress
     __snappy_uncompressed_length = lib_snappy.snappy_uncompressed_length
@@ -56,7 +54,7 @@ def uncompress(s):
     if cresult != 0:
         raise SnappyException(f"Error in snappy_uncompressed_length: {cresult}")
     ubuf = ctypes.create_string_buffer(ulen.value)
-    __snappy_uncompress(s, len(s), ubuf, ctypes.byref(ulen))
+    cresult = __snappy_uncompress(s, len(s), ubuf, ctypes.byref(ulen))
     if cresult != 0:
         raise SnappyException(f"Error in snappy_uncompress: {cresult}")
     return ubuf.raw


### PR DESCRIPTION
This replaces the python-snappy dependency (which had a number of installation difficulties) with a ctypes wrapper.  The wrapper does not force a dependency on the whole of volatility in order to support AVML files, and provides information if the AVML file format is detected but cannot be processed.  On most linux/mac systems the system package for libsnappy should install it to the right location, on Windows, snappy32.dll/snappy64.dll will need to be installed off [the link](https://snappy.machinezoo.com/#shell) from the [official snappy page](https://google.github.io/snappy/).

This should resolve a number of snappy instruction/snappy installation issues that have plagued the AVML support.