### PR TITLE
Add PID exclusion filter as commandline flag

### DIFF
--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -65,6 +65,11 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
                 description="Process IDs to include (all other processes are excluded)",
                 optional=True,
             ),
+            requirements.BooleanRequirement(
+                name="exclude",
+                description="Make filters exclusive instead of inclusive (e.g. pid filter excludes processes)",
+                optional=True,
+            ),
         ]
 
     def _generator(self):
@@ -72,7 +77,9 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
 
         rules = yarascan.YaraScan.process_yara_options(dict(self.config))
 
-        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+        filter_func = pslist.PsList.create_pid_filter(
+            self.config.get("pid", None), self.config.get("exclude", False)
+        )
 
         for task in pslist.PsList.list_processes(
             context=self.context,


### PR DESCRIPTION
The `windows.vadyarascan` plugin allows for PID filtering using the `--pid` flag. However, when scanning memory some processes such as detection engines might match an abundance of rules. This pull request implements an `--exclude` flag which makes filters exclusive instead of inclusive, effectively allowing users to exclude known sources of false positives.

# Example
The following memory capture contains traces of the [AURORA](https://www.nextron-systems.com/aurora/) detection engine.
```
> vol.exe -f .\memdump.mem windows.pstree --pid 6840 6872
Volatility 3 Framework 2.4.1
Progress:  100.00               PDB scanning finished
PID     PPID    ImageFileName   Offset(V)       Threads Handles SessionId       Wow64   CreateTime      ExitTime

564     476     wininit.exe     0x848341865140  1       -       0       False   2023-02-26 11:15:45.000000      N/A
* 704   564     services.exe    0x8483426940c0  7       -       0       False   2023-02-26 11:15:45.000000      N/A
** 6872 704     aurora-agent-6  0x8483459c5300  22      -       0       False   2023-02-26 11:20:56.000000      N/A
664     556     winlogon.exe    0x8483418c1100  6       -       1       False   2023-02-26 11:15:45.000000      N/A
* 5136  664     userinit.exe    0x84834c448080  0       -       1       False   2023-02-26 11:15:56.000000      2023-02-26 11:16:21.000000
** 5220 5136    explorer.exe    0x84834c49b080  57      -       1       False   2023-02-26 11:15:57.000000      N/A
*** 6840        5220    powershell.exe  0x84834bf79080  12      -       1       False   2023-02-26 11:45:31.000000      N/A
**** 2072       6840    conhost.exe     0x84834ce5f080  5       -       1       False   2023-02-26 11:45:32.000000      N/A
**** 3436       6840    cmd.exe 0x848342c18080  1       -       1       False   2023-02-26 11:46:01.000000      N/A
```
Scanning the memory using `windows.vadyarascan` will result in thousands of matches on the agent itself given it has detection rules loaded in memory as shown in the following trimmed output.
```
> vol.exe -f .\memdump.mem windows.vadyarascan --yara-file .\signature-base.yar
Volatility 3 Framework 2.4.1
Progress:  100.00               PDB scanning finished
Offset  PID     Rule    Component       Value

0xc000018270    6872    APT10_Malware_Sample_Gen        $c2_428 66 74 70 2e 77 69 6e 64 6f 77 73 75 70 64 61 74 65 2e 72 65 62 61 74 65 73 72 75 6c 65 2e 6e 65 74
0xc000018360    6872    APT10_Malware_Sample_Gen        $c2_429 66 74 70 2e 77 69 6e 64 6f 77 73 75 70 64 61 74 65 2e 73 65 6c 6c 63 6c 61 73 73 69 63 73 2e 63 6f 6d
0xc000018274    6872    APT10_Malware_Sample_Gen        $c2_981 77 69 6e 64 6f 77 73 75 70 64 61 74 65 2e 72 65 62 61 74 65 73 72 75 6c 65 2e 6e 65 74
0xc000018364    6872    APT10_Malware_Sample_Gen        $c2_982 77 69 6e 64 6f 77 73 75 70 64 61 74 65 2e 73 65 6c 6c 63 6c 61 73 73 69 63 73 2e 63 6f 6d
0xc000019e90    6872    APT10_Malware_Sample_Gen        $c2_491 69 6d 61 67 65 73 2e 77 69 6e 64 6f 77 73 75 70 64 61 74 65 2e 6f 72 67 61 6e 69 63 63 72 61 70 2e 63 6f 6d
0xc000019084    6872    APT10_Malware_Sample_Gen        $c2_642 6d 69 63 72 6f 73 6f 66 74 65 6d 70 6f 77 65 72 69 6e 67 2e 73 65 6e 64 73 6d 74 70 2e 63 6f 6d
0xc000019234    6872    APT10_Malware_Sample_Gen        $c2_645 6d 69 63 72 6f 73 6f 66 74 67 65 74 73 74 61 72 74 65 64 2e 73 65 78 69 64 75 64 65 2e 63 6f 6d
0xc000019324    6872    APT10_Malware_Sample_Gen        $c2_646 6d 69 63 72 6f 73 6f 66 74 69 6d 61 67 65 73 2e 6f 72 67 61 6e 69 63 63 72 61 70 2e 63 6f 6d
0xc000019714    6872    APT10_Malware_Sample_Gen        $c2_651 6d 69 63 72 6f 73 6f 66 74 71 63 6b 6d 61 6e 61 67 65 72 2e 70 63 61 6e 79 77 68 65 72 65 2e 6e 65 74
0xc000019e97    6872    APT10_Malware_Sample_Gen        $c2_980 77 69 6e 64 6f 77 73 75 70 64 61 74 65 2e 6f 72 67 61 6e 69 63 63 72 61 70 2e 63 6f 6d
0xc000019080    6872    APT10_Malware_Sample_Gen        $c2_1169        77 77 77 2e 6d 69 63 72 6f 73 6f 66 74 65 6d 70 6f 77 65 72 69 6e 67 2e 73 65 6e 64 73 6d 74 70 2e 63 6f 6d
0xc000019230    6872    APT10_Malware_Sample_Gen        $c2_1171        77 77 77 2e 6d 69 63 72 6f 73 6f 66 74 67 65 74 73 74 61 72 74 65 64 2e 73 65 78 69 64 75 64 65 2e 63 6f 6d
0xc000019320    6872    APT10_Malware_Sample_Gen        $c2_1172        77 77 77 2e 6d 69 63 72 6f 73 6f 66 74 69 6d 61 67 65 73 2e 6f 72 67 61 6e 69 63 63 72 61 70 2e 63 6f 6d
0xc000019710    6872    APT10_Malware_Sample_Gen        $c2_1176        77 77 77 2e 6d 69 63 72 6f 73 6f 66 74 71 63 6b 6d 61 6e 61 67 65 72 2e 70 63 61 6e 79 77 68 65 72 65 2e 6e 65 74
0xc00001e8e4    6872    APT10_Malware_Sample_Gen        $c2_110 63 69 76 69 6c 77 61 72 35 32 30 2e 6f 6e 6d 79 70 63 2e 6f 72 67
0xc00001eba4    6872    APT10_Malware_Sample_Gen        $c2_118 63 6f 6d 6d 69 73 73 69 6f 6e 65 72 2e 73 68 65 6e 61 6a 6f 75 2e 63 6f 6d
0xc00001e420    6872    APT10_Malware_Sample_Gen        $c2_313 66 74 70 2e 6b 6e 6f 77 6c 65 64 67 65 2e 73 65 6c 6c 63 6c 61 73 73 69 63 73 2e 63 6f 6d
0xc00001e6e0    6872    APT10_Malware_Sample_Gen        $c2_316 66 74 70 2e 6c 61 74 65 73 74 6e 65 77 73 2e 6f 72 67 61 6e 69 63 63 72 61 70 2e 63 6f 6d
0xc00001e7e0    6872    APT10_Malware_Sample_Gen        $c2_317 66 74 70 2e 6c 65 65 64 6f 6e 67 2e 6c 6f 6e 67 6d 75 73 69 63 2e 63 6f 6d
0xc00001ec60    6872    APT10_Malware_Sample_Gen        $c2_322 66 74 70 2e 6d 61 72 74 69 6e 2e 73 65 6c 6c 63 6c 61 73 73 69 63 73 2e 63 6f 6d
0xc00001ee40    6872    APT10_Malware_Sample_Gen        $c2_324 66 74 70 2e 6d 65 64 69 61 70 61 74 68 2e 6f 72 67 61 6e 69 63 63 72 61 70 2e 63 6f 6d
0xc00001ef40    6872    APT10_Malware_Sample_Gen        $c2_325 66 74 70 2e 6d 69 63 72 6f 73 6f 66 74 2e 67 6f 74 2d 67 61 6d 65 2e 6f 72 67
0xc00001e424    6872    APT10_Malware_Sample_Gen        $c2_585 6b 6e 6f 77 6c 65 64 67 65 2e 73 65 6c 6c 63 6c 61 73 73 69 63 73 2e 63 6f 6d
...
```
By using the `--pid` flag alongside the `--exclude` flag, one can exclude this source of known false positives to focus the scanning on all other processes.
```
> vol.exe -f .\memdump.mem windows.vadyarascan --yara-file .\signature-base.yar --exclude --pid 6872
Volatility 3 Framework 2.4.1
Progress:  100.00               PDB scanning finished
Offset  PID     Rule    Component       Value

0x17dc710d939   6840    SUSP_PowerShell_IEX_Download_Combo      $x1     49 45 58 20 28 28 6e 65 77 2d 6f 62 6a 65 63 74 20 6e 65 74 2e 77 65 62 63 6c 69 65 6e 74 29 2e 64 6f 77 6e 6c 6f 61 64
0x17dc71745f6   6840    SUSP_PowerShell_IEX_Download_Combo      $x1     49 45 58 20 28 28 6e 65 77 2d 6f 62 6a 65 63 74 20 6e 65 74 2e 77 65 62 63 6c 69 65 6e 74 29 2e 64 6f 77 6e 6c 6f 61 64
0x17dc71752ae   6840    SUSP_PowerShell_IEX_Download_Combo      $x1     49 45 58 20 28 28 6e 65 77 2d 6f 62 6a 65 63 74 20 6e 65 74 2e 77 65 62 63 6c 69 65 6e 74 29 2e 64 6f 77 6e 6c 6f 61 64
```