### PR TITLE
Adding test install workflow for GitHub Actions pipelines

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ ubuntu-latest, macOS-latest, windows-latest ]
+        host: [ ubuntu-latest, windows-latest ]
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,29 @@
+name: Test install Volatility3
+on: [push, pull_request]
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Setup python-pip
+      run: python -m pip install --upgrade pip
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    - name: Install volatility3
+      run: pip install .
+
+    - name: Run volatility3
+      run: vol --help

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,19 +1,14 @@
-name: Test install Volatility3
+name: Install Volatility3 test
 on: [push, pull_request]
 jobs:
 
-  build:
+  install:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.7"]
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Setup python-pip
       run: python -m pip install --upgrade pip

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,13 +2,20 @@ name: Install Volatility3 test
 on: [push, pull_request]
 jobs:
 
-  install:
-    runs-on: ubuntu-latest
+  install_test:
+    runs-on: ${{ matrix.host }}
+    strategy:
+      matrix:
+        fail-fast: false
+        host: [ ubuntu-latest, macOS-latest, windows-latest ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Setup python-pip
       run: python -m pip install --upgrade pip

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -5,8 +5,8 @@ jobs:
   install_test:
     runs-on: ${{ matrix.host }}
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         host: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     steps:


### PR DESCRIPTION
Added a workflow that makes sure volatility installs and runs as intended for all push and pull request triggers.
Will help avoid issues like https://github.com/volatilityfoundation/volatility3/issues/1002 in the future