### PR TITLE
Linux: Update kmsg issue 1055

### DIFF
--- a/volatility3/framework/plugins/linux/kmsg.py
+++ b/volatility3/framework/plugins/linux/kmsg.py
@@ -67,7 +67,7 @@ class ABCKmsg(ABC):
         vmlinux = context.modules[self._config["kernel"]]
         self.layer_name = vmlinux.layer_name  # type: ignore
         symbol_table_name = vmlinux.symbol_table_name  # type: ignore
-        self.vmlinux = contexts.Module.create(context, symbol_table_name, self.layer_name, 0)  # type: ignore
+        self.vmlinux = contexts.Module.create(context, symbol_table_name, self.layer_name, vmlinux.offset)  # type: ignore
         self.long_unsigned_int_size = self.vmlinux.get_type("long unsigned int").size
 
     @classmethod
@@ -365,12 +365,14 @@ class KmsgFiveTen(ABCKmsg):
             offset=desc_ring.descs,
             subtype=self.vmlinux.get_type("prb_desc"),
             count=desc_count,
+            absolute=True,
         )
         info_arr = self.vmlinux.object(
             object_type="array",
             offset=desc_ring.infos,
             subtype=self.vmlinux.get_type("printk_info"),
             count=desc_count,
+            absolute=True,
         )
 
         # See kernel/printk/printk_ringbuffer.h

--- a/volatility3/framework/plugins/linux/kmsg.py
+++ b/volatility3/framework/plugins/linux/kmsg.py
@@ -412,7 +412,7 @@ class Kmsg(plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:


### PR DESCRIPTION
Hello 👋 

This PR makes changes to the linux kmsg plugin as discussed in issue https://github.com/volatilityfoundation/volatility3/issues/1055

This does not fix https://github.com/volatilityfoundation/volatility3/issues/1055 completely for @4n6-fl as there is a related dwarf2json issue that also needs fixing https://github.com/volatilityfoundation/dwarf2json/issues/49 

It allows `KmsgFiveTen` to work on kernels that have ~~KALSR~~ KASLR. 

Before it wasn't possible to use kmsg on this sample:
```
$ python vol.py -f v6.1.15.dmp linux.kmsg
Volatility 3 Framework 2.5.2
Progress:  100.00               Stacking attempts finished
facility        level   timestamp       caller  line


Volatility was unable to read a requested page:
Page error 0xffff82253380 in layer layer_name (Page Fault at entry 0x0 in table page table)

        * Memory smear during acquisition (try re-acquiring if possible)
        * An intentionally invalid page lookup (operating system protection)
        * A bug in the plugin/volatility3 (re-run with -vvv and file a bug)

No further results will be produced
```

However with the changes it now shows the output as expected:
```
$ python vol.py -f v6.1.15.dmp linux.kmsg
Volatility 3 Framework 2.5.2
Progress:  100.00               Stacking attempts finished
facility        level   timestamp       caller  line

kern    notice  0.000000        Task(0) Linux version 6.1.15-vol (root@deb10) (gcc (Debian 8.3.0-6) 8.3.0, GNU ld (GNU Binutils for Debian) 2.31.1) #1 SMP PREEMPT_DYNAMIC Sat Mar 11 14:59:42 EST 2023
kern    info    0.000000        Task(0) Command line: BOOT_IMAGE=/boot/vmlinuz-6.1.15-vol root=UUID=c46e3962-8fa4-4620-af46-dfff4bb49610 ro quiet splash resume=UUID=9ede18ae-c5a0-4e05-992b-04786c06c80e
kern    info    0.000000        Task(0) x86/fpu: x87 FPU will use FXSAVE
kern    info    0.000000        Task(0) signal: max sigframe size: 1440
kern    info    0.000000        Task(0) BIOS-provided physical RAM map:
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x0000000000100000-0x00000000bffd9fff] usable
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x00000000bffda000-0x00000000bfffffff] reserved
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
kern    info    0.000000        Task(0) BIOS-e820: [mem 0x0000000100000000-0x000000013fffffff] usable
kern    info    0.000000        Task(0) NX (Execute Disable) protection: active
kern    info    0.000000        Task(0) SMBIOS 2.8 present.
kern    info    0.000000        Task(0) DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS rel-1.16.0-0-gd239552ce722-prebuilt.qemu.org 04/01/2014
kern    info    0.000000        Task(0) Hypervisor detected: KVM
kern    info    0.000000        Task(0) kvm-clock: Using msrs 4b564d01 and 4b564d00
kern    info    0.000001        Task(0) kvm-clock: using sched offset of 118876718327327 cycles
<snip>
```