### PR TITLE
Linux update mm extension

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -44,8 +44,8 @@ BANG = "!"
 
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 5  # Number of changes that only add to the interface
-VERSION_PATCH = 2  # Number of changes that do not change the interface
+VERSION_MINOR = 6  # Number of changes that only add to the interface
+VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 # TODO: At version 2.0.0, remove the symbol_shift feature

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -17,7 +17,7 @@ class PsList(interfaces.plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (2, 2, 0)
+    _version = (2, 2, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -128,7 +128,7 @@ class PsList(interfaces.plugins.PluginInterface):
         else:
             # Find the vma that belongs to the main ELF of the process
             file_output = "Error outputting file"
-            for v in task.mm.get_mmap_iter():
+            for v in task.mm.get_vma_iter():
                 if v.vm_start == task.mm.start_code:
                     file_handle = elfs.Elfs.elf_dump(
                         self.context,

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -448,6 +448,7 @@ class maple_tree(objects.StructType):
 
 class mm_struct(objects.StructType):
 
+    # TODO: As of version 3.0.0 this method should be removed
     def get_mmap_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """
         Deprecated: Use either get_vma_iter() or _get_mmap_iter().
@@ -478,6 +479,7 @@ class mm_struct(objects.StructType):
             seen.add(link.vol.offset)
             link = link.vm_next
 
+    # TODO: As of version 3.0.0 this method should be removed
     def get_maple_tree_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """
         Deprecated: Use either get_vma_iter() or _get_maple_tree_iter().

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -447,12 +447,14 @@ class maple_tree(objects.StructType):
 
 
 class mm_struct(objects.StructType):
-    def get_mmap_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
-        """Returns an iterator for the mmap list member of an mm_struct."""
+    def _get_mmap_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
+        """Returns an iterator for the mmap list member of an mm_struct. Use this only if
+        required, get_vma_iter() will choose the correct _get_maple_tree_iter() or
+        _get_mmap_iter() automatically as required."""
 
         if not self.has_member("mmap"):
             raise AttributeError(
-                "get_mmap_iter called on mm_struct where no mmap member exists."
+                "_get_mmap_iter called on mm_struct where no mmap member exists."
             )
         if not self.mmap:
             return None
@@ -466,12 +468,14 @@ class mm_struct(objects.StructType):
             seen.add(link.vol.offset)
             link = link.vm_next
 
-    def get_maple_tree_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
-        """Returns an iterator for the mm_mt member of an mm_struct."""
+    def _get_maple_tree_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
+        """Returns an iterator for the mm_mt member of an mm_struct. Use this only if
+        required, get_vma_iter() will choose the correct _get_maple_tree_iter() or
+        get_mmap_iter() automatically as required."""
 
         if not self.has_member("mm_mt"):
             raise AttributeError(
-                "get_maple_tree_iter called on mm_struct where no mm_mt member exists."
+                "_get_maple_tree_iter called on mm_struct where no mm_mt member exists."
             )
         symbol_table_name = self.get_symbol_table_name()
         for vma_pointer in self.mm_mt.get_slot_iter():
@@ -487,9 +491,9 @@ class mm_struct(objects.StructType):
         """Returns an iterator for the VMAs in an mm_struct. Automatically choosing the mmap or mm_mt as required."""
 
         if self.has_member("mmap"):
-            yield from self.get_mmap_iter()
+            yield from self._get_mmap_iter()
         elif self.has_member("mm_mt"):
-            yield from self.get_maple_tree_iter()
+            yield from self._get_maple_tree_iter()
         else:
             raise AttributeError("Unable to find mmap or mm_mt in mm_struct")
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -447,6 +447,16 @@ class maple_tree(objects.StructType):
 
 
 class mm_struct(objects.StructType):
+
+    def get_mmap_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
+        """
+        Deprecated: Use either get_vma_iter() or _get_mmap_iter().
+        """
+        vollog.warning(
+            "This method has been deprecated in favour of using the get_vma_iter() method."
+        )
+        yield from self.get_vma_iter()
+
     def _get_mmap_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Returns an iterator for the mmap list member of an mm_struct. Use this only if
         required, get_vma_iter() will choose the correct _get_maple_tree_iter() or
@@ -467,6 +477,15 @@ class mm_struct(objects.StructType):
             yield link
             seen.add(link.vol.offset)
             link = link.vm_next
+
+    def get_maple_tree_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
+        """
+        Deprecated: Use either get_vma_iter() or _get_maple_tree_iter().
+        """
+        vollog.warning(
+            "This method has been deprecated in favour of using the get_vma_iter() method."
+        )
+        yield from self.get_vma_iter()
 
     def _get_maple_tree_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Returns an iterator for the mm_mt member of an mm_struct. Use this only if


### PR DESCRIPTION
Hello 👋 

@gcmoreira pointed out that the current linux pslist plugin used `get_mmap_iter()` when dumping out elfs. This would fail on kernels that use the maple tree structure instead. (First added here https://github.com/volatilityfoundation/volatility3/pull/928)

This PR updates the pslist plugin to use `get_vma_iter` instead. 

It also changes `get_mmap_iter`  and `get_maple_tree_iter` to `_get_mmap_iter` and `_get_maple_tree_iter` to make it more obvious that they should only be directly used if you know what you're doing. 

Thanks!