### PR TITLE
Windows: SvcScan Binary Info

### DIFF
--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -87,7 +87,7 @@ class ContextInterface(metaclass=ABCMeta):
         offset: int,
         native_layer_name: str = None,
         **arguments,
-    ):
+    ) -> "interfaces.objects.ObjectInterface":
         """Object factory, takes a context, symbol, offset and optional
         layer_name.
 

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -144,7 +144,7 @@ class SvcScan(interfaces.plugins.PluginInterface):
             native_types=native_types,
         )
 
-    def _get_service_key(self, kernel):
+    def _get_service_key(self, kernel) -> Optional[objects.StructType]:
         for hive in hivelist.HiveList.list_hives(
             context=self.context,
             base_config_path=interfaces.configuration.path_join(
@@ -156,10 +156,14 @@ class SvcScan(interfaces.plugins.PluginInterface):
         ):
             # Get ControlSet\Services.
             try:
-                return hive.get_key(r"CurrentControlSet\Services")
+                return cast(
+                    objects.StructType, hive.get_key(r"CurrentControlSet\Services")
+                )
             except (KeyError, exceptions.InvalidAddressException):
                 try:
-                    return hive.get_key(r"ControlSet001\Services")
+                    return cast(
+                        objects.StructType, hive.get_key(r"ControlSet001\Services")
+                    )
                 except (KeyError, exceptions.InvalidAddressException):
                     pass
 

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -32,7 +32,7 @@ class SvcScan(interfaces.plugins.PluginInterface):
     """Scans for windows services."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
+    _version = (2, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -107,25 +107,45 @@ class SvcScan(interfaces.plugins.PluginInterface):
         ):
             symbol_filename = "services-xp-2003-x64"
         elif (
+            versions.is_win10_25398_or_later(context=context, symbol_table=symbol_table)
+            and is_64bit
+        ):
+            symbol_filename = "services-win10-25398-x64"
+        elif (
+            versions.is_win10_19041_or_later(context=context, symbol_table=symbol_table)
+            and is_64bit
+        ):
+            symbol_filename = "services-win10-19041-x64"
+        elif (
+            versions.is_win10_19041_or_later(context=context, symbol_table=symbol_table)
+            and not is_64bit
+        ):
+            symbol_filename = "services-win10-19041-x86"
+        elif (
+            versions.is_win10_18362_or_later(context=context, symbol_table=symbol_table)
+            and is_64bit
+        ):
+            symbol_filename = "services-win10-18362-x64"
+        elif (
+            versions.is_win10_18362_or_later(context=context, symbol_table=symbol_table)
+            and not is_64bit
+        ):
+            symbol_filename = "services-win10-18362-x86"
+        elif (
             versions.is_win10_16299_or_later(context=context, symbol_table=symbol_table)
             and is_64bit
         ):
             symbol_filename = "services-win10-16299-x64"
         elif (
+            versions.is_win10_17763_or_later(context=context, symbol_table=symbol_table)
+            and not is_64bit
+        ):
+            symbol_filename = "services-win10-17763-x86"
+        elif (
             versions.is_win10_16299_or_later(context=context, symbol_table=symbol_table)
             and not is_64bit
         ):
             symbol_filename = "services-win10-16299-x86"
-        elif (
-            versions.is_win10_up_to_15063(context=context, symbol_table=symbol_table)
-            and is_64bit
-        ):
-            symbol_filename = "services-win8-x64"
-        elif (
-            versions.is_win10_up_to_15063(context=context, symbol_table=symbol_table)
-            and not is_64bit
-        ):
-            symbol_filename = "services-win8-x86"
         elif (
             versions.is_win10_15063(context=context, symbol_table=symbol_table)
             and is_64bit
@@ -136,6 +156,16 @@ class SvcScan(interfaces.plugins.PluginInterface):
             and not is_64bit
         ):
             symbol_filename = "services-win10-15063-x86"
