### PR TITLE
Fix mac pslist

### DIFF
--- a/volatility3/framework/plugins/mac/pslist.py
+++ b/volatility3/framework/plugins/mac/pslist.py
@@ -188,7 +188,7 @@ class PsList(interfaces.plugins.PluginInterface):
 
         kernel_layer = context.layers[kernel.layer_name]
 
-        queue_entry = kernel.object_from_symbol(symbol_name="tasks")
+        queue_entry = kernel.object("queue_entry", kernel.get_symbol("tasks").address)
 
         seen: Dict[int, int] = {}
         for task in queue_entry.walk_list(queue_entry, "tasks", "task"):

--- a/volatility3/framework/plugins/mac/pslist.py
+++ b/volatility3/framework/plugins/mac/pslist.py
@@ -49,9 +49,7 @@ class PsList(interfaces.plugins.PluginInterface):
         ]
 
     @classmethod
-    def get_list_tasks(
-        cls, method: str
-    ) -> Callable[
+    def get_list_tasks(cls, method: str) -> Callable[
         [interfaces.context.ContextInterface, str, Callable[[int], bool]],
         Iterable[interfaces.objects.ObjectInterface],
     ]:
@@ -188,9 +186,7 @@ class PsList(interfaces.plugins.PluginInterface):
 
         kernel_layer = context.layers[kernel.layer_name]
 
-        queue_entry = kernel.object(
-            object_type="queue_entry", offset=kernel.get_symbol("tasks").address
-        )
+        queue_entry = kernel.object_from_symbol(symbol_name="tasks")
 
         seen: Dict[int, int] = {}
         for task in queue_entry.walk_list(queue_entry, "tasks", "task"):

--- a/volatility3/framework/plugins/mac/pslist.py
+++ b/volatility3/framework/plugins/mac/pslist.py
@@ -188,7 +188,9 @@ class PsList(interfaces.plugins.PluginInterface):
 
         kernel_layer = context.layers[kernel.layer_name]
 
-        queue_entry = kernel.object(object_type="queue_entry", offset=kernel.get_symbol("tasks").address)
+        queue_entry = kernel.object(
+            object_type="queue_entry", offset=kernel.get_symbol("tasks").address
+        )
 
         seen: Dict[int, int] = {}
         for task in queue_entry.walk_list(queue_entry, "tasks", "task"):

--- a/volatility3/framework/plugins/mac/pslist.py
+++ b/volatility3/framework/plugins/mac/pslist.py
@@ -188,7 +188,7 @@ class PsList(interfaces.plugins.PluginInterface):
 
         kernel_layer = context.layers[kernel.layer_name]
 
-        queue_entry = kernel.object("queue_entry", kernel.get_symbol("tasks").address)
+        queue_entry = kernel.object(object_type="queue_entry", offset=kernel.get_symbol("tasks").address)
 
         seen: Dict[int, int] = {}
         for task in queue_entry.walk_list(queue_entry, "tasks", "task"):

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -21,12 +21,14 @@ class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("vm_map_object", extensions.vm_map_object)
         self.set_type_class("socket", extensions.socket)
         self.set_type_class("inpcb", extensions.inpcb)
-        self.set_type_class("queue_entry", extensions.queue_entry)
         self.set_type_class("ifnet", extensions.ifnet)
         self.set_type_class("sockaddr_dl", extensions.sockaddr_dl)
         self.set_type_class("sockaddr", extensions.sockaddr)
         self.set_type_class("sysctl_oid", extensions.sysctl_oid)
         self.set_type_class("kauth_scope", extensions.kauth_scope)
+        # https://developer.apple.com/documentation/kernel/queue_head_t
+        self.set_type_class("queue_entry", extensions.queue_entry)
+        self.set_type_class("queue_head_t", extensions.queue_entry)
 
 
 class MacUtilities(interfaces.configuration.VersionableInterface):

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -28,7 +28,7 @@ class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("kauth_scope", extensions.kauth_scope)
         # https://developer.apple.com/documentation/kernel/queue_head_t
         self.set_type_class("queue_entry", extensions.queue_entry)
-        self.set_type_class("queue_head_t", extensions.queue_entry)
+        self.optional_set_type_class("queue_head_t", extensions.queue_entry)
 
 
 class MacUtilities(interfaces.configuration.VersionableInterface):

--- a/volatility3/framework/symbols/mac/extensions/__init__.py
+++ b/volatility3/framework/symbols/mac/extensions/__init__.py
@@ -490,22 +490,24 @@ class queue_entry(objects.StructType):
 
         for attr in ["next", "prev"]:
             with contextlib.suppress(exceptions.InvalidAddressException):
-                n = getattr(self, attr).dereference().cast(type_name)
-
-                while n is not None and n.vol.offset != list_head:
-                    if n.vol.offset in seen:
+                queue_element = getattr(self, attr).dereference().cast(type_name)
+                while (
+                    queue_element is not None
+                    and queue_element.vol.offset != list_head.vol.offset
+                ):
+                    if queue_element.vol.offset in seen:
                         break
 
-                    yield n
+                    yield queue_element
 
-                    seen.add(n.vol.offset)
+                    seen.add(queue_element.vol.offset)
 
                     yielded = yielded + 1
                     if yielded == max_size:
-                        return
+                        return None
 
-                    n = (
-                        getattr(n.member(attr=member_name), attr)
+                    queue_element = (
+                        getattr(queue_element.member(attr=member_name), attr)
                         .dereference()
                         .cast(type_name)
                     )


### PR DESCRIPTION
- Volatility3 version used : 2.5.1
- Memory dump : Mac OS 10.8.5_build-12F45

Executing `mac.pslist` or any plugin needing it results in : 

```sh
$ vol3 [...] mac.pslist
Volatility 3 Framework 2.5.1	Stacking attempts finished                  

PID	Process	Argc	Arguments
Traceback (most recent call last):
  File "/volatility3/vol.py", line 10, in <module>
    volatility3.cli.main()
  File "/volatility3/volatility3/cli/__init__.py", line 790, in main
    CommandLine().run()
  File "/volatility3/volatility3/cli/__init__.py", line 447, in run
    renderers[args.renderer]().render(constructed.run())
  File "/volatility3/volatility3/cli/text_renderer.py", line 193, in render
    grid.populate(visitor, outfd)
  File "/volatility3/volatility3/framework/renderers/__init__.py", line 241, in populate
    for level, item in self._generator:
  File "/volatility3/volatility3/framework/plugins/mac/psaux.py", line 41, in _generator
    for task in tasks:
  File "/volatility3/volatility3/framework/plugins/mac/pslist.py", line 194, in list_tasks_tasks
    for task in queue_entry.walk_list(queue_entry, "tasks", "task"):
  File "/volatility3/volatility3/framework/objects/__init__.py", line 968, in __getattr__
    raise AttributeError(
AttributeError: ClassType has no attribute: symbol_table_name1!queue_head_t.walk_list
```

Here is the symbol from the ISF file : 

```json 
"tasks": {
    "type": {
    "kind": "struct",
    "name": "queue_entry"
    },
    "offset": 40
}
```


After investigating the code, I found out that instantiating `queue_entry` to "queue_entry" type manually gave it the property "walk_list" : 

```diff
diff --git a/volatility3/framework/plugins/mac/pslist.py b/volatility3/framework/plugins/mac/pslist.py
index 88045a27..c0e149fc 100644
--- a/volatility3/framework/plugins/mac/pslist.py
+++ b/volatility3/framework/plugins/mac/pslist.py
@@ -188,7 +188,7 @@ class PsList(interfaces.plugins.PluginInterface):
 
         kernel_layer = context.layers[kernel.layer_name]
 
-        queue_entry = kernel.object_from_symbol(symbol_name="tasks")
+        queue_entry = kernel.object("queue_entry", kernel.get_symbol("tasks").address)
 
         seen: Dict[int, int] = {}
         for task in queue_entry.walk_list(queue_entry, "tasks", "task"):
```

Patch is based on Volatility2 implementation of mac_pslist plugin : 

```python
# https://github.com/volatilityfoundation/volatility/blob/master/volatility/plugins/mac/pstasks.py#L35
def allprocs(self):
    common.set_plugin_members(self)
    tasksaddr = self.addr_space.profile.get_symbol("_tasks")
    queue_entry = obj.Object("queue_entry", offset = tasksaddr, vm = self.addr_space)
    seen = { tasksaddr : 1 }
    for task in queue_entry.walk_list(list_head = tasksaddr):
        # [...]
```

Fix seems retrocompatible to me, and should not break the existing implementation.