### PR TITLE
Linux: update maple tree extension to fix issue #1032

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -314,8 +314,13 @@ class maple_tree(objects.StructType):
     ):
         """Recursively parse Maple Tree Nodes and yield all non empty slots"""
 
-        # create seen set if it does not exist, e.g. on the first call into
-        # this recursive function.
+        # Create seen set if it does not exist, e.g. on the first call into this recursive function. This
+        # must be None or an existing set of addresses for MTEs that have already been processed or that
+        # should otherwise be ignored. If parsing from the root node for example this should be None on the
+        # first call. If you needed to parse all nodes downwards from part of the tree this should still be
+        # None. If however you wanted to parse from a node, but ignore some parts of the tree below it then
+        # this could be populated with the addresses of the nodes you wish to ignore.
+
         if seen == None:
             seen = set()
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -301,7 +301,11 @@ class maple_tree(objects.StructType):
             self.ma_flags & self.MT_FLAGS_HEIGHT_MASK
         ) >> self.MT_FLAGS_HEIGHT_OFFSET
         yield from self._parse_maple_tree_node(
-            self.ma_root, maple_tree_offset, expected_maple_tree_depth
+            self.ma_root,
+            maple_tree_offset,
+            expected_maple_tree_depth,
+            seen=set(),
+            current_depth=1,
         )
 
     def _parse_maple_tree_node(


### PR DESCRIPTION
Hello,

While debugging the maple tree parsing to see what has caused this issue https://github.com/volatilityfoundation/volatility3/issues/1032 for @4n6-fl I realized how I could recreate the issue and fix it. 

For some reason that I don't understand (and I would like to understand so, if this makes sense to you please would you team me) if the `get_slot_iter` function is called twice it will fail, the `seen` set still contains values when the `_parse_maple_tree_node` function starts. It's supposed to be an optional parameter with the default set to an empty set - so I'm not really sure what is going on. It's likely some python I don't understand. 

To recreate the issue it is as simple as opening volshell and trying to to parse the maple tree twice. 
```
(layer_name) >>> [ vma for  vma in ps()[-2].mm.mm_mt.get_slot_iter()]
[154723148639504, 154723148637832, 154723148638592, 154723148639352, 154723353319200, 154723148638744, 154723353319352, 154723353318592, 154723353320872, 154723353318896, 154723353317984, 154723353317680, 154723353317832, 154723353321176, 154723353318744, 154723353318440, 154723148638440, 154723353320720, 154723353319504, 154723148637224, 154723353317376, 154723353319656, 154723353319048, 154723148638896, 154723148636312, 154723148637984, 154723148636160, 154723353318288, 154723148639200, 154723148637376, 154723148639808, 154723148638136, 154723353317528, 154723148636464, 154723353321024, 154723148639048, 154723148636920, 154723148639960, 154723148636616, 154723353320112, 154723148636768, 154723148638288, 154723148637528, 154723148637680]
(layer_name) >>> [ vma for  vma in ps()[-2].mm.mm_mt.get_slot_iter()]
WARNING  volatility3.framework.symbols.linux.extensions: The mte 0x8cb84e6c971e has all ready been seen, no further results will be produced for this node.
WARNING  volatility3.framework.symbols.linux.extensions: The mte 0x8cb84e6c971e has all ready been seen, no further results will be produced for this node.
```

It is the double parsing that causes the bash plugin to have this issue. It does so here https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/plugins/linux/bash.py#L82 and https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/plugins/linux/bash.py#L92. 

This PR changes the call to `_parse_maple_tree_node` to actually specify the empty set - which seems to do the trick as seen here: 

```
(layer_name) >>> [ vma for  vma in ps()[-2].mm.mm_mt.get_slot_iter()]
[154723148639504, 154723148637832, 154723148638592, 154723148639352, 154723353319200, 154723148638744, 154723353319352, 154723353318592, 154723353320872, 154723353318896, 154723353317984, 154723353317680, 154723353317832, 154723353321176, 154723353318744, 154723353318440, 154723148638440, 154723353320720, 154723353319504, 154723148637224, 154723353317376, 154723353319656, 154723353319048, 154723148638896, 154723148636312, 154723148637984, 154723148636160, 154723353318288, 154723148639200, 154723148637376, 154723148639808, 154723148638136, 154723353317528, 154723148636464, 154723353321024, 154723148639048, 154723148636920, 154723148639960, 154723148636616, 154723353320112, 154723148636768, 154723148638288, 154723148637528, 154723148637680]
(layer_name) >>> [ vma for  vma in ps()[-2].mm.mm_mt.get_slot_iter()]
[154723148639504, 154723148637832, 154723148638592, 154723148639352, 154723353319200, 154723148638744, 154723353319352, 154723353318592, 154723353320872, 154723353318896, 154723353317984, 154723353317680, 154723353317832, 154723353321176, 154723353318744, 154723353318440, 154723148638440, 154723353320720, 154723353319504, 154723148637224, 154723353317376, 154723353319656, 154723353319048, 154723148638896, 154723148636312, 154723148637984, 154723148636160, 154723353318288, 154723148639200, 154723148637376, 154723148639808, 154723148638136, 154723353317528, 154723148636464, 154723353321024, 154723148639048, 154723148636920, 154723148639960, 154723148636616, 154723353320112, 154723148636768, 154723148638288, 154723148637528, 154723148637680]
```

Now I rolled back to 804d68d94d507747d42f018baa3255dfe8635b4d from https://github.com/volatilityfoundation/volatility3/pull/996 to see if this has always been like that, and yes. Calling it twice on that commit still caused it to error. I would have tested it at the time, and alishir on slack also said this patch fixed there issue so I'm not exactly sure what's happened. I can only imagine I made some mistake with my testing, or updating python has changed something?

Here is the output showing this fixes the issue with the bash plugin:
```
$ python vol.py -f v6.1.15.dmp linux.bash
Volatility 3 Framework 2.5.2
Progress:  100.00               Stacking attempts finished
PID     Process CommandTime     Command

826     bash    2023-03-11 20:09:54.000000      ssh root@10.10.10.2 mkdir -p /mnt/data/$VERSION
826     bash    2023-03-11 20:09:54.000000      ssh-copy-id root@10.10.10.2
826     bash    2023-03-11 20:09:54.000000      apt update
826     bash    2023-03-11 20:09:54.000000      sudo apt update
826     bash    2023-03-11 20:09:54.000000      uname -a
<SNIP>
```