### PR TITLE
Documentation: Fix up syntax errors involving * character

### DIFF
--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -60,7 +60,7 @@ class FileHandlerInterface(io.RawIOBase):
     @staticmethod
     def sanitize_filename(filename: str) -> str:
         """Sanititizes the filename to ensure only a specific whitelist of characters is allowed through"""
-        allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.- ()[]\{\}!$%^:#~?<>,|"
+        allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.- ()[]{}!$%^:#~?<>,|"
         result = ""
         for char in filename:
             if char in allowed:

--- a/volatility3/framework/plugins/linux/kmsg.py
+++ b/volatility3/framework/plugins/linux/kmsg.py
@@ -198,7 +198,9 @@ class ABCKmsg(ABC):
 class Kmsg_pre_3_5(ABCKmsg):
     """The kernel ring buffer (log_buf) is a char array that sequentially stores
     log lines, each separated by newline (LF) characters. i.e:
-        <6>[ 9565.250411] line1!\n<6>[ 9565.250412] line2\n...
+
+        <6>[ 9565.250411] line1!\\n<6>[ 9565.250412] line2\\n...
+
     """
 
     @classmethod

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -83,11 +83,11 @@ class PsList(interfaces.plugins.PluginInterface):
         cls, task: interfaces.objects.ObjectInterface, decorate_comm: bool = False
     ) -> Tuple[int, int, int, str]:
         """Extract the fields needed for the final output
+
         Args:
             task: A task object from where to get the fields.
-            decorate_comm: If True, it decorates the comm string of
-                            - User threads: in curly brackets,
-                            - Kernel threads: in square brackets
+            decorate_comm: If True, it decorates the comm string of user threads in curly brackets,
+                           and of Kernel threads in square brackets.
                            Defaults to False.
         Returns:
             A tuple with the fields to show in the plugin output.

--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -83,7 +83,7 @@ class SockHandlers(interfaces.configuration.VersionableInterface):
             sock: Kernel generic `sock` object
 
         Returns a tuple with:
-            sock: The respective kernel's \*_sock object for that socket family
+            sock: The respective kernel's \\*_sock object for that socket family
             sock_stat: A tuple with the source and destination (address and port) along with its state string
             socket_filter: A dictionary with information about the socket filter
         """
@@ -501,7 +501,7 @@ class Sockstat(plugins.PluginInterface):
             family: Socket family string (AF_UNIX, AF_INET, etc)
             sock_type: Socket type string (STREAM, DGRAM, etc)
             protocol: Protocol string (UDP, TCP, etc)
-            sock_fields: A tuple with the \*_sock object, the sock stats and the extended info dictionary
+            sock_fields: A tuple with the \\*_sock object, the sock stats and the extended info dictionary
         """
         vmlinux = context.modules[symbol_table]
 

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -38,7 +38,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
         # Yara Rule to scan for MFT Header Signatures
         rules = yarascan.YaraScan.process_yara_options(
-            {"yara_rules": "/FILE0|FILE\*|BAAD/"}
+            {"yara_rules": "/FILE0|FILE\\*|BAAD/"}
         )
 
         # Read in the Symbol File
@@ -197,7 +197,7 @@ class ADS(interfaces.plugins.PluginInterface):
 
         # Yara Rule to scan for MFT Header Signatures
         rules = yarascan.YaraScan.process_yara_options(
-            {"yara_rules": "/FILE0|FILE\*|BAAD/"}
+            {"yara_rules": "/FILE0|FILE\\*|BAAD/"}
         )
 
         # Read in the Symbol File

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1137,17 +1137,17 @@ class vfsmount(objects.StructType):
         """Helper to make sure it is comparing two pointers to 'vfsmount'.
 
         Depending on the kernel version, the calling object (self) could be
-        a 'vfsmount \*' (<3.3.8) or a 'vfsmount' (>=3.3.8). This way we trust
+        a 'vfsmount \\*' (<3.3.8) or a 'vfsmount' (>=3.3.8). This way we trust
         in the framework "auto" dereferencing ability to assure that when we
         reach this point 'self' will be a 'vfsmount' already and self.vol.offset
-        a 'vfsmount \*' and not a 'vfsmount \*\*'. The argument must be a 'vfsmount \*'.
+        a 'vfsmount \\*' and not a 'vfsmount \\*\\*'. The argument must be a 'vfsmount \\*'.
         Typically, it's called from do_get_path().
 
         Args:
-            vfsmount_ptr (vfsmount \*): A pointer to a 'vfsmount'
+            vfsmount_ptr (vfsmount *): A pointer to a 'vfsmount'
 
         Raises:
-            exceptions.VolatilityException: If vfsmount_ptr is not a 'vfsmount \*'
+            exceptions.VolatilityException: If vfsmount_ptr is not a 'vfsmount \\*'
 
         Returns:
             bool: 'True' if the given argument points to the the same 'vfsmount'


### PR DESCRIPTION
Fixes #1105.

Changes single escaped star characters to double literal backslashes (so that when later interpreted they come out as actual *s in the documentation).  Also fix up some brackets with a similar problem.  All appears to work fine with python 3.11 and python 3.12.  Also included some miscellaneous documentation fixes.

Unless someone shouts, I'll probably commit this in a couple of days.