### PR TITLE
Windows: Add filtering by type to handles.

### DIFF
--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -60,6 +60,12 @@ class Handles(interfaces.plugins.PluginInterface):
                 description="Process offset in the physical address space",
                 optional=True,
             ),
+            requirements.ListRequirement(
+                name="types",
+                element_type=str,
+                description="Types of handles to include (all other handle types are excluded)",
+                optional=True,
+            ),
         ]
 
     def _decode_pointer(self, value, magic):
@@ -357,6 +363,8 @@ class Handles(interfaces.plugins.PluginInterface):
             symbol_table=kernel.symbol_table_name,
         )
 
+        object_types = [s.lower() for s in self.config.get("types", [])]
+
         cookie = self.find_cookie(
             context=self.context,
             layer_name=kernel.layer_name,
@@ -380,6 +388,9 @@ class Handles(interfaces.plugins.PluginInterface):
                     obj_type = entry.get_object_type(type_map, cookie)
                     if obj_type is None:
                         continue
+                    elif object_types and obj_type.lower() not in object_types:
+                        continue
+
                     if obj_type == "File":
                         item = entry.Body.cast("_FILE_OBJECT")
                         obj_name = item.file_name_with_device()


### PR DESCRIPTION
In volatility2, the `windows.handles` plugin allows filtering by type of handle. This MR adds the corresponding functionality to volatility3.

Like for volatility2, specified types are treated as case-insensitive and they are not checked against a list of valid handle types.  For example, a user-inputted type of value "Foo" is not a valid type, but it won't trigger an error and will simply yield no handles. The following volatility2 function contains the functionality that this MR replicates: https://github.com/volatilityfoundation/volatility/blob/a438e768194a9e05eb4d9ee9338b881c0fa25937/volatility/plugins/handles.py#L41

Manual testing was performed on a windows memory image to verify the expected behavior. The windows test suite was also run.