### PR TITLE
issue #1017 - check for valid root node type

### DIFF
--- a/volatility3/framework/layers/registry.py
+++ b/volatility3/framework/layers/registry.py
@@ -174,7 +174,10 @@ class RegistryHive(linear.LinearlyMappedLayer):
         root_node = self.get_node(self.root_cell_offset)
         if not root_node.vol.type_name.endswith(constants.BANG + "_CM_KEY_NODE"):
             raise RegistryFormatException(
-                self.name, "Encountered {} instead of _CM_KEY_NODE".format(root_node.vol.type_name)
+                self.name,
+                "Encountered {} instead of _CM_KEY_NODE".format(
+                    root_node.vol.type_name
+                ),
             )
         node_key = [root_node]
         if key.endswith("\\"):

--- a/volatility3/framework/layers/registry.py
+++ b/volatility3/framework/layers/registry.py
@@ -171,7 +171,12 @@ class RegistryHive(linear.LinearlyMappedLayer):
         node (default) or a list of nodes from root to the current node
         (if return_list is true).
         """
-        node_key = [self.get_node(self.root_cell_offset)]
+        root_node = self.get_node(self.root_cell_offset)
+        if not root_node.vol.type_name.endswith(constants.BANG + "_CM_KEY_NODE"):
+            raise RegistryFormatException(
+                self.name, "Encountered {} instead of _CM_KEY_NODE".format(root_node.vol.type_name)
+            )
+        node_key = [root_node]
         if key.endswith("\\"):
             key = key[:-1]
         key_array = key.split("\\")


### PR DESCRIPTION
The root node should be of type _CM_KEY_NODE, if it's not, don't try to continue processing the key.