### PR TITLE
Linux: psscan tiny update so that  memory_layer_name is reused

### DIFF
--- a/volatility3/framework/plugins/linux/psscan.py
+++ b/volatility3/framework/plugins/linux/psscan.py
@@ -28,7 +28,7 @@ class PsScan(interfaces.plugins.PluginInterface):
     """Scans for processes present in a particular linux image."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -139,7 +139,7 @@ class PsScan(interfaces.plugins.PluginInterface):
                 kernel_layer_name, f"Layer {kernel_layer_name} has no dependencies"
             )
         memory_layer_name = kernel_layer.dependencies[0]
-        memory_layer = context.layers[kernel_layer.dependencies[0]]
+        memory_layer = context.layers[memory_layer_name]
 
         # scan the memory_layer for these needles
         for address, _ in memory_layer.scan(


### PR DESCRIPTION
Hello - almost not worth anyone's time but I saw this today and felt like I needed to change it. 

In psscan when getting the memory layer it goes via `kernel_layer.dependencies[0]` twice. This is okay enough while the two lines are next to each other - but it might cause a mismatch in the future when it gets split up and multiple "memory_layers" are supported (e.g. ram + swap etc) and we forget to keep them in sync. It made sense to me to just reuse  `memory_layer_name`.

Thanks! 