### PR TITLE
Fix for windows.strings revmap offsets

### DIFF
--- a/volatility3/framework/plugins/windows/strings.py
+++ b/volatility3/framework/plugins/windows/strings.py
@@ -92,7 +92,7 @@ class Strings(interfaces.plugins.PluginInterface):
 
             # We should really take care of this in the revmap generator
             mapping_entry = revmap.get(
-                phys_offset & 0xFFFFFFFFFFFFF000, [("In Unallocated Space", 0)]
+                phys_offset >> 12, [("In Unallocated Space", 0)]
             )
             for item in mapping_entry:
                 region, offset = item
@@ -178,9 +178,9 @@ class Strings(interfaces.plugins.PluginInterface):
             for mapval in layer.mapping(0x0, layer.maximum_address, ignore_errors=True):
                 offset, _, mapped_offset, mapped_size, maplayer = mapval
                 for val in range(mapped_offset, mapped_offset + mapped_size, 0x1000):
-                    cur_set = reverse_map.get(val, set())
+                    cur_set = reverse_map.get(val >> 12, set())
                     cur_set.add(("kernel", val))
-                    reverse_map[offset] = cur_set
+                    reverse_map[offset >> 12] = cur_set
                 if progress_callback:
                     progress_callback(
                         (offset * 100) / layer.maximum_address,
@@ -214,14 +214,14 @@ class Strings(interfaces.plugins.PluginInterface):
                             for val in range(
                                 mapped_offset, mapped_offset + mapped_size, 0x1000
                             ):
-                                cur_set = reverse_map.get(mapped_offset, set())
+                                cur_set = reverse_map.get(mapped_offset >> 12, set())
                                 cur_set.add(
                                     (
                                         f"Process {process.UniqueProcessId}",
                                         mapped_offset,
                                     )
                                 )
-                                reverse_map[offset] = cur_set
+                                reverse_map[offset >> 12] = cur_set
                             # FIXME: make the progress for all processes, rather than per-process
                             if progress_callback:
                                 progress_callback(

--- a/volatility3/framework/plugins/windows/strings.py
+++ b/volatility3/framework/plugins/windows/strings.py
@@ -91,13 +91,13 @@ class Strings(interfaces.plugins.PluginInterface):
             line_count += 1
 
             mapping_entry = revmap.get(
-                phys_offset >> 12, [{"region": "Unallocated", "pid": -1, "offset": 0x00}]
+                phys_offset >> 12,
+                [{"region": "Unallocated", "pid": -1, "offset": 0x00}],
             )
             for item in mapping_entry:
-
                 # Get the full virtual address not just the page start
                 # If the string is in unalloacted memory, we set the offset to 0x00
-                offset = item.get('offset', 0x00)
+                offset = item.get("offset", 0x00)
                 if offset == 0x00:
                     virtual_address = 0x00
                 else:
@@ -160,14 +160,13 @@ class Strings(interfaces.plugins.PluginInterface):
         filter = pslist.PsList.create_pid_filter(pid_list)
 
         layer = context.layers[layer_name]
-        #reverse_map: Dict[int, Set[Tuple[str, int]]] = dict()
+        # reverse_map: Dict[int, Set[Tuple[str, int]]] = dict()
         reverse_map: Dict[int, List[Dict[str, Union[str, int]]]] = dict()
         if isinstance(layer, intel.Intel):
             # We don't care about errors, we just wanted chunks that map correctly
             for mapval in layer.mapping(0x0, layer.maximum_address, ignore_errors=True):
                 offset, _, mapped_offset, mapped_size, maplayer = mapval
                 for val in range(mapped_offset, mapped_offset + mapped_size, 0x1000):
-                    
                     cur_set = reverse_map.get(val >> 12, list())
                     cur_set.append({"region": "kernel", "pid": -1, "offset": val})
 
@@ -206,7 +205,13 @@ class Strings(interfaces.plugins.PluginInterface):
                                 mapped_offset, mapped_offset + mapped_size, 0x1000
                             ):
                                 cur_set = reverse_map.get(mapped_offset >> 12, list())
-                                cur_set.append({"region": "process", "pid": process.UniqueProcessId, "offset": mapped_offset})
+                                cur_set.append(
+                                    {
+                                        "region": "process",
+                                        "pid": process.UniqueProcessId,
+                                        "offset": mapped_offset,
+                                    }
+                                )
 
                                 reverse_map[offset >> 12] = cur_set
                             # FIXME: make the progress for all processes, rather than per-process

--- a/volatility3/framework/plugins/windows/strings.py
+++ b/volatility3/framework/plugins/windows/strings.py
@@ -118,7 +118,7 @@ class Strings(interfaces.plugins.PluginInterface):
                 yield (
                     0,
                     (
-                        str(string, "latin-1"),
+                        str(string.strip(), "latin-1"),
                         location,
                         int(pid),
                         format_hints.Hex(phys_offset),

--- a/volatility3/framework/plugins/windows/strings.py
+++ b/volatility3/framework/plugins/windows/strings.py
@@ -99,7 +99,6 @@ class Strings(interfaces.plugins.PluginInterface):
             # actually addr. 0xFFF is 4095 e.g. all lower bits set.
             offset_within_page = phys_offset & 0xFFF
 
-
             mapping_entry = revmap.get(
                 phys_offset >> 12,
                 [{"region": "Unallocated", "pid": -1, "offset": 0x00}],
@@ -122,7 +121,6 @@ class Strings(interfaces.plugins.PluginInterface):
                     ),
                 )
 
-            
             prog = line_count / num_strings * 100
             if round(prog, 1) > last_prog:
                 last_prog = round(prog, 1)
@@ -200,15 +198,21 @@ class Strings(interfaces.plugins.PluginInterface):
                     # offset_to_page_within_mapping to ensure that all pages match correctly.
                     # Without this the 2nd, 3rd etc pages would all incorrectly map to the same
                     # virtual offset.
-                    cur_set.append({"region": "Kernel", "pid": -1, "offset": virt_offset + offset_to_page_within_mapping})
+                    cur_set.append(
+                        {
+                            "region": "Kernel",
+                            "pid": -1,
+                            "offset": virt_offset + offset_to_page_within_mapping,
+                        }
+                    )
 
                     # store these results back in the reverse_map
                     reverse_map[physical_page] = cur_set
                 if progress_callback:
                     progress_callback(
                         (virt_offset * 100) / layer.maximum_address,
-                         "Creating reverse kernel map",
-                     )
+                        "Creating reverse kernel map",
+                    )
 
             # TODO: Include kernel modules
 
@@ -252,7 +256,8 @@ class Strings(interfaces.plugins.PluginInterface):
                                     {
                                         "region": "Process",
                                         "pid": process.UniqueProcessId,
-                                        "offset": virt_offset + offset_to_page_within_mapping,
+                                        "offset": virt_offset
+                                        + offset_to_page_within_mapping,
                                     }
                                 )
                                 reverse_map[physical_page] = cur_set


### PR DESCRIPTION
This PR fixes a bug with `windows.strings` ref: https://github.com/volatilityfoundation/volatility3/issues/876

Output has been compared from Vol2.6 to ensure the correct offsets are being returned now. 

This PR also changes the output to better fit the new renderer separating results into parts instead of a string `.join` that was used before. 

As a significant change to the output, the version has also been bumped to `2.0.0` 

Example of these changes working and compared to vol2.6 can be seen in the issue thread