### PR TITLE
Fix: typo for `linux.iomem` plugin.

### DIFF
--- a/volatility3/framework/plugins/linux/iomem.py
+++ b/volatility3/framework/plugins/linux/iomem.py
@@ -42,7 +42,7 @@ class IOMem(interfaces.plugins.PluginInterface):
         Args:
             context: The context to retrieve required elements (layers, symbol tables) from
             vmlinux_module_name: The name of the kernel module on which to operate
-            resource_offset: The offset to the resouce to be parsed
+            resource_offset: The offset to the resource to be parsed
             seen: The set of resource offsets that have already been parsed
             depth: How deep into the resource structure we are
 
@@ -57,7 +57,7 @@ class IOMem(interfaces.plugins.PluginInterface):
         except exceptions.InvalidAddressException:
             vollog.warning(
                 f"Unable to create resource object at {resource_offset:#x}. This resource, "
-                "its sibling, and any of it's childern and will be missing from the output."
+                "its sibling, and any of it's children and will be missing from the output."
             )
             return None
 


### PR DESCRIPTION
## Descriptions
I found a typo in the error message and comment on `linux.iomem` plugin that we worked on recently and fixed it. :)