### PR TITLE
Linux: update bash plugin to only get memory sections once

### DIFF
--- a/volatility3/framework/plugins/linux/bash.py
+++ b/volatility3/framework/plugins/linux/bash.py
@@ -75,11 +75,16 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
             bang_addrs = []
 
+            # get task memory sections to be used by scanners
+            task_memory_sections = [
+                section for section in task.get_process_memory_sections(heap_only=True)
+            ]
+
             # find '#' values on the heap
             for address in proc_layer.scan(
                 self.context,
                 scanners.BytesScanner(b"#"),
-                sections=task.get_process_memory_sections(heap_only=True),
+                sections=task_memory_sections,
             ):
                 bang_addrs.append(struct.pack(pack_format, address))
 
@@ -89,7 +94,7 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 for address, _ in proc_layer.scan(
                     self.context,
                     scanners.MultiStringScanner(bang_addrs),
-                    sections=task.get_process_memory_sections(heap_only=True),
+                    sections=task_memory_sections,
                 ):
                     hist = self.context.object(
                         bash_table_name + constants.BANG + "hist_entry",


### PR DESCRIPTION
Hello, 

After seeing that the Linux bash plugin calls the `get_process_memory_sections` function twice to get the same results in https://github.com/volatilityfoundation/volatility3/pull/1034  

I felt like I had to change it to be the smallest most insignificant amount more efficient. It likely makes no difference with older kernels that don't use maple tree structures, but in 6.1+ parsing the tree is at least a little bit more work so it makes sense to only do it once. 

This doesn't change how the plugin works or what any of the functions return, they all work exactly as they did before - perhaps meaning this PR wasn't worth wasting anyone time with....