### PR TITLE
Check IoC of dirty bit in PTEs from executable VMAs.

### DIFF
--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -110,11 +110,11 @@ class Intel(linear.LinearlyMappedLayer):
     def _page_is_valid(entry: int) -> bool:
         """Returns whether a particular page is valid based on its entry."""
         return bool(entry & 1)
-    
+
     @staticmethod
     def _page_is_dirty(entry: int) -> bool:
         """Returns whether a particular page is dirty based on its entry."""
-        return bool(entry & (1<<6))
+        return bool(entry & (1 << 6))
 
     def canonicalize(self, addr: int) -> int:
         """Canonicalizes an address by performing an appropiate sign extension on the higher addresses"""
@@ -267,7 +267,7 @@ class Intel(linear.LinearlyMappedLayer):
     def is_dirty(self, offset: int) -> bool:
         """Returns whether the page at offset is marked dirty"""
         return self._page_is_dirty(self._translate_entry(offset)[0])
-    
+
     def mapping(
         self, offset: int, length: int, ignore_errors: bool = False
     ) -> Iterable[Tuple[int, int, int, int, str]]:

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -110,6 +110,11 @@ class Intel(linear.LinearlyMappedLayer):
     def _page_is_valid(entry: int) -> bool:
         """Returns whether a particular page is valid based on its entry."""
         return bool(entry & 1)
+    
+    @staticmethod
+    def _page_is_dirty(entry: int) -> bool:
+        """Returns whether a particular page is dirty based on its entry."""
+        return bool(entry & (1<<6))
 
     def canonicalize(self, addr: int) -> int:
         """Canonicalizes an address by performing an appropiate sign extension on the higher addresses"""
@@ -259,6 +264,10 @@ class Intel(linear.LinearlyMappedLayer):
         except exceptions.InvalidAddressException:
             return False
 
+    def is_dirty(self, offset: int) -> bool:
+        """Returns whether the page at offset is marked dirty"""
+        return self._page_is_dirty(self._translate_entry(offset)[0])
+    
     def mapping(
         self, offset: int, length: int, ignore_errors: bool = False
     ) -> Iterable[Tuple[int, int, int, int, str]]:

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -47,7 +47,7 @@ class Malfind(interfaces.plugins.PluginInterface):
         proc_layer = self.context.layers[proc_layer_name]
 
         for vma in task.mm.get_vma_iter():
-            if vma.is_suspicious() and vma.get_name(self.context, task) != "[vdso]":
+            if vma.is_suspicious(proc_layer) and vma.get_name(self.context, task) != "[vdso]":
                 data = proc_layer.read(vma.vm_start, 64, pad=True)
                 yield vma, data
 

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -3,13 +3,15 @@
 #
 
 from typing import List
-
+import logging
 from volatility3.framework import constants, interfaces
 from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.linux import pslist
+
+vollog = logging.getLogger(__name__)
 
 
 class Malfind(interfaces.plugins.PluginInterface):
@@ -47,7 +49,14 @@ class Malfind(interfaces.plugins.PluginInterface):
         proc_layer = self.context.layers[proc_layer_name]
 
         for vma in task.mm.get_vma_iter():
-            if vma.is_suspicious(proc_layer) and vma.get_name(self.context, task) != "[vdso]":
+            vma_name = vma.get_name(self.context, task)
+            vollog.debug(
+                f"Injections : processing PID {task.pid} : VMA {vma_name} : {hex(vma.vm_start)}-{hex(vma.vm_end)}"
+            )
+            if (
+                vma.is_suspicious(proc_layer)
+                and vma.get_name(self.context, task) != "[vdso]"
+            ):
                 data = proc_layer.read(vma.vm_start, 64, pad=True)
                 yield vma, data
 


### PR DESCRIPTION
Currently, the Malfind plugin in volatility3 does not check the dirty bit in PTEs associated with executable VMAs.  When someone modifies running code for example using ptrace (e.g. by writing to /proc/pid/mem), the permissions of the VMA remain r-x (ptrace does not require rwx) and the targeted pages become dirty. This is visible in /proc/pid/smaps where the Private_Dirty of executable VMAs become non zero.

The goal of this patch is to detect such dirty executable pages as it likely means that the target process was debugged at some point or that malicious code was injected.

It could happen that no modification is found when comparing the memory dump of the process with the original executable/libraries.  In that case, it can mean that the malware got uninstalled, i.e. the original code was rewritten on top of the malicious code before the memory dump took place.  Nevertheless, it is still interesting to know that some code got injected at some point in the past.

The downside of this patch is that it makes Malfind slower.