### PR TITLE
Linux extensions patches

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -105,14 +105,18 @@ class module(generic.GenericIntelProcess):
             yield attr
 
     def get_symbols(self):
-        """Get module symbols"""
+        """Get module symbols
+
+        Yields:
+                A tuple for each symbol containing the symbol name and its corresponding value
+        """
         if symbols.symbol_table_is_64bit(self._context, self.get_symbol_table_name()):
             prefix = "Elf64_"
         else:
             prefix = "Elf32_"
         elf_table_name = intermed.IntermediateSymbolTable.create(
             self._context,
-            self._context.modules["kernel"].config_path,
+            "module",
             "linux",
             "elf",
             native_types=None,

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -134,8 +134,8 @@ class module(generic.GenericIntelProcess):
                 try:
                     sym_offset = self.section_strtab + sym.st_name
                     sym_name = self._context.layers[self.vol.layer_name].read(
-                        sym_offset, sym.st_size
-                    )
+                        sym_offset, 512
+                    )  # 512 is the value of KSYM_NAME_LEN
                 except exceptions.PagedInvalidAddressException:
                     continue
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -139,12 +139,12 @@ class module(generic.GenericIntelProcess):
                 except exceptions.PagedInvalidAddressException:
                     continue
 
-                if sym_name:
+                # Stop at first null byte (strtab is a null terminated strings list)
+                sym_name = sym_name.split(b"\x00")[0].decode("latin-1")
+                if sym_name != "":
                     # Normalize sym_value
                     mask = self._context.layers[self.vol.layer_name].address_mask
                     sym_value = sym.st_value & mask
-                    # Stop at first null byte (strtab is a null terminated strings list)
-                    sym_name = sym_name.split(b"\x00")[0].decode("latin-1")
                     yield (sym_name, sym_value, sym_offset)
 
     def get_symbol(self, wanted_sym_name):

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1154,7 +1154,7 @@ class vfsmount(objects.StructType):
 class kobject(objects.StructType):
     def reference_count(self):
         refcnt = self.kref.refcount
-        if self.has_member("counter"):
+        if refcnt.has_member("counter"):
             ret = refcnt.counter
         else:
             ret = refcnt.refs.counter

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -141,7 +141,7 @@ class module(generic.GenericIntelProcess):
             for sym in syms:
                 yield sym
 
-    def get_symbols_names_and_addresses(self):
+    def get_symbols_names_and_addresses(self) -> Tuple[str, int]:
         """Get names and addresses for each symbol of the module
 
         Yields:


### PR DESCRIPTION
- Fix a small error in the kobject class (see https://github.com/volatilityfoundation/volatility/blob/master/volatility/plugins/overlays/linux/linux.py#L1204 for comparison)

module class :
- Fix leftovers from https://github.com/volatilityfoundation/volatility3/commit/83a8afba6baddf919a4e7fb032854bd354ca216c
- Fix broken implementation of module symbols construction (sources : https://refspecs.linuxbase.org/elf/gabi4+/ch4.symtab.html, https://github.com/TheCodeArtist/elf-parser/blob/master/elf-parser.c#L313) 

Reading symbols of an arbitrary module : 

```python
(layer_name) >>> from volatility3.framework.objects import utility
(layer_name) >>> vmlinux = self.context.modules[self.config["kernel"]]
(layer_name) >>> m = vmlinux.object("module",0xffffc06db040,absolute=True) # lime module
(layer_name) >>> utility.array_to_string(m.name)
'lime'
(layer_name) >>> list(m.get_symbols())
[('.LC0', 281473910153660, 281473910405065), ('setup_tcp', 281473910149120, 281473910405070), ('filp_open', 281473822829024, 281473910405080), ('crypto_alloc_ahash', 281473825133440, 281473910405090), ('strcpy', 281473826031120, 281473910405109), ('digest', 281473910158312, 281473910405313), ('deflate', 281473910153040, 281473910405339), ('path', 281473910158336, 281473910405116), ('localhostonly', 281473910158320, 281473910405121), ('ldigest_write_tcp', 281473910152432, 281473910405135)] # stripped for readability
```