### PR TITLE
Core: Add (optional) sanitization to the FileHandler class

### DIFF
--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -43,7 +43,7 @@ class FileHandlerInterface(io.RawIOBase):
         return self._preferred_filename
 
     @preferred_filename.setter
-    def preferred_filename(self, filename):
+    def preferred_filename(self, filename: str):
         """Sets the preferred filename"""
         if self.closed:
             raise IOError("FileHandler name cannot be changed once closed")
@@ -56,6 +56,18 @@ class FileHandlerInterface(io.RawIOBase):
     @abstractmethod
     def close(self):
         """Method that commits the file and fixes the final filename for use"""
+
+    @staticmethod
+    def sanitize_filename(filename: str) -> str:
+        """Sanititizes the filename to ensure only a specific whitelist of characters is allowed through"""
+        allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.- ()[]\{\}!$%^:#~?<>,|"
+        result = ""
+        for char in filename:
+            if char in allowed:
+                result += char
+            else:
+                result += "?"
+        return result
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This is a first cut at ensuring filename writes are safe.  This completely excludes unicode filenames, which will not be useful for a large chunk of forensics, which is why it's being made optional to each plugin before we move forward with it.  Whitelists are much more effective than blacklists, but I'm not certain how to allow unicode characters without potentially tripping over something a filesystem handles poorly, so for now its an explicit latin-1 whitelist.