### PR TITLE
Layer debug info to show file size

### DIFF
--- a/volatility3/framework/automagic/stacker.py
+++ b/volatility3/framework/automagic/stacker.py
@@ -156,6 +156,9 @@ class LayerStacker(interfaces.automagic.AutomagicInterface):
                 self._cached = context.config.get(path, None), context.config.branch(
                     path
                 )
+        vollog.debug(
+            f"physical_layer maximum_address: {physical_layer.maximum_address}"
+        )
         vollog.debug(f"Stacked layers: {stacked_layers}")
 
     @classmethod


### PR DESCRIPTION
Hello!

This adds an extra line to debug logs when the stacker shows the layers it has managed to stack. 

It simply shows the file size of the file in the debug log. I've found that knowing the file size of the file has been very helpful when debugging issues where plugins aren't working as expected, or the stacker fails. For example when the stacker says it was only able to stack a FileLayer for a memory dump of a VM with 8GB, but the file is only 1GB in size it's obvious that either the sample is wrong or it is compressed in some way. 

I was worried this might slow things down, particularly when dealing with very large files, but in my tests that didn't seem to be true. I think that `maximum_address` has already been set as it's needed by some of the scanners. However I'm very happy to be shown that I'm wrong about that! 

Thanks!