### PR TITLE
Windows: Add --base to modscan and modules

### DIFF
--- a/volatility3/framework/plugins/windows/modscan.py
+++ b/volatility3/framework/plugins/windows/modscan.py
@@ -45,7 +45,7 @@ class ModScan(interfaces.plugins.PluginInterface):
             ),
             requirements.IntRequirement(
                 name="base",
-                description="Extract a single module with BASE address(hex)",
+                description="Extract a single module with BASE address",
                 optional=True,
             ),
         ]

--- a/volatility3/framework/plugins/windows/modscan.py
+++ b/volatility3/framework/plugins/windows/modscan.py
@@ -190,7 +190,9 @@ class ModScan(interfaces.plugins.PluginInterface):
                 FullDllName = ""
 
             file_output = "Disabled"
-            if self.config["dump"] or (self.config["base"] and self.config["base"] == mod.DllBase):
+            if self.config["dump"] or (
+                self.config["base"] and self.config["base"] == mod.DllBase
+            ):
                 session_layer_name = self.find_session_layer(
                     self.context, session_layers, mod.DllBase
                 )

--- a/volatility3/framework/plugins/windows/modscan.py
+++ b/volatility3/framework/plugins/windows/modscan.py
@@ -43,6 +43,11 @@ class ModScan(interfaces.plugins.PluginInterface):
                 default=False,
                 optional=True,
             ),
+            requirements.IntRequirement(
+                name="base",
+                description="Extract a single module with BASE address(hex)",
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -185,7 +190,7 @@ class ModScan(interfaces.plugins.PluginInterface):
                 FullDllName = ""
 
             file_output = "Disabled"
-            if self.config["dump"]:
+            if self.config["dump"] or (self.config["base"] and self.config["base"] == mod.DllBase):
                 session_layer_name = self.find_session_layer(
                     self.context, session_layers, mod.DllBase
                 )
@@ -215,6 +220,9 @@ class ModScan(interfaces.plugins.PluginInterface):
             )
 
     def run(self):
+        if self.config["dump"] and self.config["base"]:
+            raise ValueError("--dump cannot be used with --base")
+
         return renderers.TreeGrid(
             [
                 ("Offset", format_hints.Hex),

--- a/volatility3/framework/plugins/windows/modules.py
+++ b/volatility3/framework/plugins/windows/modules.py
@@ -78,7 +78,9 @@ class Modules(interfaces.plugins.PluginInterface):
                 continue
 
             file_output = "Disabled"
-            if self.config["dump"] or (self.config["base"] and self.config["base"] == mod.DllBase):
+            if self.config["dump"] or (
+                self.config["base"] and self.config["base"] == mod.DllBase
+            ):
                 file_handle = dlllist.DllList.dump_pe(
                     self.context, pe_table_name, mod, self.open
                 )
@@ -227,7 +229,7 @@ class Modules(interfaces.plugins.PluginInterface):
     def run(self):
         if self.config["dump"] and self.config["base"]:
             raise ValueError("--dump cannot be used with --base")
-        
+
         return renderers.TreeGrid(
             [
                 ("Offset", format_hints.Hex),

--- a/volatility3/framework/plugins/windows/modules.py
+++ b/volatility3/framework/plugins/windows/modules.py
@@ -44,7 +44,7 @@ class Modules(interfaces.plugins.PluginInterface):
             ),
             requirements.IntRequirement(
                 name="base",
-                description="Extract a single module with BASE address(hex)",
+                description="Extract a single module with BASE address",
                 optional=True,
             ),
             requirements.StringRequirement(

--- a/volatility3/framework/plugins/windows/modules.py
+++ b/volatility3/framework/plugins/windows/modules.py
@@ -42,6 +42,11 @@ class Modules(interfaces.plugins.PluginInterface):
                 default=False,
                 optional=True,
             ),
+            requirements.IntRequirement(
+                name="base",
+                description="Extract a single module with BASE address(hex)",
+                optional=True,
+            ),
             requirements.StringRequirement(
                 name="name",
                 description="module name/sub string",
@@ -73,7 +78,7 @@ class Modules(interfaces.plugins.PluginInterface):
                 continue
 
             file_output = "Disabled"
-            if self.config["dump"]:
+            if self.config["dump"] or (self.config["base"] and self.config["base"] == mod.DllBase):
                 file_handle = dlllist.DllList.dump_pe(
                     self.context, pe_table_name, mod, self.open
                 )
@@ -220,6 +225,9 @@ class Modules(interfaces.plugins.PluginInterface):
             yield mod
 
     def run(self):
+        if self.config["dump"] and self.config["base"]:
+            raise ValueError("--dump cannot be used with --base")
+        
         return renderers.TreeGrid(
             [
                 ("Offset", format_hints.Hex),


### PR DESCRIPTION
In volatility2, the windows.moddump plugin allows you to extract a single module using a base address.
This PR adds the same functionality to volatility3 in the windows.modscan and windows.modules plugins.

The base address is passed in using --base=BASE where the module with base address BASE will be extracted.
The matching volatility2 functionality can be found here:
https://github.com/volatilityfoundation/volatility/blob/2.6.1/volatility/plugins/moddump.py#L71

Manual testing was performed on windows memory images across different windows versions to verify the expected output.