### PR TITLE
Windows: Update pslist.py, add friendly option

### DIFF
--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -43,7 +43,7 @@ class FileHandlerInterface(io.RawIOBase):
         return self._preferred_filename
 
     @preferred_filename.setter
-    def preferred_filename(self, filename):
+    def preferred_filename(self, filename: str):
         """Sets the preferred filename"""
         if self.closed:
             raise IOError("FileHandler name cannot be changed once closed")
@@ -56,6 +56,18 @@ class FileHandlerInterface(io.RawIOBase):
     @abstractmethod
     def close(self):
         """Method that commits the file and fixes the final filename for use"""
+
+    @staticmethod
+    def sanitize_filename(filename: str) -> str:
+        """Sanititizes the filename to ensure only a specific whitelist of characters is allowed through"""
+        allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.- ()[]\{\}!$%^:#~?<>,|"
+        result = ""
+        for char in filename:
+            if char in allowed:
+                result += char
+            else:
+                result += "?"
+        return result
 
     def __enter__(self):
         return self

--- a/volatility3/framework/plugins/windows/pslist.py
+++ b/volatility3/framework/plugins/windows/pslist.py
@@ -50,6 +50,12 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 default=False,
                 optional=True,
             ),
+            requirements.BooleanRequirement(
+                name="friendly",
+                description="Display process name in dump filename",
+                default=False,
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -60,6 +66,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         pe_table_name: str,
         proc: interfaces.objects.ObjectInterface,
         open_method: Type[interfaces.plugins.FileHandlerInterface],
+        friendly: bool = False,
     ) -> interfaces.plugins.FileHandlerInterface:
         """Extracts the complete data for a process as a FileHandlerInterface
 
@@ -90,9 +97,20 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 offset=peb.ImageBaseAddress,
                 layer_name=proc_layer_name,
             )
-            file_handle = open_method(
-                f"pid.{proc.UniqueProcessId}.{peb.ImageBaseAddress:#x}.dmp"
+
+            process_name = proc.ImageFileName.cast(
+                "string",
+                max_length=proc.ImageFileName.vol.count,
+                errors="replace",
             )
+            if friendly:
+                file_handle = open_method(
+                    f"{proc.UniqueProcessId}.{process_name}.{peb.ImageBaseAddress:#x}.dmp"
+                )
+            else:
+                file_handle = open_method(
+                    f"pid.{proc.UniqueProcessId}.{peb.ImageBaseAddress:#x}.dmp"
+                )
             for offset, data in dos_header.reconstruct():
                 file_handle.seek(offset)
                 file_handle.write(data)
@@ -243,6 +261,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                         pe_table_name,
                         proc,
                         self.open,
+                        self.config["friendly"],
                     )
                     file_output = "Error outputting file"
                     if file_handle:


### PR DESCRIPTION
Hey :) Addition of --friendly option to windows.pslist. It will work the same without the --friendly option. Here's an example when you run it:
```
volatility3 % python3 vol.py -f ../dumps/memory-images/xp-laptop-2005-07-04-1430.img windows.pslist --dump --friendly
Volatility 3 Framework 2.5.0
Progress:  100.00		PDB scanning finished
PID	PPID	ImageFileName	Offset(V)	Threads	Handles	SessionId	Wow64	CreateTime	ExitTime	File output

4	0	System	0x823c87c0	62	1133	N/A	False	N/A	N/A	Error outputting file
400	4	smss.exe	0x8214b020	3	21	N/A	False	2005-07-04 18:17:26.000000 	N/A	400.smss.exe.0x48580000.dmp
456	400	csrss.exe	0x821c11a8	11	551	0	False	2005-07-04 18:17:29.000000 	N/A	456.csrss.exe.0x4a680000.dmp
480	400	winlogon.exe	0x814dc020	18	522	0	False	2005-07-04 18:17:29.000000 	N/A	480.winlogon.exe.0x1000000.dmp
524	480	services.exe	0x815221c8	17	321	0	False	2005-07-04 18:17:30.000000 	N/A	524.services.exe.0x1000000.dmp
536	480	lsass.exe	0x821d8248	20	369	0	False	2005-07-04 18:17:30.000000 	N/A	536.lsass.exe.0x1000000.dmp
680	524	svchost.exe	0x814f0020	19	206	0	False	2005-07-04 18:17:31.000000 	N/A	680.svchost.exe.0x1000000.dmp
760	524	svchost.exe	0x821daa88	10	289	0	False	2005-07-04 18:17:31.000000 	N/A	760.svchost.exe.0x1000000.dmp
800	524	svchost.exe	0x821463a8	75	1558	0	False	2005-07-04 18:17:31.000000 	N/A	800.svchost.exe.0x1000000.dmp
840	524	Smc.exe	0x8216c9b0	22	421	0	False	2005-07-04 18:17:32.000000 	N/A	840.Smc.exe.0x400000.dmp
932	524	svchost.exe	0x81530228	6	93	0	False	2005-07-04 18:17:33.000000 	N/A	932.svchost.exe.0x1000000.dmp
972	524	svchost.exe	0x81534c10	15	212	0	False	2005-07-04 18:17:34.000000 	N/A	972.svchost.exe.0x1000000.dmp
1104	524	spoolsv.exe	0x8202e7e8	11	145	0	False	2005-07-04 18:17:38.000000 	N/A	1104.spoolsv.exe.0x1000000.dmp
1272	524	ati2evxx.exe	0x8152f9a0	4	38	0	False	2005-07-04 18:17:39.000000 	N/A	1272.ati2evxx.exe.0x400000.dmp
1356	524	Crypserv.exe	0x820ac020	3	34	0	False	2005-07-04 18:17:40.000000 	N/A	1356.Crypserv.exe.0x400000.dmp
1380	524	DefWatch.exe	0x81521da0	3	27	0	False	2005-07-04 18:17:40.000000 	N/A	1380.DefWatch.exe.0x400000.dmp
1440	524	msdtc.exe	0x820b5670	15	164	0	False	2005-07-04 18:17:40.000000 	N/A	1440.msdtc.exe.0x400000.dmp
1484	524	Rtvscan.exe	0x81fcf460	37	312	0	False	2005-07-04 18:17:40.000000 	N/A	1484.Rtvscan.exe.0x400000.dmp
1548	524	tcpsvcs.exe	0x8204b8e0	2	105	0	False	2005-07-04 18:17:41.000000 	N/A	1548.tcpsvcs.exe.0x1000000.dmp
1564	524	snmp.exe	0x82027a78	5	192	0	False	2005-07-04 18:17:41.000000 	N/A	1564.snmp.exe.0x1000000.dmp
1588	524	svchost.exe	0x8204c558	5	122	0	False	2005-07-04 18:17:41.000000 	N/A	1588.svchost.exe.0x1000000.dmp
1640	524	wdfmgr.exe	0x8202f558	4	65	0	False	2005-07-04 18:17:42.000000 	N/A	1640.wdfmgr.exe.0x1000000.dmp
1844	524	Fast.exe	0x81fb5da0	2	33	0	False	2005-07-04 18:17:43.000000 	N/A	1844.Fast.exe.0x1000000.dmp
1860	524	mqsvc.exe	0x81fe9da0	23	218	0	False	2005-07-04 18:17:43.000000 	N/A	1860.mqsvc.exe.0x1000000.dmp
712	524	mqtgsvc.exe	0x82022760	9	119	0	False	2005-07-04 18:17:47.000000 	N/A	712.mqtgsvc.exe.0x1000000.dmp
992	524	alg.exe	0x81fe6a78	5	105	0	False	2005-07-04 18:17:50.000000 	N/A	992.alg.exe.0x1000000.dmp
2196	2172	ssonsvr.exe	0x8202c6a0	1	24	0	False	2005-07-04 18:17:59.000000 	N/A	2196.ssonsvr.exe.0x400000.dmp
2392	2300	explorer.exe	0x8146e860	18	489	0	False	2005-07-04 18:18:03.000000 	N/A	2392.explorer.exe.0x1000000.dmp
2456	2392	Directcd.exe	0x820d1b00	4	40	0	False	2005-07-04 18:18:05.000000 	N/A	2456.Directcd.exe.0x400000.dmp
2472	2392	TaskSwitch.exe	0x81540da0	1	24	0	False	2005-07-04 18:18:05.000000 	N/A	2472.TaskSwitch.exe.0x1000000.dmp
2480	2392	Fast.exe	0x8219dda0	1	23	0	False	2005-07-04 18:18:05.000000 	N/A	2480.Fast.exe.0x1000000.dmp
2496	2392	VPTray.exe	0x81462be0	2	111	0	False	2005-07-04 18:18:06.000000 	N/A	2496.VPTray.exe.0x400000.dmp
2524	2392	atiptaxx.exe	0x8219d960	1	51	0	False	2005-07-04 18:18:06.000000 	N/A	2524.atiptaxx.exe.0x400000.dmp
2548	2392	jusched.exe	0x814ecc00	1	22	0	False	2005-07-04 18:18:07.000000 	N/A	2548.jusched.exe.0x400000.dmp
2588	2540	EM_EXEC.EXE	0x820d1718	2	80	0	False	2005-07-04 18:18:09.000000 	N/A	2588.EM_EXEC.EXE.0x400000.dmp
2692	2392	WZQKPICK.EXE	0x814b8a58	1	17	0	False	2005-07-04 18:18:15.000000 	N/A	2692.WZQKPICK.EXE.0x400000.dmp
3128	800	wuauclt.exe	0x81474510	3	157	0	False	2005-07-04 18:19:11.000000 	N/A	3128.wuauclt.exe.0x400000.dmp
3192	2392	taskmgr.exe	0x81f7fb98	3	65	0	False	2005-07-04 18:19:33.000000 	N/A	3192.taskmgr.exe.0x1000000.dmp
3256	2392	cmd.exe	0x8153f480	1	29	0	False	2005-07-04 18:20:58.000000 	N/A	3256.cmd.exe.0x4ad00000.dmp
3276	2392	firefox.exe	0x8133d810	7	189	0	False	2005-07-04 18:21:11.000000 	N/A	3276.firefox.exe.0x400000.dmp
3352	680	PluckSvr.exe	0xff96b860	6	206	0	False	2005-07-04 18:21:42.000000 	N/A	3352.PluckSvr.exe.0x400000.dmp
3612	3352	PluckTray.exe	0x813383b0	3	102	0	False	2005-07-04 18:24:00.000000 	N/A	3612.PluckTray.exe.0x400000.dmp
368	3352	PluckUpdater.ex	0x81488350	0	-	0	False	2005-07-04 18:24:30.000000 	2005-07-04 18:26:44.000000 	Error outputting file
3300	3256	dd.exe	0x81543870	1	22	0	False	2005-07-04 18:30:32.000000 	N/A	3300.dd.exe.0x400000.dmp
```
This is my first request really interested in your feedback, do you think --friendly is the best name for this? And is the format ok?