### PR TITLE
Feature: Import Address Table

### DIFF
--- a/volatility3/framework/plugins/windows/iat.py
+++ b/volatility3/framework/plugins/windows/iat.py
@@ -1,0 +1,132 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+
+import logging
+import io
+from typing import Callable, List
+from volatility3.framework.symbols import intermed
+from volatility3.framework import renderers, interfaces, exceptions, constants
+from volatility3.framework.configuration import requirements
+from volatility3.plugins.windows import pslist
+from volatility3.framework.symbols.windows import pdbutil
+from volatility3.framework.symbols.windows.extensions import pe
+import pefile
+
+vollog = logging.getLogger(__name__)
+
+
+class IAT(interfaces.plugins.PluginInterface):
+    """Extract Import Address Table to list API (functions) used by a program contained in external libraries"""
+
+    _required_framework_version = (2, 4, 0)
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                element_type=int,
+                description="Process ID to include (all other processes are excluded)",
+                optional=True,
+            ),
+        ]
+
+    def _generator(self, procs):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        for proc in procs:
+            try:
+                proc_id = proc.UniqueProcessId
+                proc_layer_name = proc.add_process_layer()
+                peb = self.context.object(
+                    kernel.symbol_table_name + constants.BANG + "_PEB",
+                    layer_name=proc_layer_name,
+                    offset=proc.Peb,
+                )
+
+                if proc_layer_name is None:
+                    raise TypeError("Layer must be a string not None")
+
+                pe_table_name = intermed.IntermediateSymbolTable.create(
+                    self.context,
+                    self.config_path,
+                    "windows",
+                    "pe",
+                    class_types=pe.class_types,
+                )
+                pe_data = io.BytesIO()
+
+                dos_header = self.context.object(
+                    pe_table_name + constants.BANG + "_IMAGE_DOS_HEADER",
+                    offset=peb.ImageBaseAddress,
+                    layer_name=proc_layer_name,
+                )
+
+                for offset, data in dos_header.reconstruct():
+                    pe_data.seek(offset)
+                    pe_data.write(data)
+
+                pe_obj = pefile.PE(data=pe_data.getvalue(), fast_load=True)
+                pe_obj.parse_data_directories(
+                    [pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_IMPORT"]]
+                )
+                if hasattr(pe_obj, "DIRECTORY_ENTRY_IMPORT"):
+                    for entry in pe_obj.DIRECTORY_ENTRY_IMPORT:
+                        dll_entry = entry.dll
+                        if dll_entry:
+                            dll_entry = dll_entry.decode()
+                        else:
+                            dll_entry = renderers.NotAvailableValue
+
+                        # Iterate over imported functions
+                        for imp in entry.imports:
+                            import_name = imp.name
+                            if import_name:
+                                import_name = imp.name.decode()
+                            else:
+                                import_name = renderers.NotAvailableValue()
+                            yield (
+                                0,
+                                (
+                                    proc_id,
+                                    proc.ImageFileName.cast(
+                                        "string",
+                                        max_length=proc.ImageFileName.vol.count,
+                                        errors="replace",
+                                    ),
+                                    dll_entry,
+                                    import_name,
+                                ),
+                            )
+            except exceptions.InvalidAddressException as excp:
+                vollog.debug(
+                    "Process {}: invalid address {} in layer {}".format(
+                        proc_id, excp.invalid_address, excp.layer_name
+                    )
+                )
+                continue
+
+    def run(self):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        return renderers.TreeGrid(
+            [("PID", int), ("Process", str), ("Library", str), ("Function", str)],
+            self._generator(
+                pslist.PsList.list_processes(
+                    context=self.context,
+                    layer_name=kernel.layer_name,
+                    symbol_table=kernel.symbol_table_name,
+                    filter_func=pslist.PsList.create_pid_filter(
+                        self.config.get("pid", None)
+                    ),
+                )
+            ),
+        )

--- a/volatility3/framework/plugins/windows/iat.py
+++ b/volatility3/framework/plugins/windows/iat.py
@@ -1,4 +1,4 @@
-# This file is Copyright 2023 Volatility Foundation and licensed under the Volatility Software License 1.0
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 
 import logging, io, pefile

--- a/volatility3/framework/plugins/windows/iat.py
+++ b/volatility3/framework/plugins/windows/iat.py
@@ -50,7 +50,7 @@ class IAT(interfaces.plugins.PluginInterface):
                 )
 
                 if proc_layer_name is None:
-                    raise TypeError("Layer must be a string not None")
+                    raise TypeError("add_process_layer failed")
 
                 pe_table_name = intermed.IntermediateSymbolTable.create(
                     self.context,


### PR DESCRIPTION
Hello,

This new plugin can be used to extract the Import Address Table from a process to identify the API/functions used by the program. Useful to identify some of the capabilities of a PE and orient the later reverse code analysis phase.

Details here: https://www.forensicxlab.com/posts/voliat/

Example output:

```bash
~» vol -r pretty -f Triage-Memory.mem windows.iat --pid 3496
Volatility 3 Framework 2.5.1
Formatting...0.00               PDB scanning finished                        
  |  PID |           Name |      Library | Bound |                        Function |  Address
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                            _iob | 0x80c0c8
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                _except_handler3 | 0x80c0cc
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                  __set_app_type | 0x80c0d0
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                      __p__fmode | 0x80c0d4
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                    __p__commode | 0x80c0d8
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                    _adjust_fdiv | 0x80c0dc
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                __setusermatherr | 0x80c0e0
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                       _initterm | 0x80c0e4
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                   __getmainargs | 0x80c0e8
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                   __p___initenv | 0x80c0ec
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                     _XcptFilter | 0x80c0f0
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                           _exit | 0x80c0f4
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                         _onexit | 0x80c0f8
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                     __dllonexit | 0x80c0fc
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                         strrchr | 0x80c100
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                         wcsncmp | 0x80c104
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                          _close | 0x80c108
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                          wcslen | 0x80c10c
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                          wcscpy | 0x80c110
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                        strerror | 0x80c114
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                            modf | 0x80c118
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                          strspn | 0x80c11c
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                         realloc | 0x80c120
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                    __p__environ | 0x80c124
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                   __p__wenviron | 0x80c128
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                          _errno | 0x80c12c
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                            free | 0x80c130
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                         strncmp | 0x80c134
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                          strstr | 0x80c138
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                         strncpy | 0x80c13c
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                           _ftol | 0x80c140
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                           qsort | 0x80c144
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                           fopen | 0x80c148
* | 3496 | UWkpjFjDzM.exe |   MSVCRT.dll | False |                          perror | 0x80c14c
[TRUNCATED]
```

Best regards and merry Christmas ☺️