### PR TITLE
Use python-snappy binding instead of ctypes to make it more portable and shorter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ pycryptodome
 
 # This is required for memory acquisition via leechcore/pcileech.
 leechcorepyc>=2.4.0
+
+# Compressed AVML files require snappy
+python-snappy

--- a/volatility3/framework/layers/avml.py
+++ b/volatility3/framework/layers/avml.py
@@ -6,7 +6,7 @@
 
 The user of the file doesn't have to worry about the compression,
 but random access is not allowed."""
-import ctypes
+import snappy
 import logging
 import struct
 from typing import Tuple, List, Optional
@@ -16,49 +16,8 @@ from volatility3.framework.layers import segmented
 
 vollog = logging.getLogger(__name__)
 
-try:
-    # TODO: Find library for windows if needed
-    try:
-        # Linux/Mac
-        lib_snappy = ctypes.cdll.LoadLibrary("libsnappy.so.1")
-    except OSError:
-        lib_snappy = None
-
-    try:
-        if not lib_snappy:
-            # Windows 64
-            lib_snappy = ctypes.cdll.LoadLibrary("snappy64")
-    except OSError:
-        lib_snappy = None
-
-    if lib_snappy:
-        # Windows 32
-        lib_snappy = ctypes.cdll.LoadLibrary("snappy32")
-
-    __snappy_uncompress = lib_snappy.snappy_uncompress
-    __snappy_uncompressed_length = lib_snappy.snappy_uncompressed_length
-
-    HAS_SNAPPY = True
-except (AttributeError, OSError):
-    HAS_SNAPPY = False
-
-
 class SnappyException(exceptions.VolatilityException):
     pass
-
-
-def uncompress(s):
-    """Uncompress a snappy compressed string."""
-    ulen = ctypes.c_int(0)
-    cresult = __snappy_uncompressed_length(s, len(s), ctypes.byref(ulen))
-    if cresult != 0:
-        raise SnappyException(f"Error in snappy_uncompressed_length: {cresult}")
-    ubuf = ctypes.create_string_buffer(ulen.value)
-    cresult = __snappy_uncompress(s, len(s), ubuf, ctypes.byref(ulen))
-    if cresult != 0:
-        raise SnappyException(f"Error in snappy_uncompress: {cresult}")
-    return ubuf.raw
-
 
 class AVMLLayer(segmented.NonLinearlySegmentedLayer):
     """A Lime format TranslationLayer.
@@ -80,14 +39,6 @@ class AVMLLayer(segmented.NonLinearlySegmentedLayer):
         )
         if magic not in [0x4C4D5641] or version != 2:
             raise exceptions.LayerException("File not in AVML format")
-        if not HAS_SNAPPY:
-            vollog.warning(
-                "AVML file detected, but snappy library could not be found\n"
-                "Please install the snappy from your distribution or https://google.github.io/snappy/."
-            )
-            raise exceptions.LayerException(
-                "AVML format dependencies not satisfied (snappy)"
-            )
 
     def _load_segments(self) -> None:
         base_layer = self.context.layers[self._base_layer]
@@ -169,7 +120,7 @@ class AVMLLayer(segmented.NonLinearlySegmentedLayer):
                     ]
                     if frame_type == 0x00:
                         # Compressed data
-                        frame_data = uncompress(frame_data)
+                        frame_data = snappy.uncompress(frame_data)
                     # TODO: Verify CRC
                     segments.append(
                         (
@@ -194,7 +145,7 @@ class AVMLLayer(segmented.NonLinearlySegmentedLayer):
     ) -> bytes:
         start_offset, _, _, _ = self._find_segment(offset)
         if self._compressed[mapped_offset]:
-            decoded_data = uncompress(data)
+            decoded_data = snappy.uncompress(data)
         else:
             decoded_data = data
         decoded_data = decoded_data[offset - start_offset :]


### PR DESCRIPTION
On macOS, the snappy library couldn't be loaded properly when processing a compressed avml file.
It's easier, shorter and more portable to use the python-snappy binding.
It was tested successfully on a compressed AVML file.