### PR TITLE
Windows: Add additional command line argument info to windows pstree

### DIFF
--- a/volatility3/framework/plugins/windows/pstree.py
+++ b/volatility3/framework/plugins/windows/pstree.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 from typing import Callable, Dict, Set, Tuple
 
-from volatility3.framework import objects, interfaces, renderers
+from volatility3.framework import objects, interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.windows import pslist
@@ -132,6 +132,25 @@ class PsTree(interfaces.plugins.PluginInterface):
                 proc.get_exit_time(),
             )
 
+            try:
+                audit = proc.SeAuditProcessCreationInfo.ImageFileName.Name
+                # If 'audit' is set to the empty string, display NotAvailableValue
+                row += (audit.get_string() or renderers.NotAvailableValue(),)
+            except exceptions.InvalidAddressException:
+                row += (renderers.NotAvailableValue(),)
+
+            try:
+                process_params = proc.get_peb().ProcessParameters
+                row += (
+                    process_params.CommandLine.get_string(),
+                    process_params.ImagePathName.get_string(),
+                )
+            except exceptions.InvalidAddressException:
+                row += (
+                    renderers.NotAvailableValue(),
+                    renderers.NotAvailableValue(),
+                )
+
             yield (self._levels[pid] - 1, row)
             for child_pid in self._children.get(pid, []):
                 yield from yield_processes(
@@ -161,6 +180,9 @@ class PsTree(interfaces.plugins.PluginInterface):
                 ("Wow64", bool),
                 ("CreateTime", datetime.datetime),
                 ("ExitTime", datetime.datetime),
+                ("Audit", str),
+                ("Cmd", str),
+                ("Path", str),
             ],
             self._generator(
                 filter_func=pslist.PsList.create_pid_filter(


### PR DESCRIPTION
In the original volatility framework, the `windows.pstree` plugin offers a  '--verbose' option that displays additional command line argument info of processes in the tree. The fields that are added when this option is used are `audit`, `cmd`, and `path`. `audit` refers to the ImageFileName in the SeAuditProcessCreationInfo struct of a process; and `cmd` and `path` refer to the CommandLine and ImagePathName strings, respectively, in the process parameter information.

This PR adds these additional fields to the volatility3 `windows.pstree` plugin TreeGrid to match the output expected when using the '--verbose' option of the original framework. Manual testing was performed on multiple windows memory images to verify the expected behavior. 