### PR TITLE
Core: Add type parameter to object_from_symbol

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -4,6 +4,10 @@ API Changes
 When an addition to the existing API is made, the minor version is bumped.
 When an API feature or function is removed or changed, the major version is bumped.
 
+2.5.0
+=====
+Add in support for specifying a type override for object_from_symbol
+
 2.4.0
 =====
 Add a `get_size()` method to Windows VAD structures and fix several off-by-one issues when calculating VAD sizes.

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -44,8 +44,8 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 4  # Number of changes that only add to the interface
-VERSION_PATCH = 2  # Number of changes that do not change the interface
+VERSION_MINOR = 5  # Number of changes that only add to the interface
+VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 # TODO: At version 2.0.0, remove the symbol_shift feature

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -272,9 +272,9 @@ class Module(interfaces.context.ModuleInterface):
         symbol_name: str,
         native_layer_name: Optional[str] = None,
         absolute: bool = False,
-        object_type: Optional[Union[str, interfaces.objects.ObjectInterface]] = None,
+        object_type: Optional[Union[str, "interfaces.objects.ObjectInterface"]] = None,
         **kwargs,
-    ) -> interfaces.objects.ObjectInterface:
+    ) -> "interfaces.objects.ObjectInterface":
         """Returns an object based on a specific symbol (containing type and
         offset information) and the layer_name of the Module.  This will throw
         a ValueError if the symbol does not contain an associated type, or if

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -272,8 +272,9 @@ class Module(interfaces.context.ModuleInterface):
         symbol_name: str,
         native_layer_name: Optional[str] = None,
         absolute: bool = False,
+        object_type: Optional[Union[str, interfaces.objects.ObjectInterface]] = None,
         **kwargs,
-    ) -> "interfaces.objects.ObjectInterface":
+    ) -> interfaces.objects.ObjectInterface:
         """Returns an object based on a specific symbol (containing type and
         offset information) and the layer_name of the Module.  This will throw
         a ValueError if the symbol does not contain an associated type, or if
@@ -284,6 +285,7 @@ class Module(interfaces.context.ModuleInterface):
             symbol_name: Name of the symbol (within the module) to construct
             native_layer_name: Name of the layer in which constructed objects are made (for pointers)
             absolute: whether the symbol's address is absolute or relative to the module
+            object_type: Override for the type from the symobl to use (or if the symbol type is missing)
         """
         if constants.BANG not in symbol_name:
             symbol_name = self.symbol_table_name + constants.BANG + symbol_name
@@ -299,8 +301,13 @@ class Module(interfaces.context.ModuleInterface):
         if not absolute:
             offset += self._offset
 
-        if symbol_val.type is None:
-            raise TypeError(f"Symbol {symbol_val.name} has no associated type")
+        if object_type is None:
+            if symbol_val.type is None:
+                raise TypeError(
+                    f"Symbol {symbol_val.name} has no associated type and no object_type specified"
+                )
+            else:
+                object_type = symbol_val.type
 
         # Ensure we don't use a layer_name other than the module's, why would anyone do that?
         if "layer_name" in kwargs:
@@ -308,7 +315,7 @@ class Module(interfaces.context.ModuleInterface):
 
         # Since type may be a template, we don't just call our own module method
         return self._context.object(
-            object_type=symbol_val.type,
+            object_type=object_type,
             layer_name=self._layer_name,
             offset=offset,
             native_layer_name=native_layer_name or self._native_layer_name,

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -253,7 +253,7 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
         symbol_name: str,
         native_layer_name: Optional[str] = None,
         absolute: bool = False,
-        object_type: Optional[Union[str, interfaces.objects.ObjectInterface]] = None,
+        object_type: Optional[Union[str, "interfaces.objects.ObjectInterface"]] = None,
         **kwargs,
     ) -> "interfaces.objects.ObjectInterface":
         """Returns an object created using the symbol_table_name and layer_name

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -253,6 +253,7 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
         symbol_name: str,
         native_layer_name: Optional[str] = None,
         absolute: bool = False,
+        object_type: Optional[Union[str, interfaces.objects.ObjectInterface]] = None,
         **kwargs,
     ) -> "interfaces.objects.ObjectInterface":
         """Returns an object created using the symbol_table_name and layer_name
@@ -262,6 +263,7 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
             symbol_name: The name of a symbol (that must be present in the module's symbol table).  The symbol's associated type will be used to construct an object at the symbol's offset.
             native_layer_name: The native layer for objects that reference a different layer (if not the default provided during module construction)
             absolute: A boolean specifying whether the offset is absolute within the layer, or relative to the start of the module
+            object_type: Override for the type from the symobl to use (or if the symbol type is missing)
 
         Returns:
             The constructed object


### PR DESCRIPTION
Add in the ability to pass a type name when creating a symbol from an object (since windows symbols don't often have the type information associated with them in the ISF files).