### PR TITLE
Simplify attribute object accesses

### DIFF
--- a/volatility3/framework/symbols/windows/mft.json
+++ b/volatility3/framework/symbols/windows/mft.json
@@ -230,21 +230,21 @@
                     "offset": 0,
                     "type": {
                         "kind": "struct",
-                        "name": "mft!ATTR_HEADER"
+                        "name": "ATTR_HEADER"
                     }
                 },
                 "Resident_Header": {
                     "offset": 16,
                     "type": {
                         "kind": "struct",
-                        "name": "mft!RESIDENT_HEADER"
+                        "name": "RESIDENT_HEADER"
                     }
                 },
                 "Attr_Data": {
                     "offset": 24,
                     "type": {
                         "kind": "struct",
-                        "name": "mft!ATTR_HEADER"
+                        "name": "ATTR_HEADER"
                     }
                 }
             },


### PR DESCRIPTION
This is a very small percentage slower, for some reason, than the previous mechanism, probably overhead from object creation/member access.  However, it vastly simplifies the code and makes better use of the volatility object model.

Related to #1044 