### PR TITLE
vmware: Add warning when no metadata file is found for a vmem file.

### DIFF
--- a/volatility3/framework/layers/vmware.py
+++ b/volatility3/framework/layers/vmware.py
@@ -232,6 +232,9 @@ class VmwareStacker(interfaces.automagic.StackerLayerInterface):
             )
 
             if not vmss_success and not vmsn_success:
+                vollog.warning(
+                    f"No metadata file alongside VMEM file! A VMSS or VMSN file is required to correctly process a VMEM file. These should be placed in the same directory with the same file name, e.g. sample.vmem and sample.vmsn.",
+                )
                 return None
             new_layer_name = context.layers.free_layer_name("VmwareLayer")
             context.config[

--- a/volatility3/framework/layers/vmware.py
+++ b/volatility3/framework/layers/vmware.py
@@ -4,6 +4,7 @@
 import contextlib
 import logging
 import struct
+import os
 from typing import Any, Dict, List, Optional
 
 from volatility3.framework import constants, exceptions, interfaces
@@ -232,8 +233,10 @@ class VmwareStacker(interfaces.automagic.StackerLayerInterface):
             )
 
             if not vmss_success and not vmsn_success:
+                vmem_file_basename = os.path.basename(location)
+                example_vmss_file_basename = os.path.basename(vmss)
                 vollog.warning(
-                    f"No metadata file alongside VMEM file! A VMSS or VMSN file is required to correctly process a VMEM file. These should be placed in the same directory with the same file name, e.g. sample.vmem and sample.vmsn.",
+                    f"No metadata file found alongside VMEM file. A VMSS or VMSN file may be required to correctly process a VMEM file. These should be placed in the same directory with the same file name, e.g. {vmem_file_basename} and {example_vmss_file_basename}.",
                 )
                 return None
             new_layer_name = context.layers.free_layer_name("VmwareLayer")


### PR DESCRIPTION
Hello,

Richard Davis of 13cubed (@13cubed) posted a video on YouTube showing how to process a vmem file the metadata files are also needed. Highlighting how it isn't very obvious. Not just for vol, but other tools as well. The verbose logs do show this, however you'd have to know what you are looking for. I've seen a few instances of this problem affecting people in the slack community. 

This PR simply adds a warning when vol is unable to find the metadata files, which might mean less people struggle with this as a warning is shown:

```
$ python vol.py -f linux-sample-1.vmem linux.pslist
Volatility 3 Framework 2.5.2
WARNING  volatility3.framework.layers.vmware: No metadata file alongside VMEM file! A VMSS or VMSN file is required to correctly process a VMEM file. These should be placed in the same directory with the same file name, e.g. sample.vmem and sample.vmsn.
```

Here is the video: https://www.youtube.com/watch?v=P0yw93GJsYU

Thanks!