### PR TITLE
Linux basic support for scanned tasks

### DIFF
--- a/volatility3/framework/symbols/generic/__init__.py
+++ b/volatility3/framework/symbols/generic/__init__.py
@@ -39,7 +39,7 @@ class GenericIntelProcess(objects.StructType):
                 preferred_name = context.layers.free_layer_name(prefix=preferred_name)
 
         # Copy the parent's config and then make suitable changes
-        parent_layer = context.layers[self.vol.layer_name]
+        parent_layer = context.layers[self.vol.native_layer_name]
         parent_config = parent_layer.build_configuration()
         # It's an intel layer, because we hardwire the "memory_layer" config option
         # FIXME: this could be for other architectures if we don't hardwire this/these values

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -179,7 +179,7 @@ class task_struct(generic.GenericIntelProcess):
         Returns the name of the Layer or None.
         """
 
-        parent_layer = self._context.layers[self.vol.layer_name]
+        parent_layer = self._context.layers[self.vol.native_layer_name]
         try:
             pgd = self.mm.pgd
         except exceptions.InvalidAddressException:


### PR DESCRIPTION
Hello!

This PR adds some basic support for tasks found via scanning to some of the existing linux plugins. I've not done them all as I wanted views on this first. Is this a good way to do it? Would it be better to allow users to provide a physical address to the plugins rather than using the linux.psscan plugn?

It would help work towards [924](https://github.com/volatilityfoundation/volatility3/issues/924).

I've added them in slightly different ways to the existing plugins, perhaps one method is the best, or perhaps it doesn't really matter.

Here is an example of what this would allow, using the `linux-sample-5` file, (sha1: d1edf3635f2726033a81fab12364e03a111bba74).

First see that pid 2282 is not found with the normal pslist plugin:
```
python vol.py -f linux-sample-5.dmp linux.pslist --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
OFFSET (V)      PID     TID     PPID    COMM    File output

```

Therefore can't be used in lsof etc, as this pid isn't found
```
python vol.py -f linux-sample-5.dmp linux.lsof --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
PID     Process FD      Path

<no results>

python vol.py -f linux-sample-5.dmp linux.elfs --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
PID     Process Start   End     File Path       File Output

<no results>

python vol.py -f linux-sample-5.dmp linux.psaux --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
PID     PPID    COMM    ARGS

<no results>
```

However it is found with psscan:
```
$ python vol.py -f linux-sample-5.dmp linux.psscan --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
OFFSET (P)      PID     TID     PPID    COMM    EXIT_STATE

0x1d24c7c0      2262    2282    2257    apache2 TASK_RUNNING
```

So by passing the --scan option to the plugins that have been modified, lsof, psaux, and elfs mean that the results for this task are displayed:

lsof:
```
python vol.py -f linux-sample-5.dmp linux.lsof --scan --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
PID     Process FD      Path

2282    apache2 0       /dev/null
2282    apache2 1       /dev/null
2282    apache2 2       /var/log/apache2/error.log
2282    apache2 3       socket:[6225]
2282    apache2 4       socket:[6226]
2282    apache2 5       pipe:[6237]
2282    apache2 6       pipe:[6237]
2282    apache2 7       /var/log/apache2/other_vhosts_access.log
2282    apache2 8       /var/log/apache2/access.log
2282    apache2 10      anon_inode:[1518]
```

psaux:
```
python vol.py -f linux-sample-5.dmp linux.psaux --scan --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
PID     PPID    COMM    ARGS

2282    2257    apache2 /usr/sbin/apache2 -k start
```

elfs:
```
python vol.py -f linux-sample-5.dmp linux.elfs --scan --pid 2282
Volatility 3 Framework 2.5.1
Progress:  100.00               Stacking attempts finished
PID     Process Start   End     File Path       File Output

2282    apache2 0x7fd330a17000  0x7fd330a2c000  /lib/x86_64-linux-gnu/libgcc_s.so.1     Disabled
2282    apache2 0x7fd33e45a000  0x7fd33e465000  /lib/x86_64-linux-gnu/libnss_files-2.13.so      Disabled
2282    apache2 0x7fd33e666000  0x7fd33e670000  /lib/x86_64-linux-gnu/libnss_nis-2.13.so        Disabled
2282    apache2 0x7fd33e871000  0x7fd33e886000  /lib/x86_64-linux-gnu/libnsl-2.13.so    Disabled
2282    apache2 0x7fd33ea89000  0x7fd33ea90000  /lib/x86_64-linux-gnu/libnss_compat-2.13.so     Disabled
2282    apache2 0x7fd33ec91000  0x7fd33ec95000  /usr/lib/apache2/modules/mod_status.so  Disabled
2282    apache2 0x7fd33ee97000  0x7fd33ee9a000  /usr/lib/apache2/modules/mod_setenvif.so        Disabled
2282    apache2 0x7fd33f09b000  0x7fd33f09e000  /usr/lib/apache2/modules/mod_reqtimeout.so      Disabled
2282    apache2 0x7fd33f29f000  0x7fd33f2a7000  /usr/lib/apache2/modules/mod_negotiation.so     Disabled
<SNIP>
```