+        elif (
+            versions.is_win10_up_to_15063(context=context, symbol_table=symbol_table)
+            and is_64bit
+        ):
+            symbol_filename = "services-win8-x64"
+        elif (
+            versions.is_win10_up_to_15063(context=context, symbol_table=symbol_table)
+            and not is_64bit
+        ):
+            symbol_filename = "services-win8-x86"
         elif (
             versions.is_windows_8_or_later(context=context, symbol_table=symbol_table)
             and is_64bit

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -153,7 +153,6 @@ class SvcScan(interfaces.plugins.PluginInterface):
             layer_name=kernel.layer_name,
             symbol_table=kernel.symbol_table_name,
             filter_string="machine\\system",
-            hive_offsets=None,
         ):
             # Get ControlSet\Services.
             try:

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -169,9 +169,8 @@ class SvcScan(interfaces.plugins.PluginInterface):
                         constants.LOGLEVEL_VVVV,
                         "Could not retrieve any control set from SYSTEM hive",
                     )
-                    pass
 
-            return None
+        return None
 
     @staticmethod
     def _get_service_dll(

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -147,7 +147,9 @@ class SvcScan(interfaces.plugins.PluginInterface):
     def _get_service_key(self, kernel):
         for hive in hivelist.HiveList.list_hives(
             context=self.context,
-            base_config_path=self.config_path,
+            base_config_path=interfaces.configuration.path_join(
+                self.config_path, "hivelist"
+            ),
             layer_name=kernel.layer_name,
             symbol_table=kernel.symbol_table_name,
             filter_string="machine\\system",

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -165,6 +165,10 @@ class SvcScan(interfaces.plugins.PluginInterface):
                         objects.StructType, hive.get_key(r"ControlSet001\Services")
                     )
                 except (KeyError, exceptions.InvalidAddressException):
+                    vollog.log(
+                        constants.LOGLEVEL_VVVV,
+                        "Could not retrieve any control set from SYSTEM hive",
+                    )
                     pass
 
             return None

--- a/volatility3/framework/symbols/windows/services/services-win10-17763-x86.json
+++ b/volatility3/framework/symbols/windows/services/services-win10-17763-x86.json
@@ -1,0 +1,248 @@
+{
+    "symbols": {}, 
+    "enums": {
+        "StateEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_START_PENDING": 2, 
+                "SERVICE_STOP_PENDING": 3, 
+                "SERVICE_STOPPED": 1, 
+                "SERVICE_CONTINUE_PENDING": 5, 
+                "SERVICE_PAUSE_PENDING": 6, 
+                "SERVICE_PAUSED": 7, 
+                "SERVICE_RUNNING": 4
+            }, 
+            "size": 4
+        }, 
+        "StartEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_DEMAND_START": 3, 
+                "SERVICE_AUTO_START": 2, 
+                "SERVICE_BOOT_START": 0, 
+                "SERVICE_DISABLED": 4, 
+                "SERVICE_SYSTEM_START": 1
+            }, 
+            "size": 4
+        }
+    }, 
+    "base_types": {
+        "unsigned long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "_SERVICE_LIST_ENTRY": {
+            "fields": {
+                "Flink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    },
+                    "offset": 4
+                }, 
+                "Blink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 0
+                }
+            }, 
+            "kind": "struct", 
+            "size": 8
+        }, 
+        "_SERVICE_PROCESS": {
+            "fields": {
+                "BinaryPath": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 12
+                }, 
+                "ProcessId": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 20
+                }
+            }, 
+            "kind": "struct", 
+            "size": 20
+        }, 
+        "_SERVICE_HEADER": {
+            "fields": {
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 0
+                }, 
+                "ServiceRecord": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    }, 
+                    "offset": 12
+                }
+            }, 
+            "kind": "struct", 
+            "size": 12
+        }, 
+        "_SERVICE_RECORD": {
+            "fields": {
+                "DisplayName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 48
+                }, 
+                "ServiceProcess": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_PROCESS"
+                        }
+                    },
+                    "offset": 160
+                }, 
+                "PrevEntry": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 12
+                }, 
+                "Start": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StartEnum"
+                    }, 
+                    "offset": 24
+                }, 
+                "State": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StateEnum"
+                    }, 
+                    "offset": 56
+                }, 
+                "ServiceName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    }, 
+                    "offset": 44
+                },
+                "Tag": {
+                    "type": {
+                        "count": 4,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        },
+                        "kind": "array"
+                    },
+                    "offset": 0
+                },
+                "DriverName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 160
+                }, 
+                "Type": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned long"
+                    }, 
+                    "offset": 52
+                }, 
+                "Order": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 20
+                }
+            }, 
+            "kind": "struct", 
+            "size": 156
+        }
+    }, 
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "vtypes_to_json.py", 
+            "datetime": "2019-04-17T13:45:16.417006"
+        }, 
+        "format": "4.1.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/services/services-win10-18362-x64.json
+++ b/volatility3/framework/symbols/windows/services/services-win10-18362-x64.json
@@ -1,0 +1,255 @@
+{
+    "symbols": {}, 
+    "enums": {
+        "StateEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_START_PENDING": 2, 
+                "SERVICE_STOP_PENDING": 3, 
+                "SERVICE_STOPPED": 1, 
+                "SERVICE_CONTINUE_PENDING": 5, 
+                "SERVICE_PAUSE_PENDING": 6, 
+                "SERVICE_PAUSED": 7, 
+                "SERVICE_RUNNING": 4
+            }, 
+            "size": 4
+        }, 
+        "StartEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_DEMAND_START": 3, 
+                "SERVICE_AUTO_START": 2, 
+                "SERVICE_BOOT_START": 0, 
+                "SERVICE_DISABLED": 4, 
+                "SERVICE_SYSTEM_START": 1
+            }, 
+            "size": 4
+        }
+    }, 
+    "base_types": {
+        "unsigned long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 8, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "_SERVICE_LIST_ENTRY": {
+            "fields": {
+                "Flink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 16
+                }, 
+                "Blink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 0
+                }
+            }, 
+            "kind": "struct", 
+            "size": 16
+        }, 
+        "_SERVICE_PROCESS": {
+            "fields": {
+                "BinaryPath": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 24
+                }, 
+                "ProcessId": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 40
+                }
+            }, 
+            "kind": "struct", 
+            "size": 40
+        }, 
+        "_SERVICE_HEADER": {
+            "fields": {
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 0
+                }, 
+                "ServiceRecord": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 16
+                }
+            }, 
+            "kind": "struct", 
+            "size": 16
+        }, 
+        "_SERVICE_RECORD": {
+            "fields": {
+                "ServiceList": {
+                    "type": {
+                        "kind": "struct", 
+                        "name": "_SERVICE_LIST_ENTRY"
+                    }, 
+                    "offset": 0
+                }, 
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 32
+                }, 
+                "DisplayName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 64
+                }, 
+                "ServiceProcess": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_PROCESS"
+                        }
+                    },
+                    "offset": 240
+                }, 
+                "PrevEntry": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 16
+                }, 
+                "Start": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StartEnum"
+                    }, 
+                    "offset": 36
+                }, 
+                "State": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StateEnum"
+                    }, 
+                    "offset": 76
+                }, 
+                "ServiceName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 56
+                }, 
+                "DriverName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 240
+                }, 
+                "Type": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned long"
+                    }, 
+                    "offset": 72
+                }, 
+                "Order": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 32
+                }
+            }, 
+            "kind": "struct", 
+            "size": 248
+        }
+    }, 
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "vtypes_to_json.py", 
+            "datetime": "2019-04-17T13:45:16.417006"
+        }, 
+        "format": "4.1.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/services/services-win10-18362-x86.json
+++ b/volatility3/framework/symbols/windows/services/services-win10-18362-x86.json
@@ -1,0 +1,248 @@
+{
+    "symbols": {}, 
+    "enums": {
+        "StateEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_START_PENDING": 2, 
+                "SERVICE_STOP_PENDING": 3, 
+                "SERVICE_STOPPED": 1, 
+                "SERVICE_CONTINUE_PENDING": 5, 
+                "SERVICE_PAUSE_PENDING": 6, 
+                "SERVICE_PAUSED": 7, 
+                "SERVICE_RUNNING": 4
+            }, 
+            "size": 4
+        }, 
+        "StartEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_DEMAND_START": 3, 
+                "SERVICE_AUTO_START": 2, 
+                "SERVICE_BOOT_START": 0, 
+                "SERVICE_DISABLED": 4, 
+                "SERVICE_SYSTEM_START": 1
+            }, 
+            "size": 4
+        }
+    }, 
+    "base_types": {
+        "unsigned long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "_SERVICE_LIST_ENTRY": {
+            "fields": {
+                "Flink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    },
+                    "offset": 4
+                }, 
+                "Blink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 0
+                }
+            }, 
+            "kind": "struct", 
+            "size": 8
+        }, 
+        "_SERVICE_PROCESS": {
+            "fields": {
+                "BinaryPath": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 12
+                }, 
+                "ProcessId": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 20
+                }
+            }, 
+            "kind": "struct", 
+            "size": 20
+        }, 
+        "_SERVICE_HEADER": {
+            "fields": {
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 0
+                }, 
+                "ServiceRecord": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    }, 
+                    "offset": 12
+                }
+            }, 
+            "kind": "struct", 
+            "size": 12
+        }, 
+        "_SERVICE_RECORD": {
+            "fields": {
+                "DisplayName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 48
+                }, 
+                "ServiceProcess": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_PROCESS"
+                        }
+                    },
+                    "offset": 164
+                }, 
+                "PrevEntry": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 12
+                }, 
+                "Start": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StartEnum"
+                    }, 
+                    "offset": 24
+                }, 
+                "State": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StateEnum"
+                    }, 
+                    "offset": 56
+                }, 
+                "ServiceName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    }, 
+                    "offset": 44
+                },
+                "Tag": {
+                    "type": {
+                        "count": 4,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        },
+                        "kind": "array"
+                    },
+                    "offset": 0
+                },
+                "DriverName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 164
+                }, 
+                "Type": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned long"
+                    }, 
+                    "offset": 52
+                }, 
+                "Order": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 20
+                }
+            }, 
+            "kind": "struct", 
+            "size": 156
+        }
+    }, 
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "vtypes_to_json.py", 
+            "datetime": "2019-04-17T13:45:16.417006"
+        }, 
+        "format": "4.1.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/services/services-win10-19041-x64.json
+++ b/volatility3/framework/symbols/windows/services/services-win10-19041-x64.json
@@ -1,0 +1,255 @@
+{
+    "symbols": {}, 
+    "enums": {
+        "StateEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_START_PENDING": 2, 
+                "SERVICE_STOP_PENDING": 3, 
+                "SERVICE_STOPPED": 1, 
+                "SERVICE_CONTINUE_PENDING": 5, 
+                "SERVICE_PAUSE_PENDING": 6, 
+                "SERVICE_PAUSED": 7, 
+                "SERVICE_RUNNING": 4
+            }, 
+            "size": 4
+        }, 
+        "StartEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_DEMAND_START": 3, 
+                "SERVICE_AUTO_START": 2, 
+                "SERVICE_BOOT_START": 0, 
+                "SERVICE_DISABLED": 4, 
+                "SERVICE_SYSTEM_START": 1
+            }, 
+            "size": 4
+        }
+    }, 
+    "base_types": {
+        "unsigned long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 8, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "_SERVICE_LIST_ENTRY": {
+            "fields": {
+                "Flink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 16
+                }, 
+                "Blink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 0
+                }
+            }, 
+            "kind": "struct", 
+            "size": 16
+        }, 
+        "_SERVICE_PROCESS": {
+            "fields": {
+                "BinaryPath": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 24
+                }, 
+                "ProcessId": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 40
+                }
+            }, 
+            "kind": "struct", 
+            "size": 40
+        }, 
+        "_SERVICE_HEADER": {
+            "fields": {
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 0
+                }, 
+                "ServiceRecord": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 16
+                }
+            }, 
+            "kind": "struct", 
+            "size": 16
+        }, 
+        "_SERVICE_RECORD": {
+            "fields": {
+                "ServiceList": {
+                    "type": {
+                        "kind": "struct", 
+                        "name": "_SERVICE_LIST_ENTRY"
+                    }, 
+                    "offset": 0
+                }, 
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 32
+                }, 
+                "DisplayName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 64
+                }, 
+                "ServiceProcess": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_PROCESS"
+                        }
+                    },
+                    "offset": 296
+                }, 
+                "PrevEntry": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 16
+                }, 
+                "Start": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StartEnum"
+                    }, 
+                    "offset": 36
+                }, 
+                "State": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StateEnum"
+                    }, 
+                    "offset": 76
+                }, 
+                "ServiceName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 56
+                }, 
+                "DriverName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 296
+                }, 
+                "Type": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned long"
+                    }, 
+                    "offset": 72
+                }, 
+                "Order": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 32
+                }
+            }, 
+            "kind": "struct", 
+            "size": 296
+        }
+    }, 
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "David McDonald", 
+            "datetime": "2023-11-16T15:05:35-06:00"
+        }, 
+        "format": "4.1.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/services/services-win10-19041-x86.json
+++ b/volatility3/framework/symbols/windows/services/services-win10-19041-x86.json
@@ -1,0 +1,248 @@
+{
+    "symbols": {}, 
+    "enums": {
+        "StateEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_START_PENDING": 2, 
+                "SERVICE_STOP_PENDING": 3, 
+                "SERVICE_STOPPED": 1, 
+                "SERVICE_CONTINUE_PENDING": 5, 
+                "SERVICE_PAUSE_PENDING": 6, 
+                "SERVICE_PAUSED": 7, 
+                "SERVICE_RUNNING": 4
+            }, 
+            "size": 4
+        }, 
+        "StartEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_DEMAND_START": 3, 
+                "SERVICE_AUTO_START": 2, 
+                "SERVICE_BOOT_START": 0, 
+                "SERVICE_DISABLED": 4, 
+                "SERVICE_SYSTEM_START": 1
+            }, 
+            "size": 4
+        }
+    }, 
+    "base_types": {
+        "unsigned long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "_SERVICE_LIST_ENTRY": {
+            "fields": {
+                "Flink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    },
+                    "offset": 4
+                }, 
+                "Blink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 0
+                }
+            }, 
+            "kind": "struct", 
+            "size": 8
+        }, 
+        "_SERVICE_PROCESS": {
+            "fields": {
+                "BinaryPath": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 12
+                }, 
+                "ProcessId": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 20
+                }
+            }, 
+            "kind": "struct", 
+            "size": 20
+        }, 
+        "_SERVICE_HEADER": {
+            "fields": {
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 0
+                }, 
+                "ServiceRecord": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    }, 
+                    "offset": 16
+                }
+            }, 
+            "kind": "struct", 
+            "size": 12
+        }, 
+        "_SERVICE_RECORD": {
+            "fields": {
+                "DisplayName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 48
+                }, 
+                "ServiceProcess": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_PROCESS"
+                        }
+                    },
+                    "offset": 192
+                }, 
+                "PrevEntry": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 12
+                }, 
+                "Start": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StartEnum"
+                    }, 
+                    "offset": 24
+                }, 
+                "State": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StateEnum"
+                    }, 
+                    "offset": 56
+                }, 
+                "ServiceName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    }, 
+                    "offset": 44
+                },
+                "Tag": {
+                    "type": {
+                        "count": 4,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        },
+                        "kind": "array"
+                    },
+                    "offset": 0
+                },
+                "DriverName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 192
+                }, 
+                "Type": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned long"
+                    }, 
+                    "offset": 52
+                }, 
+                "Order": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 20
+                }
+            }, 
+            "kind": "struct", 
+            "size": 192
+        }
+    }, 
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "vtypes_to_json.py", 
+            "datetime": "2019-04-17T13:45:16.417006"
+        }, 
+        "format": "4.1.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/services/services-win10-25398-x64.json
+++ b/volatility3/framework/symbols/windows/services/services-win10-25398-x64.json
@@ -1,0 +1,255 @@
+{
+    "symbols": {}, 
+    "enums": {
+        "StateEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_START_PENDING": 2, 
+                "SERVICE_STOP_PENDING": 3, 
+                "SERVICE_STOPPED": 1, 
+                "SERVICE_CONTINUE_PENDING": 5, 
+                "SERVICE_PAUSE_PENDING": 6, 
+                "SERVICE_PAUSED": 7, 
+                "SERVICE_RUNNING": 4
+            }, 
+            "size": 4
+        }, 
+        "StartEnum": {
+            "base": "long", 
+            "constants": {
+                "SERVICE_DEMAND_START": 3, 
+                "SERVICE_AUTO_START": 2, 
+                "SERVICE_BOOT_START": 0, 
+                "SERVICE_DISABLED": 4, 
+                "SERVICE_SYSTEM_START": 1
+            }, 
+            "size": 4
+        }
+    }, 
+    "base_types": {
+        "unsigned long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned char": {
+            "kind": "char", 
+            "size": 1, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "pointer": {
+            "kind": "int", 
+            "size": 8, 
+            "signed": false, 
+            "endian": "little"
+        }, 
+        "unsigned int": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int", 
+            "size": 4, 
+            "signed": false, 
+            "endian": "little"
+        }
+    }, 
+    "user_types": {
+        "_SERVICE_LIST_ENTRY": {
+            "fields": {
+                "Flink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 16
+                }, 
+                "Blink": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_LIST_ENTRY"
+                        }
+                    }, 
+                    "offset": 0
+                }
+            }, 
+            "kind": "struct", 
+            "size": 16
+        }, 
+        "_SERVICE_PROCESS": {
+            "fields": {
+                "BinaryPath": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 24
+                }, 
+                "ProcessId": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 40
+                }
+            }, 
+            "kind": "struct", 
+            "size": 40
+        }, 
+        "_SERVICE_HEADER": {
+            "fields": {
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 0
+                }, 
+                "ServiceRecord": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 16
+                }
+            }, 
+            "kind": "struct", 
+            "size": 16
+        }, 
+        "_SERVICE_RECORD": {
+            "fields": {
+                "ServiceList": {
+                    "type": {
+                        "kind": "struct", 
+                        "name": "_SERVICE_LIST_ENTRY"
+                    }, 
+                    "offset": 0
+                }, 
+                "Tag": {
+                    "type": {
+                        "count": 4, 
+                        "subtype": {
+                            "kind": "base", 
+                            "name": "unsigned char"
+                        }, 
+                        "kind": "array"
+                    }, 
+                    "offset": 32
+                }, 
+                "DisplayName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 64
+                }, 
+                "ServiceProcess": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_PROCESS"
+                        }
+                    },
+                    "offset": 336
+                }, 
+                "PrevEntry": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_SERVICE_RECORD"
+                        }
+                    },
+                    "offset": 16
+                }, 
+                "Start": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StartEnum"
+                    }, 
+                    "offset": 36
+                }, 
+                "State": {
+                    "type": {
+                        "kind": "enum", 
+                        "name": "StateEnum"
+                    }, 
+                    "offset": 84
+                }, 
+                "ServiceName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 56
+                }, 
+                "DriverName": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned short"
+                        }
+                    },
+                    "offset": 296
+                }, 
+                "Type": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned long"
+                    }, 
+                    "offset": 80
+                }, 
+                "Order": {
+                    "type": {
+                        "kind": "base", 
+                        "name": "unsigned int"
+                    }, 
+                    "offset": 32
+                }
+            }, 
+            "kind": "struct", 
+            "size": 336
+        }
+    }, 
+    "metadata": {
+        "producer": {
+            "version": "0.0.1", 
+            "name": "David McDonald", 
+            "datetime": "2023-11-16T15:05:35-06:00"
+        }, 
+        "format": "4.1.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/versions.py
+++ b/volatility3/framework/symbols/windows/versions.py
@@ -151,9 +151,43 @@ is_win10_16299_or_later = OsDistinguisher(
     ],
 )
 
