### PR TITLE
Linux: fix bug where get_process_memory_sections fails with 6.1+ kernels

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -203,7 +203,7 @@ class task_struct(generic.GenericIntelProcess):
     ) -> Generator[Tuple[int, int], None, None]:
         """Returns a list of sections based on the memory manager's view of
         this task's virtual memory."""
-        for vma in self.mm.get_mmap_iter():
+        for vma in self.mm.get_vma_iter():
             start = int(vma.vm_start)
             end = int(vma.vm_end)
 


### PR DESCRIPTION
This fixes a bug spotted by alishir on slack. This changes ensures that the `get_process_memory_sections` function in the `task_struct` uses the generic `get_vma_iter` iterator in the `mm_struct` extension - this will then choose either `mmap` or `mm_mt` as needed. 

The `get_vma_iter` function was added in this pull request but this path was missed:  https://github.com/volatilityfoundation/volatility3/pull/928 

Without this plugins that use `get_process_memory_sections` won't work on Linux kernels 6.1+.