### PR TITLE
Automagic: Update clear-cache and do removals first

### DIFF
--- a/volatility3/framework/__init__.py
+++ b/volatility3/framework/__init__.py
@@ -224,8 +224,4 @@ def list_plugins() -> Dict[str, Type[interfaces.plugins.PluginInterface]]:
 
 
 def clear_cache(complete=False):
-    glob_pattern = "*.cache"
-    if not complete:
-        glob_pattern = "data_" + glob_pattern
-    for cache_filename in glob.glob(os.path.join(constants.CACHE_PATH, glob_pattern)):
-        os.unlink(cache_filename)
+    os.unlink(os.path.join(constants.CACHE_PATH, constants.IDENTIFIERS_FILENAME))


### PR DESCRIPTION
Change around when the missing files are processed and implement a proper clear-cache function for the new database driven cache mechanism. 

This is an effort to close #931, but it's not directly clear what was causing it in the first place.  Testing is required to see if this actually solves the problems and try to identify the exact cause.

Closes: #931 