### PR TITLE
Windows: Added '--refined' option to windows malfind plugin

### DIFF
--- a/volatility3/framework/plugins/windows/malfind.py
+++ b/volatility3/framework/plugins/windows/malfind.py
@@ -140,7 +140,7 @@ class Malfind(interfaces.plugins.PluginInterface):
     def _generator(self, procs):
         # determine if we're on a 32 or 64 bit kernel
         kernel = self.context.modules[self.config["kernel"]]
-        
+
         # set refined criteria to know when to add to "Notes" column
         refined_criteria = [b"MZ", b"\x55\x8B", b"\x55\x48", b"\x55\x89"]
 
@@ -150,7 +150,7 @@ class Malfind(interfaces.plugins.PluginInterface):
 
         for proc in procs:
             # by default, "Notes" column will be set to none
-            notes = "None" 
+            notes = "None"
             process_name = utility.array_to_string(proc.ImageFileName)
 
             for vad, data in self.list_injections(


### PR DESCRIPTION
The windows malfind plugin lists process memory ranges that potentially contain injected code. In the original volatility framework, the windows malfind plugin offered a "W" command line option that refined the results to only high confidence matches. The criteria for a high confidence match was either memory regions with an MZ header or that started with a well known opcode combination, ie. PUSH EBP.

This PR adds support for a "--refined" option for volatility3 to match the functionality of the "W" option from the original framework. For this PR, the possible criteria for a high confidence match was updated to include the common opcodes for 32 and 64bit functions ("\x55\x48" and "\x55\x89"),  in addition to the original criteria of the MZ header or the PUSH EBP opcode ("\x55\x8B") from volatility.  I have tested against various memory samples with injected code to validate the functionality of this option.
