### PR TITLE
Making cred optional as it didn't exist in old 2.6 kernels

### DIFF
--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -28,7 +28,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("fs_struct", extensions.fs_struct)
         self.set_type_class("files_struct", extensions.files_struct)
         self.set_type_class("kobject", extensions.kobject)
-        self.set_type_class("cred", extensions.cred)
+        self.optional_set_type_class("cred", extensions.cred)
         self.set_type_class("kernel_cap_struct", extensions.kernel_cap_struct)
         # Might not exist in the current symbols
         self.optional_set_type_class("module", extensions.module)


### PR DESCRIPTION
When running volatility3 on an old system with a 2.6 kernel, I get this error message:

`ValueError: Symbol type not in LintelStacker1 SymbolTable: cred`

This patch is to make `cred` optional, which allows volatility to run fine on that old kernel.