### PR TITLE
Windows: add `--verbose` option for `ldrmodules` plugin.

### DIFF
--- a/volatility3/framework/plugins/windows/ldrmodules.py
+++ b/volatility3/framework/plugins/windows/ldrmodules.py
@@ -88,9 +88,9 @@ class LdrModules(interfaces.plugins.PluginInterface):
                 init_mod = init_order_mod.get(base, None)
                 mem_mod = mem_order_mod.get(base, None)
                 
-                load = "-"
-                init = "-"
-                mem = "-"
+                load = renderers.NotApplicableValue()
+                init = renderers.NotApplicableValue()
+                mem = renderers.NotApplicableValue()
 
                 try:
                     if load_mod:

--- a/volatility3/framework/plugins/windows/ldrmodules.py
+++ b/volatility3/framework/plugins/windows/ldrmodules.py
@@ -37,7 +37,7 @@ class LdrModules(interfaces.plugins.PluginInterface):
                 description="Print the full paths and base names in verbose mode ",
                 default=False,
                 optional=True,
-            )
+            ),
         ]
 
     def _generator(self, procs):
@@ -87,21 +87,30 @@ class LdrModules(interfaces.plugins.PluginInterface):
                 load_mod = load_order_mod.get(base, None)
                 init_mod = init_order_mod.get(base, None)
                 mem_mod = mem_order_mod.get(base, None)
-                
+
                 load = renderers.NotApplicableValue()
                 init = renderers.NotApplicableValue()
                 mem = renderers.NotApplicableValue()
 
                 try:
                     if load_mod:
-                        load = "{0} : {1}".format(load_mod.FullDllName.get_string(), load_mod.BaseDllName.get_string())
+                        load = "{0} : {1}".format(
+                            load_mod.FullDllName.get_string(),
+                            load_mod.BaseDllName.get_string(),
+                        )
                     if init_mod:
-                        init = "{0} : {1}".format(init_mod.FullDllName.get_string(), init_mod.BaseDllName.get_string())
+                        init = "{0} : {1}".format(
+                            init_mod.FullDllName.get_string(),
+                            init_mod.BaseDllName.get_string(),
+                        )
                     if mem_mod:
-                        mem = "{0} : {1}".format(mem_mod.FullDllName.get_string(), mem_mod.BaseDllName.get_string())
+                        mem = "{0} : {1}".format(
+                            mem_mod.FullDllName.get_string(),
+                            mem_mod.BaseDllName.get_string(),
+                        )
                 except exceptions.InvalidAddressException:
                     continue
-                
+
                 if not self.config.get("verbose", True):
                     yield (
                         0,
@@ -140,7 +149,7 @@ class LdrModules(interfaces.plugins.PluginInterface):
                             mapped_files[base],
                             load,
                             init,
-                            mem
+                            mem,
                         ],
                     )
 
@@ -180,7 +189,7 @@ class LdrModules(interfaces.plugins.PluginInterface):
                     ("MappedPath", str),
                     ("LoadPath", str),
                     ("InitPath", str),
-                    ("MemPath", str)
+                    ("MemPath", str),
                 ],
                 self._generator(
                     pslist.PsList.list_processes(

--- a/volatility3/framework/plugins/windows/ldrmodules.py
+++ b/volatility3/framework/plugins/windows/ldrmodules.py
@@ -34,7 +34,7 @@ class LdrModules(interfaces.plugins.PluginInterface):
             ),
             requirements.BooleanRequirement(
                 name="verbose",
-                description="Print the full paths and base names in verbose mode ",
+                description="Print the full paths and base names in verbose mode",
                 default=False,
                 optional=True,
             ),


### PR DESCRIPTION
## Description
Hello, everyone in the community! :)
This PR comes from this issue (#967).
It will be meaningful to re-implement the original features of [volatility](https://github.com/volatilityfoundation/volatility/blob/a438e768194a9e05eb4d9ee9338b881c0fa25937/volatility/plugins/malware/malfind.py#L523).

## Examples
```shell
> python3 vol.py -f case.vmem windows.ldrmodules --verbose
Volatility 3 Framework 2.4.2
Progress:  100.00		PDB scanning finished
Pid	Process	Base	InLoad	InInit	InMem	MappedPath	LoadPath	InitPath	MemPath

644	services.exe	0x22ea0970000	False	False	False	\Windows\System32\ko-KR\services.exe.mui	N/A	N/A	N/A
644	services.exe	0x7ff6cee90000	True	False	True	\Windows\System32\services.exe	C:\Windows\system32\services.exe : services.exe	N/A	C:\Windows\system32\services.exe : services.exe
660	lsass.exe	0x7ffd48da0000	True	True	True	\Windows\System32\rsaenh.dll	C:\Windows\system32\rsaenh.dll : rsaenh.dll	C:\Windows\system32\rsaenh.dll : rsaenh.dll	C:\Windows\system32\rsaenh.dll : rsaenh.dll
660	lsass.exe	0x7ffd4a610000	True	True	True	\Windows\System32\rpcrt4.dll	C:\Windows\System32\RPCRT4.dll : RPCRT4.dll	C:\Windows\System32\RPCRT4.dll : RPCRT4.dll	C:\Windows\System32\RPCRT4.dll : RPCRT4.dll
760	svchost.exe	0x7ff760700000	True	False	True	\Windows\System32\svchost.exe	C:\Windows\system32\svchost.exe : svchost.exe	N/A	C:\Windows\system32\svchost.exe : svchost.exe
760	svchost.exe	0x7ffd418e0000	True	True	True	\Windows\System32\AppXDeploymentClient.dll	C:\Windows\System32\AppXDeploymentClient.dll : AppXDeploymentClient.dll	C:\Windows\System32\AppXDeploymentClient.dll : AppXDeploymentClient.dll	C:\Windows\System32\AppXDeploymentClient.dll : AppXDeploymentClient.dll
760	svchost.exe	0x7ffd48da0000	True	True	True	\Windows\System32\rsaenh.dll	C:\Windows\system32\rsaenh.dll : rsaenh.dll	C:\Windows\system32\rsaenh.dll : rsaenh.dll	C:\Windows\system32\rsaenh.dll : rsaenh.dll
```