### PR TITLE
Add basic support for Linux maple tree struct

### DIFF
--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -48,7 +48,7 @@ class Elfs(plugins.PluginInterface):
 
             name = utility.array_to_string(task.comm)
 
-            for vma in task.mm.get_mmap_iter():
+            for vma in task.mm.get_vma_iter():
                 hdr = proc_layer.read(vma.vm_start, 4, pad=True)
                 if not (
                     hdr[0] == 0x7F

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -46,7 +46,7 @@ class Malfind(interfaces.plugins.PluginInterface):
 
         proc_layer = self.context.layers[proc_layer_name]
 
-        for vma in task.mm.get_mmap_iter():
+        for vma in task.mm.get_vma_iter():
             if vma.is_suspicious() and vma.get_name(self.context, task) != "[vdso]":
                 data = proc_layer.read(vma.vm_start, 64, pad=True)
                 yield vma, data

--- a/volatility3/framework/plugins/linux/proc.py
+++ b/volatility3/framework/plugins/linux/proc.py
@@ -44,7 +44,7 @@ class Maps(plugins.PluginInterface):
 
             name = utility.array_to_string(task.comm)
 
-            for vma in task.mm.get_mmap_iter():
+            for vma in task.mm.get_vma_iter():
                 flags = vma.get_protection()
                 page_offset = vma.get_page_offset()
                 major = 0

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -53,6 +53,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         # Only found in 6.1+ kernels
         self.optional_set_type_class("maple_tree", extensions.maple_tree)
 
+
 class LinuxUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful linux functions."""
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -50,6 +50,8 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.optional_set_type_class("bt_sock", extensions.bt_sock)
         self.optional_set_type_class("xdp_sock", extensions.xdp_sock)
 
+        # Only found in 6.1+ kernels
+        self.optional_set_type_class("maple_tree", extensions.maple_tree)
 
 class LinuxUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful linux functions."""

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -34,10 +34,8 @@ class module(generic.GenericIntelProcess):
     def get_init_size(self):
         if self.has_member("init_layout"):
             return self.init_layout.size
-
         elif self.has_member("init_size"):
             return self.init_size
-
         raise AttributeError(
             "module -> get_init_size: Unable to determine .init section size of module"
         )
@@ -45,10 +43,8 @@ class module(generic.GenericIntelProcess):
     def get_core_size(self):
         if self.has_member("core_layout"):
             return self.core_layout.size
-
         elif self.has_member("core_size"):
             return self.core_size
-
         raise AttributeError(
             "module -> get_core_size: Unable to determine core size of module"
         )
@@ -58,7 +54,6 @@ class module(generic.GenericIntelProcess):
             return self.core_layout.base
         elif self.has_member("module_core"):
             return self.module_core
-
         raise AttributeError("module -> get_module_core: Unable to get module core")
 
     def get_module_init(self):
@@ -66,7 +61,6 @@ class module(generic.GenericIntelProcess):
             return self.init_layout.base
         elif self.has_member("module_init"):
             return self.module_init
-
         raise AttributeError("module -> get_module_core: Unable to get module init")
 
     def get_name(self):
@@ -88,7 +82,6 @@ class module(generic.GenericIntelProcess):
         idx = 0
         while arr[idx]:
             idx = idx + 1
-
         return idx
 
     def get_sections(self):
@@ -97,7 +90,6 @@ class module(generic.GenericIntelProcess):
             num_sects = self.sect_attrs.nsections
         else:
             num_sects = self._get_sect_count(self.sect_attrs.grp)
-
         arr = self._context.object(
             self.get_symbol_table().name + constants.BANG + "array",
             layer_name=self.vol.layer_name,
@@ -116,7 +108,6 @@ class module(generic.GenericIntelProcess):
             prefix = "Elf64_"
         else:
             prefix = "Elf32_"
-
         elf_table_name = intermed.IntermediateSymbolTable.create(
             self.context,
             self.config_path,
@@ -155,7 +146,6 @@ class module(generic.GenericIntelProcess):
             return self.kallsyms.symtab
         elif self.has_member("symtab"):
             return self.symtab
-
         raise AttributeError("module -> symtab: Unable to get symtab")
 
     @property
@@ -164,7 +154,6 @@ class module(generic.GenericIntelProcess):
             return int(self.kallsyms.num_symtab)
         elif self.has_member("num_symtab"):
             return int(self.num_symtab)
-
         raise AttributeError(
             "module -> num_symtab: Unable to determine number of symbols"
         )
@@ -177,7 +166,6 @@ class module(generic.GenericIntelProcess):
         # Older kernels
         elif self.has_member("strtab"):
             return self.strtab
-
         raise AttributeError("module -> strtab: Unable to get strtab")
 
 
@@ -195,19 +183,15 @@ class task_struct(generic.GenericIntelProcess):
             pgd = self.mm.pgd
         except exceptions.InvalidAddressException:
             return None
-
         if not isinstance(parent_layer, linear.LinearlyMappedLayer):
             raise TypeError(
                 "Parent layer is not a translation layer, unable to construct process layer"
             )
-
         dtb, layer_name = parent_layer.translate(pgd)
         if not dtb:
             return None
-
         if preferred_name is None:
             preferred_name = self.vol.layer_name + f"_Process{self.pid}"
-
         # Add the constructed layer and return the name
         return self._add_process_layer(
             self._context, dtb, config_prefix, preferred_name
@@ -229,7 +213,6 @@ class task_struct(generic.GenericIntelProcess):
                 vollog.info(
                     f"adding vma: {start:x} {self.mm.brk:x} | {end:x} {self.mm.start_brk:x}"
                 )
-
             yield (start, end - start)
 
     @property
@@ -282,7 +265,6 @@ class fs_struct(objects.StructType):
             return self.root
         elif self.root.has_member("dentry"):
             return self.root.dentry
-
         raise AttributeError("Unable to find the root dentry")
 
     def get_root_mnt(self):
@@ -291,7 +273,6 @@ class fs_struct(objects.StructType):
             return self.rootmnt
         elif self.root.has_member("mnt"):
             return self.root.mnt
-
         raise AttributeError("Unable to find the root mount")
 
 
@@ -340,7 +321,6 @@ class maple_tree(objects.StructType):
             return
         else:
             seen.add(maple_tree_entry)
-
         # check if we have exceeded the expected depth of this maple tree.
         # e.g. when current_depth is larger than expected_maple_tree_depth there may be an issue.
         # it is normal that expected_maple_tree_depth is equal to current_depth.
@@ -349,7 +329,6 @@ class maple_tree(objects.StructType):
                 f"The depth for the maple tree at {hex(self.vol.offset)} is {expected_maple_tree_depth}, however when parsing the nodes "
                 f"a depth of {current_depth} was reached. This is unexpected and may lead to incorrect results."
             )
-
         # parse the mte to extract the pointer value, node type, and leaf status
         pointer = maple_tree_entry & ~(self.MAPLE_NODE_POINTER_MASK)
         node_type = (
@@ -421,10 +400,8 @@ class mm_struct(objects.StructType):
             raise AttributeError(
                 "get_mmap_iter called on mm_struct where no mmap member exists."
             )
-
         if not self.mmap:
             return
-
         yield self.mmap
 
         seen = {self.mmap.vol.offset}
@@ -442,7 +419,6 @@ class mm_struct(objects.StructType):
             raise AttributeError(
                 "get_maple_tree_iter called on mm_struct where no mm_mt member exists."
             )
-
         symbol_table_name = self.get_symbol_table_name()
         for vma_pointer in self.mm_mt.get_slot_iter():
             # convert pointer to vm_area_struct and yield
@@ -569,7 +545,6 @@ class vm_area_struct(objects.StructType):
                 retval = retval + char
             else:
                 retval = retval + "-"
-
         return retval
 
     # only parse the rwx bits
@@ -583,7 +558,6 @@ class vm_area_struct(objects.StructType):
     def get_page_offset(self) -> int:
         if self.vm_file == 0:
             return 0
-
         return self.vm_pgoff << constants.linux.PAGE_SHIFT
 
     def get_name(self, context, task):
@@ -600,7 +574,6 @@ class vm_area_struct(objects.StructType):
             fname = "[vdso]"
         else:
             fname = "Anonymous Mapping"
-
         return fname
 
     # used by malfind
@@ -611,10 +584,8 @@ class vm_area_struct(objects.StructType):
 
         if flags_str == "rwx":
             ret = True
-
         elif flags_str == "r-x" and self.vm_file.dereference().vol.offset == 0:
             ret = True
-
         return ret
 
 
@@ -624,12 +595,10 @@ class qstr(objects.StructType):
             str_length = self.len + 1  # Maximum length should include null terminator
         else:
             str_length = 255
-
         try:
             ret = objects.utility.pointer_to_string(self.name, str_length)
         except (exceptions.InvalidAddressException, ValueError):
             ret = ""
-
         return ret
 
 
@@ -660,7 +629,6 @@ class dentry(objects.StructType):
         """
         if self.vol.offset == old_dentry:
             return True
-
         return self.d_ancestor(old_dentry)
 
     def d_ancestor(self, ancestor_dentry):
@@ -678,10 +646,8 @@ class dentry(objects.StructType):
         ):
             if current_dentry.d_parent == ancestor_dentry.vol.offset:
                 return current_dentry
-
             dentry_seen.add(current_dentry.vol.offset)
             current_dentry = current_dentry.d_parent
-
         return None
 
 
@@ -738,12 +704,10 @@ class list_head(objects.StructType, collections.abc.Iterable):
             link = getattr(self, direction).dereference()
         except exceptions.InvalidAddressException:
             return
-
         if not sentinel:
             yield self._context.object(
                 symbol_type, layer, offset=self.vol.offset - relative_offset
             )
-
         seen = {self.vol.offset}
         while link.vol.offset not in seen:
             obj = self._context.object(
@@ -869,7 +833,6 @@ class mount(objects.StructType):
             peer = current_mnt.get_peer_under_root(self.mnt_ns, root)
             if peer and peer.vol.offset != 0:
                 return peer.mnt_group_id
-
             mnt_seen.add(current_mnt.vol.offset)
             current_mnt = current_mnt.mnt_master
         return 0
@@ -885,12 +848,10 @@ class mount(objects.StructType):
                 current_mnt.mnt.mnt_root, root
             ):
                 return current_mnt
-
             mnt_seen.add(current_mnt.vol.offset)
             current_mnt = current_mnt.next_peer()
             if current_mnt.vol.offset == self.vol.offset:
                 break
-
         return None
 
     def is_path_reachable(self, current_dentry, root):
@@ -907,7 +868,6 @@ class mount(objects.StructType):
             current_dentry = current_mnt.mnt_mountpoint
             mnt_seen.add(current_mnt.vol.offset)
             current_mnt = current_mnt.mnt_parent
-
         return current_mnt.mnt.vol.offset == root.mnt and current_dentry.is_subdir(
             root.dentry
         )
@@ -968,7 +928,6 @@ class kobject(objects.StructType):
             ret = refcnt.counter
         else:
             ret = refcnt.refs.counter
-
         return ret
 
 
@@ -987,7 +946,6 @@ class mnt_namespace(objects.StructType):
         if not self._context.symbol_space.has_type(mnt_type):
             # Old kernels ~ 2.6
             mnt_type = table_name + constants.BANG + "vfsmount"
-
         for mount in self.list.to_list(mnt_type, "mnt_list"):
             yield mount
 
@@ -1012,7 +970,6 @@ class socket(objects.StructType):
         )
         if not module_names:
             raise ValueError(f"No module using the symbol table {symbol_table}")
-
         kernel_module_name = module_names[0]
         kernel = self._context.modules[kernel_module_name]
         return kernel
@@ -1022,7 +979,6 @@ class socket(objects.StructType):
             kernel = self._get_vol_kernel()
         except ValueError:
             return 0
-
         socket_alloc = linux.LinuxUtilities.container_of(
             self.vol.offset, "socket_alloc", "socket", kernel
         )
@@ -1048,7 +1004,6 @@ class sock(objects.StructType):
     def get_inode(self):
         if not self.sk_socket:
             return 0
-
         return self.sk_socket.get_inode()
 
     def get_protocol(self):
@@ -1058,7 +1013,6 @@ class sock(objects.StructType):
         # Return the generic socket state
         if self.has_member("sk"):
             return self.sk.sk_socket.get_state()
-
         return self.sk_socket.get_state()
 
 
@@ -1066,7 +1020,6 @@ class unix_sock(objects.StructType):
     def get_name(self):
         if not self.addr:
             return
-
         sockaddr_un = self.addr.name.cast("sockaddr_un")
         saddr = str(utility.array_to_string(sockaddr_un.sun_path))
         return saddr
@@ -1102,7 +1055,6 @@ class inet_sock(objects.StructType):
         protocol = IP_PROTOCOLS.get(self.sk.sk_protocol)
         if self.get_family() == "AF_INET6":
             protocol = IPV6_PROTOCOLS.get(self.sk.sk_protocol, protocol)
-
         return protocol
 
     def get_state(self):
@@ -1133,7 +1085,6 @@ class inet_sock(objects.StructType):
             dport_le = sk_common.skc_dport
         else:
             return
-
         return socket_module.htons(dport_le)
 
     def get_src_addr(self):
@@ -1152,7 +1103,6 @@ class inet_sock(objects.StructType):
             saddr = self.pinet6.saddr
         else:
             return
-
         parent_layer = self._context.layers[self.vol.layer_name]
         try:
             addr_bytes = parent_layer.read(saddr.vol.offset, addr_size)
@@ -1161,7 +1111,6 @@ class inet_sock(objects.StructType):
                 f"Unable to read socket src address from {saddr.vol.offset:#x}"
             )
             return
-
         return socket_module.inet_ntop(family, addr_bytes)
 
     def get_dst_addr(self):
@@ -1183,7 +1132,6 @@ class inet_sock(objects.StructType):
             addr_size = 16
         else:
             return
-
         parent_layer = self._context.layers[self.vol.layer_name]
         try:
             addr_bytes = parent_layer.read(daddr.vol.offset, addr_size)
@@ -1192,7 +1140,6 @@ class inet_sock(objects.StructType):
                 f"Unable to read socket dst address from {daddr.vol.offset:#x}"
             )
             return
-
         return socket_module.inet_ntop(family, addr_bytes)
 
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -349,7 +349,7 @@ class maple_tree(objects.StructType):
         symbol_table_name = self.get_symbol_table_name()
         node_parent_mte = self._context.object(
             symbol_table_name + constants.BANG + "pointer",
-            layer_name=self.vol.layer_name,
+            layer_name=self.vol.native_layer_name,
             offset=pointer,
         )
 
@@ -424,7 +424,7 @@ class mm_struct(objects.StructType):
             # convert pointer to vm_area_struct and yield
             vma = self._context.object(
                 symbol_table_name + constants.BANG + "vm_area_struct",
-                layer_name=self.vol.layer_name,
+                layer_name=self.vol.native_layer_name,
                 offset=vma_pointer
             )
             yield vma

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -344,7 +344,6 @@ class maple_tree(objects.StructType):
         node_type = (
             maple_tree_entry >> self.MAPLE_NODE_TYPE_SHIFT
         ) & self.MAPLE_NODE_TYPE_MASK
-        is_leaf = node_type < self.MAPLE_RANGE_64
 
         # create a pointer object for the node parent mte (note this will include flags in the low bits)
         symbol_table_name = self.get_symbol_table_name()
@@ -369,24 +368,20 @@ class maple_tree(objects.StructType):
 
         # parse the slots based on the node type
         if node_type == self.MAPLE_DENSE:
-            assert is_leaf == True
             for slot in node.alloc.slot:
                 if (slot & ~(self.MAPLE_NODE_TYPE_MASK)) != 0:
                     yield slot
         elif node_type == self.MAPLE_LEAF_64:
-            assert is_leaf == True
             for slot in node.mr64.slot:
                 if (slot & ~(self.MAPLE_NODE_TYPE_MASK)) != 0:
                     yield slot
         elif node_type == self.MAPLE_RANGE_64:
-            assert is_leaf == False
             for slot in node.mr64.slot:
                 if (slot & ~(self.MAPLE_NODE_TYPE_MASK)) != 0:
                     yield from self._parse_maple_tree_node(
                         slot, pointer, maple_tree_depth, seen, depth + 1
                     )
         elif node_type == self.MAPLE_ARANGE_64:
-            assert is_leaf == False
             for slot in node.ma64.slot:
                 if (slot & ~(self.MAPLE_NODE_TYPE_MASK)) != 0:
                     yield from self._parse_maple_tree_node(


### PR DESCRIPTION
This adds basic support for Linux Maple Trees (from `include/linux/maple_tree.h` and `lib/maple_tree.c`) specifically focusing on the mm_mt tree found within the mm_struct.

This would fix https://github.com/volatilityfoundation/volatility3/issues/909

This does not yet include any smear protection, I wanted to get thoughts on this before doing that in case I've taken the wrong approach. 

This has been tested on 6.2.7, 6.2.2, and 6.1.15 for maple tree support. I have also tested against older kernels to ensure this didn't break anything. (I can share these mem images if useful.)

Here is a sample of the linux.proc plugin using this maple tree parsing and the output `cat /proc/<PID>/maps` on the test VM. They show the same results.

procfs:
```
563a816af000-563a816b4000 r--p 00000000 08:01 1442768                    /usr/bin/nano
563a816b4000-563a816dc000 r-xp 00005000 08:01 1442768                    /usr/bin/nano
563a816dc000-563a816ea000 r--p 0002d000 08:01 1442768                    /usr/bin/nano
563a816ea000-563a816eb000 r--p 0003a000 08:01 1442768                    /usr/bin/nano
563a816eb000-563a816ec000 rw-p 0003b000 08:01 1442768                    /usr/bin/nano
563a816ec000-563a816ed000 rw-p 00000000 00:00 0 
563a82594000-563a826a0000 rw-p 00000000 00:00 0                          [heap]
7ff489c00000-7ff489ee5000 r--p 00000000 08:01 1453964                    /usr/lib/locale/locale-archive
7ff48a08e000-7ff48a091000 r--p 00000000 08:01 1453247                    /usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
7ff48a091000-7ff48a098000 r-xp 00003000 08:01 1453247                    /usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
7ff48a098000-7ff48a09a000 r--p 0000a000 08:01 1453247                    /usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
7ff48a09a000-7ff48a09b000 ---p 0000c000 08:01 1453247                    /usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
7ff48a09b000-7ff48a09c000 r--p 0000c000 08:01 1453247                    /usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
7ff48a09c000-7ff48a09d000 rw-p 0000d000 08:01 1453247                    /usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
7ff48a09d000-7ff48a0a3000 rw-p 00000000 00:00 0 
7ff48a0bc000-7ff48a0c1000 rw-p 00000000 00:00 0 
7ff48a0c1000-7ff48a0c2000 r--p 00000000 08:01 1452813                    /usr/lib/x86_64-linux-gnu/libdl-2.28.so
7ff48a0c2000-7ff48a0c3000 r-xp 00001000 08:01 1452813                    /usr/lib/x86_64-linux-gnu/libdl-2.28.so
7ff48a0c3000-7ff48a0c4000 r--p 00002000 08:01 1452813                    /usr/lib/x86_64-linux-gnu/libdl-2.28.so
7ff48a0c4000-7ff48a0c5000 r--p 00002000 08:01 1452813                    /usr/lib/x86_64-linux-gnu/libdl-2.28.so
7ff48a0c5000-7ff48a0c6000 rw-p 00003000 08:01 1452813                    /usr/lib/x86_64-linux-gnu/libdl-2.28.so
7ff48a0c6000-7ff48a0e8000 r--p 00000000 08:01 1452729                    /usr/lib/x86_64-linux-gnu/libc-2.28.so
7ff48a0e8000-7ff48a22f000 r-xp 00022000 08:01 1452729                    /usr/lib/x86_64-linux-gnu/libc-2.28.so
7ff48a22f000-7ff48a27b000 r--p 00169000 08:01 1452729                    /usr/lib/x86_64-linux-gnu/libc-2.28.so
7ff48a27b000-7ff48a27c000 ---p 001b5000 08:01 1452729                    /usr/lib/x86_64-linux-gnu/libc-2.28.so
7ff48a27c000-7ff48a280000 r--p 001b5000 08:01 1452729                    /usr/lib/x86_64-linux-gnu/libc-2.28.so
7ff48a280000-7ff48a282000 rw-p 001b9000 08:01 1452729                    /usr/lib/x86_64-linux-gnu/libc-2.28.so
7ff48a282000-7ff48a286000 rw-p 00000000 00:00 0 
7ff48a286000-7ff48a294000 r--p 00000000 08:01 1442631                    /usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
7ff48a294000-7ff48a2a2000 r-xp 0000e000 08:01 1442631                    /usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
7ff48a2a2000-7ff48a2af000 r--p 0001c000 08:01 1442631                    /usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
7ff48a2af000-7ff48a2b3000 r--p 00028000 08:01 1442631                    /usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
7ff48a2b3000-7ff48a2b4000 rw-p 0002c000 08:01 1442631                    /usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
7ff48a2b4000-7ff48a2bd000 r--p 00000000 08:01 1442642                    /usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
7ff48a2bd000-7ff48a2e3000 r-xp 00009000 08:01 1442642                    /usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
7ff48a2e3000-7ff48a2ec000 r--p 0002f000 08:01 1442642                    /usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
7ff48a2ec000-7ff48a2ed000 r--p 00037000 08:01 1442642                    /usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
7ff48a2ed000-7ff48a2ee000 rw-p 00038000 08:01 1442642                    /usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
7ff48a2ee000-7ff48a2f1000 r--p 00000000 08:01 1442593                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ff48a2f1000-7ff48a303000 r-xp 00003000 08:01 1442593                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ff48a303000-7ff48a309000 r--p 00015000 08:01 1442593                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ff48a309000-7ff48a30a000 ---p 0001b000 08:01 1442593                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ff48a30a000-7ff48a30b000 r--p 0001b000 08:01 1442593                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ff48a30b000-7ff48a30c000 rw-p 0001c000 08:01 1442593                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ff48a30c000-7ff48a30e000 rw-p 00000000 00:00 0 
7ff48a320000-7ff48a327000 r--s 00000000 08:01 1968750                    /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
7ff48a327000-7ff48a328000 r--p 00000000 08:01 1452492                    /usr/lib/x86_64-linux-gnu/ld-2.28.so
7ff48a328000-7ff48a346000 r-xp 00001000 08:01 1452492                    /usr/lib/x86_64-linux-gnu/ld-2.28.so
7ff48a346000-7ff48a34e000 r--p 0001f000 08:01 1452492                    /usr/lib/x86_64-linux-gnu/ld-2.28.so
7ff48a34e000-7ff48a34f000 r--p 00026000 08:01 1452492                    /usr/lib/x86_64-linux-gnu/ld-2.28.so
7ff48a34f000-7ff48a350000 rw-p 00027000 08:01 1452492                    /usr/lib/x86_64-linux-gnu/ld-2.28.so
7ff48a350000-7ff48a351000 rw-p 00000000 00:00 0 
7fff0fb47000-7fff0fb68000 rw-p 00000000 00:00 0                          [stack]
7fff0fbeb000-7fff0fbef000 r--p 00000000 00:00 0                          [vvar]
7fff0fbef000-7fff0fbf1000 r-xp 00000000 00:00 0                          [vdso]
```  

linux.proc plugin:
```
PID     Process Start   End     Flags   PgOff   Major   Minor   Inode   File Path

838     nano    0x563a816af000  0x563a816b4000  r--     0x0     8       1       1442768 /usr/usr/bin/usr/bin/nano
838     nano    0x563a816b4000  0x563a816dc000  r-x     0x5000  8       1       1442768 /usr/usr/bin/usr/bin/nano
838     nano    0x563a816dc000  0x563a816ea000  r--     0x2d000 8       1       1442768 /usr/usr/bin/usr/bin/nano
838     nano    0x563a816ea000  0x563a816eb000  r--     0x3a000 8       1       1442768 /usr/usr/bin/usr/bin/nano
838     nano    0x563a816eb000  0x563a816ec000  rw-     0x3b000 8       1       1442768 /usr/usr/bin/usr/bin/nano
838     nano    0x563a816ec000  0x563a816ed000  rw-     0x0     0       0       0       Anonymous Mapping
838     nano    0x563a82594000  0x563a826a0000  rw-     0x0     0       0       0       [heap]
838     nano    0x7ff489c00000  0x7ff489ee5000  r--     0x0     8       1       1453964 /usr/usr/lib/usr/lib/locale/usr/lib/locale/locale-archive
838     nano    0x7ff48a08e000  0x7ff48a091000  r--     0x0     8       1       1453247 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
838     nano    0x7ff48a091000  0x7ff48a098000  r-x     0x3000  8       1       1453247 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
838     nano    0x7ff48a098000  0x7ff48a09a000  r--     0xa000  8       1       1453247 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
838     nano    0x7ff48a09a000  0x7ff48a09b000  ---     0xc000  8       1       1453247 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
838     nano    0x7ff48a09b000  0x7ff48a09c000  r--     0xc000  8       1       1453247 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
838     nano    0x7ff48a09c000  0x7ff48a09d000  rw-     0xd000  8       1       1453247 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libnss_files-2.28.so
838     nano    0x7ff48a09d000  0x7ff48a0a3000  rw-     0x0     0       0       0       Anonymous Mapping
838     nano    0x7ff48a0bc000  0x7ff48a0c1000  rw-     0x0     0       0       0       Anonymous Mapping
838     nano    0x7ff48a0c1000  0x7ff48a0c2000  r--     0x0     8       1       1452813 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libdl-2.28.so
838     nano    0x7ff48a0c2000  0x7ff48a0c3000  r-x     0x1000  8       1       1452813 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libdl-2.28.so
838     nano    0x7ff48a0c3000  0x7ff48a0c4000  r--     0x2000  8       1       1452813 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libdl-2.28.so
838     nano    0x7ff48a0c4000  0x7ff48a0c5000  r--     0x2000  8       1       1452813 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libdl-2.28.so
838     nano    0x7ff48a0c5000  0x7ff48a0c6000  rw-     0x3000  8       1       1452813 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libdl-2.28.so
838     nano    0x7ff48a0c6000  0x7ff48a0e8000  r--     0x0     8       1       1452729 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libc-2.28.so
838     nano    0x7ff48a0e8000  0x7ff48a22f000  r-x     0x22000 8       1       1452729 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libc-2.28.so
838     nano    0x7ff48a22f000  0x7ff48a27b000  r--     0x169000        8       1       1452729 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libc-2.28.so
838     nano    0x7ff48a27b000  0x7ff48a27c000  ---     0x1b5000        8       1       1452729 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libc-2.28.so
838     nano    0x7ff48a27c000  0x7ff48a280000  r--     0x1b5000        8       1       1452729 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libc-2.28.so
838     nano    0x7ff48a280000  0x7ff48a282000  rw-     0x1b9000        8       1       1452729 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libc-2.28.so
838     nano    0x7ff48a282000  0x7ff48a286000  rw-     0x0     0       0       0       Anonymous Mapping
838     nano    0x7ff48a286000  0x7ff48a294000  r--     0x0     8       1       1442631 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
838     nano    0x7ff48a294000  0x7ff48a2a2000  r-x     0xe000  8       1       1442631 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
838     nano    0x7ff48a2a2000  0x7ff48a2af000  r--     0x1c000 8       1       1442631 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
838     nano    0x7ff48a2af000  0x7ff48a2b3000  r--     0x28000 8       1       1442631 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
838     nano    0x7ff48a2b3000  0x7ff48a2b4000  rw-     0x2c000 8       1       1442631 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libtinfo.so.6.1
838     nano    0x7ff48a2b4000  0x7ff48a2bd000  r--     0x0     8       1       1442642 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
838     nano    0x7ff48a2bd000  0x7ff48a2e3000  r-x     0x9000  8       1       1442642 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
838     nano    0x7ff48a2e3000  0x7ff48a2ec000  r--     0x2f000 8       1       1442642 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
838     nano    0x7ff48a2ec000  0x7ff48a2ed000  r--     0x37000 8       1       1442642 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
838     nano    0x7ff48a2ed000  0x7ff48a2ee000  rw-     0x38000 8       1       1442642 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libncursesw.so.6.1
838     nano    0x7ff48a2ee000  0x7ff48a2f1000  r--     0x0     8       1       1442593 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libz.so.1.2.11
838     nano    0x7ff48a2f1000  0x7ff48a303000  r-x     0x3000  8       1       1442593 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libz.so.1.2.11
838     nano    0x7ff48a303000  0x7ff48a309000  r--     0x15000 8       1       1442593 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libz.so.1.2.11
838     nano    0x7ff48a309000  0x7ff48a30a000  ---     0x1b000 8       1       1442593 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libz.so.1.2.11
838     nano    0x7ff48a30a000  0x7ff48a30b000  r--     0x1b000 8       1       1442593 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libz.so.1.2.11
838     nano    0x7ff48a30b000  0x7ff48a30c000  rw-     0x1c000 8       1       1442593 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/libz.so.1.2.11
838     nano    0x7ff48a30c000  0x7ff48a30e000  rw-     0x0     0       0       0       Anonymous Mapping
838     nano    0x7ff48a320000  0x7ff48a327000  r--     0x0     8       1       1968750 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/gconv/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
838     nano    0x7ff48a327000  0x7ff48a328000  r--     0x0     8       1       1452492 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/ld-2.28.so
838     nano    0x7ff48a328000  0x7ff48a346000  r-x     0x1000  8       1       1452492 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/ld-2.28.so
838     nano    0x7ff48a346000  0x7ff48a34e000  r--     0x1f000 8       1       1452492 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/ld-2.28.so
838     nano    0x7ff48a34e000  0x7ff48a34f000  r--     0x26000 8       1       1452492 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/ld-2.28.so
838     nano    0x7ff48a34f000  0x7ff48a350000  rw-     0x27000 8       1       1452492 /usr/usr/lib/usr/lib/x86_64-linux-gnu/usr/lib/x86_64-linux-gnu/ld-2.28.so
838     nano    0x7ff48a350000  0x7ff48a351000  rw-     0x0     0       0       0       Anonymous Mapping
838     nano    0x7fff0fb47000  0x7fff0fb68000  rw-     0x0     0       0       0       [stack]
838     nano    0x7fff0fbeb000  0x7fff0fbef000  r--     0x0     0       0       0       Anonymous Mapping
838     nano    0x7fff0fbef000  0x7fff0fbf1000  r-x     0x0     0       0       0       [vdso]
```
N.B. This is from the current develop branch which is still affected by the linux paths issue. 