### PR TITLE
Linux: Fix repeating path issue in LinuxUtilities

### DIFF
--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -65,7 +65,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         ret_path: List[str] = []
 
         while dentry != rdentry or vfsmnt != rmnt:
-            dname = dentry.path()
+            dname = dentry.d_name.name_as_str()
             if dname == "":
                 break
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -74,11 +74,12 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
                 if vfsmnt.get_mnt_parent() == vfsmnt:
                     break
 
+                if vfsmnt.get_mnt_mountpoint() == dentry:
+                     break
+
                 dentry = vfsmnt.get_mnt_mountpoint()
                 vfsmnt = vfsmnt.get_mnt_parent()
-
                 continue
-
             parent = dentry.d_parent
             dentry = parent
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -75,7 +75,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
                     break
 
                 if vfsmnt.get_mnt_mountpoint() == dentry:
-                     break
+                    break
 
                 dentry = vfsmnt.get_mnt_mountpoint()
                 vfsmnt = vfsmnt.get_mnt_parent()


### PR DESCRIPTION
This would fix issue https://github.com/volatilityfoundation/volatility3/issues/930

This pull request fixes a bug in many Linux plugins where there are incorrect repeating elements in the paths as reported by volatility.

For example `/sbin/sbin/init` being reported where it should be `/sbin/init`. 

This contains the fix suggested by @gcmoreira on this pull request https://github.com/volatilityfoundation/volatility3/pull/786

It also fixes another smaller bug that also results in repeating elements in the paths, but this is much less common. (This is discussed here https://github.com/volatilityfoundation/volatility3/issues/930#issuecomment-1519446869)

This has been tested on memory dumps with the following Linux kernels: Tested on 3.7.10, 3.9.11, 3.10.108, 3.11.10, 3.12.74, 3.13.11, 3.14.79, 3.15.10, 3.16.85, 3.17.8, 3.18.140, 3.19.8, 4.0.9, 4.1.52, 4.2.8, 4.3.6, 4.4.302, 4.5.7, 4.6.7, 4.7.10, 4.8.17, 4.9.337, 4.10.17, 4.11.12, 4.12.14, 4.13.16, 4.14.309, 4.15.18, 4.16.18, 4.17.19, 4.18.20, 4.19.275, 4.20.17, 5.0.21, 5.1.21, 5.2.21, 5.3.18, 5.4.234, 5.5.19, 5.6.19, 5.7.19, 5.8.18, 5.9.16, 5.10.172, 5.11.22, 5.12.19, 5.13.19, 5.14.21, 5.15.98, 5.16.20, 5.17.15, 5.18.19, 5.19.17, 6.0.19, 6.1.15, 6.2.2, 6.2.7, 6.3.0 (can share if interested)

6.1.15, 6.2.2, 6.2.7, 6.3.0 fail on some plugins due to this issue where the mm_struct changed since 6.1 - discussed in this issue https://github.com/volatilityfoundation/volatility3/issues/909

Here is a zip file with the outputs from each of the test images. 