### PR TITLE
Windows: Memoize part of the pool handling code

### DIFF
--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -381,6 +381,7 @@ class ModuleCollection(interfaces.context.ModuleContainer):
     def __init__(
         self, modules: Optional[List[interfaces.context.ModuleInterface]] = None
     ) -> None:
+        self._prefix_count = {}
         super().__init__(modules)
 
     def deduplicate(self) -> "ModuleCollection":
@@ -400,9 +401,13 @@ class ModuleCollection(interfaces.context.ModuleContainer):
 
     def free_module_name(self, prefix: str = "module") -> str:
         """Returns an unused module name"""
-        count = 1
+        if prefix not in self._prefix_count:
+            self._prefix_count[prefix] = 1
+            return prefix
+        count = self._prefix_count[prefix]
         while prefix + str(count) in self:
             count += 1
+        self._prefix_count[prefix] = count
         return prefix + str(count)
 
     @property

--- a/volatility3/framework/symbols/windows/extensions/pool.py
+++ b/volatility3/framework/symbols/windows/extensions/pool.py
@@ -396,13 +396,9 @@ class OBJECT_HEADER(objects.StructType):
             )
 
         symbol_table_name = self.vol.type_name.split(constants.BANG)[0]
-
-        try:
-            header_offset = self.NameInfoOffset
-        except AttributeError:
-            # http://codemachine.com/article_objectheader.html (Windows 7 and later)
-            name_info_bit = 0x2
-
+        if symbol_table_name in self._context.modules:
+            ntkrnlmp = self._context.modules[symbol_table_name]
+        else:
             layer = self._context.layers[self.vol.native_layer_name]
             kvo = layer.config.get("kernel_virtual_offset", None)
 
@@ -411,16 +407,25 @@ class OBJECT_HEADER(objects.StructType):
                     f"Could not find kernel_virtual_offset for layer: {self.vol.layer_name}"
                 )
 
+            # We know this symbol table name can't exist because we checked for it earlier
             ntkrnlmp = self._context.module(
                 symbol_table_name, layer_name=self.vol.layer_name, offset=kvo
             )
+            self._context.add_module(ntkrnlmp)
+
+        try:
+            header_offset = self.NameInfoOffset
+        except AttributeError:
+            # http://codemachine.com/article_objectheader.html (Windows 7 and later)
+            name_info_bit = 0x2
+
             address = ntkrnlmp.get_symbol("ObpInfoMaskToOffset").address
             calculated_index = self.InfoMask & (name_info_bit | (name_info_bit - 1))
 
-            header_offset = self._context.object(
-                symbol_table_name + constants.BANG + "unsigned char",
+            header_offset = ntkrnlmp.object(
+                "unsigned char",
                 layer_name=self.vol.native_layer_name,
-                offset=kvo + address + calculated_index,
+                offset=address + calculated_index,
             )
 
         if header_offset == 0:
@@ -430,8 +435,8 @@ class OBJECT_HEADER(objects.StructType):
                 )
             )
 
-        header = self._context.object(
-            symbol_table_name + constants.BANG + "_OBJECT_HEADER_NAME_INFO",
+        header = ntkrnlmp.object(
+            "_OBJECT_HEADER_NAME_INFO",
             layer_name=self.vol.layer_name,
             offset=self.vol.offset - header_offset,
             native_layer_name=self.vol.native_layer_name,

--- a/volatility3/framework/symbols/windows/extensions/pool.py
+++ b/volatility3/framework/symbols/windows/extensions/pool.py
@@ -396,6 +396,7 @@ class OBJECT_HEADER(objects.StructType):
             )
 
         symbol_table_name = self.vol.type_name.split(constants.BANG)[0]
+
         if symbol_table_name in self._context.modules:
             ntkrnlmp = self._context.modules[symbol_table_name]
         else:
@@ -411,7 +412,6 @@ class OBJECT_HEADER(objects.StructType):
             ntkrnlmp = self._context.module(
                 symbol_table_name, layer_name=self.vol.layer_name, offset=kvo
             )
-            self._context.add_module(ntkrnlmp)
 
         try:
             header_offset = self.NameInfoOffset
@@ -440,5 +440,6 @@ class OBJECT_HEADER(objects.StructType):
             layer_name=self.vol.layer_name,
             offset=self.vol.offset - header_offset,
             native_layer_name=self.vol.native_layer_name,
+            absolute=True,
         )
         return header


### PR DESCRIPTION
This is designed to replace PR #886, it will properly check for an existing symbol table name, but keeps track in a table to speed up creation is a lot are made.  It also memoizes the symbol table, to reduce creation of the table (which the original patch didn't do).  Hopefully this covers all the fixes made.  If so, I'm happy to merge it in...