+is_win10_17763_or_later = OsDistinguisher(
+    version_check=lambda x: x >= (10, 0, 17763),
+    fallback_checks=[
+        ("_EPROCESS", "TrustletIdentity", False),
+        ("ParentSecurityDomain", None, False),
+    ],
+)
+
+is_win10_18362_or_later = OsDistinguisher(
+    version_check=lambda x: x >= (10, 0, 18362),
+    fallback_checks=[
+        ("ObHeaderCookie", None, True),
+        ("_CM_CACHED_VALUE_INDEX", None, False),
+        ("_WNF_PROCESS_CONTEXT", None, True),
+    ],
+)
+
 is_win10_18363_or_later = OsDistinguisher(
     version_check=lambda x: x >= (10, 0, 18363),
     fallback_checks=[("_KQOS_GROUPING_SETS", None, True)],
+)
+
+is_win10_19041_or_later = OsDistinguisher(
+    version_check=lambda x: x >= (10, 0, 19041),
+    fallback_checks=[
+        ("_EPROCESS", "TimerResolutionIgnore", True),
+        ("_EPROCESS", "VmProcessorHostTransition", True),
+        ("_KQOS_GROUPING_SETS", None, True),
+    ],
+)
+
+is_win10_25398_or_later = OsDistinguisher(
+    version_check=lambda x: x >= (10, 0, 25398),
+    fallback_checks=[
+        ("_EPROCESS", "MmSlabIdentity", True),
+        ("_EPROCESS", "EnableProcessImpersonationLogging", True),
+    ],
 )
 
 is_windows_10 = OsDistinguisher(

--- a/volatility3/framework/symbols/windows/versions.py
+++ b/volatility3/framework/symbols/windows/versions.py
@@ -155,7 +155,7 @@ is_win10_17763_or_later = OsDistinguisher(
     version_check=lambda x: x >= (10, 0, 17763),
     fallback_checks=[
         ("_EPROCESS", "TrustletIdentity", False),
-        ("ParentSecurityDomain", None, False),
+        ("ParentSecurityDomain", None, True),
     ],
 )
 


### PR DESCRIPTION
In the original volatility framework, the svcscan plugin, in addition to gathering information about running services from the services process, also retrieved the ImagePath and ServiceDll attributes from the Windows registry: https://github.com/volatilityfoundation/volatility/blob/a438e768194a9e05eb4d9ee9338b881c0fa25937/volatility/plugins/malware/svcscan.py#L642. 

This PR adds support for that in volatility3. Additionally, during testing, it became clear that the volatility3 svcscan plugin was not working correctly across all versions of Windows. Specifically, `PID` and `Binary` values were not parsing correctly in some instances, instead producing empty values. This was due to changes in the `_SERVICE_RECORD` structure between Windows versions, leading to incorrect offsets for the `ProcessId` and `BinaryPath` members. This PR also adds updated symbol files for the broken versions of Windows, as well as new`OsDistinguisher` instances for correctly detecting those Windows versions where the changes took place. I have tested these new OS versions and symbol files across all relevant versions of Windows to confirm their correctness.