### PR TITLE
Fix file encoding in run_script

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -480,7 +480,7 @@ class Volshell(interfaces.plugins.PluginInterface):
         accessor = resources.ResourceAccessor()
         with accessor.open(url=location) as fp:
             self.__console.runsource(
-                io.TextIOWrapper(fp.read(), encoding="utf-8"), symbol="exec"
+                str(fp.read(), "utf-8"), symbol="exec"
             )
         print("\nCode complete")
 


### PR DESCRIPTION
Addresses problem in https://github.com/volatilityfoundation/volatility3/issues/958.