### PR TITLE
Linux: Add error handling to elf extension magic bytes check

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/elf.py
+++ b/volatility3/framework/symbols/linux/extensions/elf.py
@@ -49,15 +49,11 @@ class elf(objects.StructType):
             vollog.debug(
                 f"Unable to check magic bytes for ELF file at offset {hex(object_info.offset)} in layer {layer_name}: {excp}"
             )
-            self._valid_magic = False
             return None
 
         # Check validity
         if magic != 0x464C457F:  # e.g. ELF
-            self._valid_magic = False
             return None
-        else:
-            self._valid_magic = True
 
         # We need to read the EI_CLASS (0x4 offset)
         ei_class = self._context.object(
@@ -88,7 +84,7 @@ class elf(objects.StructType):
         """
         Determine whether it is a valid object
         """
-        if self._valid_magic:
+        if hasattr(self, "_type_prefix") and hasattr(self, "_hdr"):
             return self._type_prefix is not None and self._hdr is not None
         else:
             return False


### PR DESCRIPTION
Hello

This PR adds some error handling to the Linux ELF extension when it checks for the ELF magic bytes. 

It was @garanews  that spotted the issue https://github.com/volatilityfoundation/volatility3/issues/1009. It causes `linux.pslist` to crash as soon as it hits the first process where the magic bytes are not available.

This doesn't happen with the `linux.elfs` plugin as it has its own protection here: https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/plugins/linux/elfs.py#L141-L149

I originally used a padded read in the extension, but thought that a try/expect was better? I could also add the protections to the `linux.pslist` plugin instead, but I thought that having them in the extension was better?

The original behavior of the extension is to return None and not check any other parts of the ELF if the magic bytes are wrong or unavailable. I've not changed that here, do you think it would be a good idea to allow the option to override this if needed? Likely better left to a different PR. 

Thanks!