### PR TITLE
Add: help comment for windows plugins (`windows.crashinfo`, `windows.ldrmodules`, `windows.statistics`).

### DIFF
--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -14,6 +14,8 @@ vollog = logging.getLogger(__name__)
 
 
 class Crashinfo(interfaces.plugins.PluginInterface):
+    """Lists the information from a Windows crash dump."""
+
     _required_framework_version = (2, 0, 0)
 
     @classmethod

--- a/volatility3/framework/plugins/windows/ldrmodules.py
+++ b/volatility3/framework/plugins/windows/ldrmodules.py
@@ -7,6 +7,8 @@ from volatility3.plugins.windows import pslist, vadinfo
 
 
 class LdrModules(interfaces.plugins.PluginInterface):
+    """Lists the loaded modules in a particular windows memory image."""
+    
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)
 

--- a/volatility3/framework/plugins/windows/ldrmodules.py
+++ b/volatility3/framework/plugins/windows/ldrmodules.py
@@ -8,7 +8,7 @@ from volatility3.plugins.windows import pslist, vadinfo
 
 class LdrModules(interfaces.plugins.PluginInterface):
     """Lists the loaded modules in a particular windows memory image."""
-    
+
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)
 

--- a/volatility3/plugins/windows/statistics.py
+++ b/volatility3/plugins/windows/statistics.py
@@ -13,7 +13,7 @@ vollog = logging.getLogger(__name__)
 
 
 class Statistics(plugins.PluginInterface):
-    """Lists statistics about the memory space."""""
+    """Lists statistics about the memory space."""
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/plugins/windows/statistics.py
+++ b/volatility3/plugins/windows/statistics.py
@@ -13,6 +13,8 @@ vollog = logging.getLogger(__name__)
 
 
 class Statistics(plugins.PluginInterface):
+    """Lists statistics about the memory space."""""
+
     _required_framework_version = (2, 0, 0)
 
     @classmethod


### PR DESCRIPTION
## Description
Hello :), I looked at this issue (#944) and found out that the current volatility version don't provide a description of some plugins (`windows.crashinfo`, `windows.ldrmodules`, `windows.statistics`).
We confirmed in the previous PR (#735) that the `windows.statistics` plugin is a plugin that we do not officially support.
However, aside from the functionality, I suggest that it would be good to modify this for unity.
So I added missing descriptions to this.
