### PR TITLE
Linux: add sanity check in `find_aslr`

### DIFF
--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -156,6 +156,18 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
                 and init_task.state.cast("unsigned int") != 0
             ):
                 continue
+            elif init_task.active_mm.cast("long unsigned int") == module.get_symbol(
+                "init_mm"
+            ).address and init_task.tasks.next.cast(
+                "long unsigned int"
+            ) == init_task.tasks.prev.cast(
+                "long unsigned int"
+            ):
+                # The idle task steals `mm` from previously running task, i.e.,
+                # `init_mm` is only used as long as no CPU has ever been idle.
+                # This catches cases where we found a fragment of the
+                # unrelocated ELF file instead of the running kernel.
+                continue
 
             # This we get for free
             aslr_shift = (


### PR DESCRIPTION
**Describe the bug**
We encountered a situation where Volatility would wrongly assume that a memory image had a virtual ASLR of zero because the first matching `init_task` was in a fragment of the `.data` section of the kernel ELF file in the page cache, instead of the one in the running kernel's `.data` section. The kernel ELF file was opened prior to acquisition and thus fragments of it were scattered in physical memory.

The kernel ELF file's `.data` section contains the `init_task`'s `task_struct` with values for the `files`, `thread_pid`, `fs`, ... members initialized to the non-randomized addresses that are also found in the system map.
```console
$ objcopy --dump-section .data=/tmp/linux.data bpfvol3-roboxes-centos9s-vmlinux_extracted-8b0ac.elf
$ readelf --symbols bpfvol3-roboxes-centos9s-vmlinux_extracted-8b0ac.elf | rg init_files
189146: ffffffff83084800   704 OBJECT  GLOBAL DEFAULT   28 init_files
$ rg 'init_files' bpfvol3-roboxes-centos9s-vmlinux_extracted-8b0ac.map
171871:ffffffff83084800 D init_files
$ xxd /tmp/linux.data | rg swapper -C 30 | rg 0048
0001b650: 20d2 0883 ffff ffff 0048 0883 ffff ffff   ........H......
```
Volatility currently picks the first valid-looking `init_task` it finds in the image and thus if such a fragment of the data section precedes the real `init_task` a virtual ASLR of zero is determined by the [following code](https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/automagic/linux.py#L161):
```python
            aslr_shift = (
                init_task.files.cast("long unsigned int")
                - module.get_symbol("init_files").address
            )
```
To identify such "phony" matches I'd propose two heuristics:
1. `"match is phony" <=> .active_mm == init_mm` where the address of `init_mm` is taken from the system map/json symbols. This works because kernel threads, i.e. tasks with `.mm=NULL`, "steal" the `active_mm` of the previous task when they are scheduled to run on a CPU. Thus, as long as some CPU on the system has been idle at least once the `active_mm` of the real init_task will be unequal to `init_mm`, even on systems that really had no ASLR. (Theoretically it would be possible to construct an edge case where this is wrong, but it is incredibly unlikely ^^)
2. There are multiple doubly-linked lists in the init_task's task_struct that are statically initialized to be empty. Thus, a possible heuristic based on this would be: "match is phony" <=>  `.tasks.next == .tasks.prev`, which should never be the case for the real `init_task`.

I personally prefer the latter option due to its simplicity (just tell me if you think so too and I'll happily remove the other one from the PR).

**Context**
Volatility Version:  [a4b927f](https://github.com/volatilityfoundation/volatility3/commit/a4b927f478eca745a8a4c7ec25c77fa6de49d0df)

**To Reproduce**
In case you are interested I uploaded some dump+symbol that exhibits this behavior. [Download](https://drive.proton.me/urls/ZMTX3CJW00#uRBQSxC0opeX)

Process listing plugins will show no output (empty task list), other plugins like `kmsg` will list dereference invalid pointers and crash.