### PR TITLE
macOS dmesg plugin support

### DIFF
--- a/volatility3/framework/plugins/mac/dmesg.py
+++ b/volatility3/framework/plugins/mac/dmesg.py
@@ -3,7 +3,7 @@
 #
 
 import logging
-from volatility3.framework import interfaces, renderers
+from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 
@@ -40,7 +40,7 @@ class Dmesg(interfaces.plugins.PluginInterface):
 
         kernel = context.modules[kernel_module_name]
         if not kernel.has_symbol("msgbufp"):
-            raise TypeError(
+            raise exceptions.SymbolError(
                 'The provided symbol table does not include the "msgbufp" symbol. This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt.'
             )
 

--- a/volatility3/framework/plugins/mac/dmesg.py
+++ b/volatility3/framework/plugins/mac/dmesg.py
@@ -46,7 +46,7 @@ class Dmesg(interfaces.plugins.PluginInterface):
 
         msgbufp = kernel.object_from_symbol(symbol_name="msgbufp")
         msg_size = msgbufp.msg_size  # max buffer size
-        msg_bufx = msgbufp.msg_bufx  # write pointer
+        msg_bufx = msgbufp.msg_bufx  # write index of the msg_bufc circular buffer
         msg_bufc = msgbufp.msg_bufc
         # msg_bufc is circular, meaning that if its size exceeds msg_size,
         # msg_bufx will point to the beginning of the buffer and start overwriting.

--- a/volatility3/framework/plugins/mac/dmesg.py
+++ b/volatility3/framework/plugins/mac/dmesg.py
@@ -1,0 +1,79 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects import utility
+
+vollog = logging.getLogger(__name__)
+
+
+class Dmesg(interfaces.plugins.PluginInterface):
+    """Prints the kernel log buffer."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Kernel module for the OS",
+                architectures=["Intel32", "Intel64"],
+            ),
+        ]
+
+    @classmethod
+    def get_kernel_log_buffer(
+        cls, context: interfaces.context.ContextInterface, kernel_module_name: str
+    ):
+        """
+        Online documentation :
+            - https://github.com/apple-open-source/macos/blob/master/xnu/bsd/sys/msgbuf.h
+            - https://github.com/apple-open-source/macos/blob/ea4cd5a06831aca49e33df829d2976d6de5316ec/xnu/bsd/kern/subr_log.c#L751
+        Volatility 2 plugin :
+            - https://github.com/volatilityfoundation/volatility/blob/master/volatility/plugins/mac/dmesg.py
+        """
+
+        kernel = context.modules[kernel_module_name]
+        if not kernel.has_symbol("msgbufp"):
+            vollog.error(
+                'The provided symbol table does not include the "msgbufp" symbol. This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt.'
+            )
+            return []
+
+        msgbufp_ptr = kernel.object_from_symbol(symbol_name="msgbufp")
+        msgbufp = msgbufp_ptr.dereference()
+        msg_size = msgbufp.msg_size  # max buffer size
+        msg_bufx = msgbufp.msg_bufx  # write pointer
+        msg_bufc = msgbufp.msg_bufc
+        # msg_bufc is circular, meaning that if its size exceeds msg_size,
+        # msg_bufx will point to the beginning of the buffer and start overwriting.
+        msg_bufc_data: str = utility.pointer_to_string(msg_bufc, msg_size)
+        # Avoid OOB reads
+        msg_bufx = msg_bufx if msg_bufx <= msg_size else 0
+        # We directly take into account the case where the write buffer did a loop,
+        # as older messages will start at msg_bufx offset (not overwritten yet).
+        dmesg = msg_bufc_data[msg_bufx:]
+        dmesg += msg_bufc_data[:msg_bufx]
+
+        # Yield each line
+        for dmesg_line in dmesg.splitlines():
+            yield (dmesg_line.strip(),)
+
+    def _generator(self):
+        for value in self.get_kernel_log_buffer(
+            context=self.context, kernel_module_name=self.config["kernel"]
+        ):
+            yield (0, value)
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("line", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/mac/dmesg.py
+++ b/volatility3/framework/plugins/mac/dmesg.py
@@ -61,7 +61,7 @@ class Dmesg(interfaces.plugins.PluginInterface):
 
         # Yield each line
         for dmesg_line in dmesg.splitlines():
-            yield (dmesg_line.strip(),)
+            yield (dmesg_line,)
 
     def _generator(self):
         for value in self.get_kernel_log_buffer(

--- a/volatility3/framework/plugins/mac/dmesg.py
+++ b/volatility3/framework/plugins/mac/dmesg.py
@@ -41,7 +41,9 @@ class Dmesg(interfaces.plugins.PluginInterface):
         kernel = context.modules[kernel_module_name]
         if not kernel.has_symbol("msgbufp"):
             raise exceptions.SymbolError(
-                'The provided symbol table does not include the "msgbufp" symbol. This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt.'
+                "msgbufp",
+                kernel.symbol_table_name,
+                'The provided symbol table does not include the "msgbufp" symbol. This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt.',
             )
 
         msgbufp = kernel.object_from_symbol(symbol_name="msgbufp")

--- a/volatility3/framework/plugins/mac/dmesg.py
+++ b/volatility3/framework/plugins/mac/dmesg.py
@@ -40,10 +40,9 @@ class Dmesg(interfaces.plugins.PluginInterface):
 
         kernel = context.modules[kernel_module_name]
         if not kernel.has_symbol("msgbufp"):
-            vollog.error(
+            raise TypeError(
                 'The provided symbol table does not include the "msgbufp" symbol. This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt.'
             )
-            return []
 
         msgbufp_ptr = kernel.object_from_symbol(symbol_name="msgbufp")
         msgbufp = msgbufp_ptr.dereference()

--- a/volatility3/framework/plugins/mac/dmesg.py
+++ b/volatility3/framework/plugins/mac/dmesg.py
@@ -44,8 +44,7 @@ class Dmesg(interfaces.plugins.PluginInterface):
                 'The provided symbol table does not include the "msgbufp" symbol. This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt.'
             )
 
-        msgbufp_ptr = kernel.object_from_symbol(symbol_name="msgbufp")
-        msgbufp = msgbufp_ptr.dereference()
+        msgbufp = kernel.object_from_symbol(symbol_name="msgbufp")
         msg_size = msgbufp.msg_size  # max buffer size
         msg_bufx = msgbufp.msg_bufx  # write pointer
         msg_bufc = msgbufp.msg_bufc


### PR DESCRIPTION
Hello ! 

This PR adds a macOS `dmesg` plugin to the framework. It is inspired from the corresponding Volatility2 plugin. 
As opposed to the Linux kernel log buffer, the macOS one does not contain detailed informations (timestamp, log level etc.). The plugin does not do line parsing, as the format does not seem consistent.

<details>
  <summary>Sample output</summary>

```sh
$ python3 vol.py -r pretty -f mac-sample-2.bin mac.dmesg
Volatility 3 Framework 2.6.1
  |                                                                                                                                                                                                                                                                 line
* |                                                                                                                                                                                                                                    Longterm timer threshold: 1000 ms
* |                                                                                                                                                                                                                                                   PMAP: PCID enabled
* |                                                                                                                                                                                                                     PMAP: Supervisor Mode Execute Protection enabled
* |                                                                                                                                                                    Darwin Kernel Version 13.2.0: Thu Apr 17 23:03:13 PDT 2014; root:xnu-2422.100.13~1/RELEASE_X86_64
* |                                                                                                                                                                                                           vm_page_bootstrap: 63335 free pages and 198809 wired pages
* |                                                                                                                                                         kext submap [0xffffff7f807a9000 - 0xffffff8000000000], kernel text [0xffffff8000200000 - 0xffffff80007a9000]
* |                                                                                                                                                                                                                                          zone leak detection enabled
* |                                                                                                                                                                                                                                            "vm_compressor_mode" is 4
* |                                                                                                                                                                                                                             standard timeslicing quantum is 10000 us
* |                                                                                                                                                                                                                               standard background quantum is 2500 us
* |                                                                                                                                                                                                                                             mig_table_max_displ = 74
* |                                                                                                                                                                                                                    AppleACPICPU: ProcessorId=0 LocalApicId=0 Enabled
* |                                                                                                                                                                                                                    AppleACPICPU: ProcessorId=1 LocalApicId=2 Enabled
* |                                                                                                                                                                                                                              calling mpo_policy_init for TMSafetyNet
* |                                                                                                                                                                                                    Security policy loaded: Safety net for Time Machine (TMSafetyNet)
* |                                                                                                                                                                                                                                  calling mpo_policy_init for Sandbox
* |                                                                                                                                                                                                            Security policy loaded: Seatbelt sandbox policy (Sandbox)
* |                                                                                                                                                                                                                               calling mpo_policy_init for Quarantine
* |                                                                                                                                                                                                               Security policy loaded: Quarantine policy (Quarantine)
* |                                                                                                                                                                                                                           Copyright (c) 1982, 1986, 1989, 1991, 1993
* |                                                                                                                                                                                                    The Regents of the University of California. All rights reserved.
* |                                                                                                                                                                                                                                                                     
* |                                                                                                                                                                                                                               MAC Framework successfully initialized
* |                                                                                                                                                                                                         using 5242 buffer headers and 4669 cluster IO buffer headers
* |                                                                                                                                                                                                                 AppleKeyStore starting (BUILT: Apr 17 2014 23:36:27)
* |                                                                                                                                                                                                                                   IOAPIC: Version 0x11 Vectors 64:87
* |                                                                                                                                                                                                                                             ACPI: sleep states S4 S5
* |                                                                                                                                                                             pci (build 23:24:05 Apr 17 2014), flags 0x63008, pfm64 (40 cpu) 0xff80000000, 0x80000000
* |                                                                                                                                                                                                                                          [ PCI configuration begin ]
* |                                                                                                                                                                                                                       mcache: 2 CPU(s), 64 bytes CPU cache line size
* |                                                                                                                                                                                                                  mbinit: done [64 MB total pool size, (42/21) split]
* |                                                                                                                                                                                                           Pthread support ABORTS when sync kernel primitives misused
* |                                                                                                                                                                                             rooting via boot-uuid from /chosen: 0A81F3B1-51D9-3335-B3E3-169C3640360D
* |                                                                                                        Waiting on <dict ID="0"><key>IOProviderClass</key><string ID="1">IOResources</string><key>IOResourceMatch</key><string ID="2">boot-uuid-media</string></dict>
* |                                                                                                                                                                                                                      com.apple.AppleFSCompressionTypeZlib kmod start
* |                                                                                                                                                                                                                  com.apple.AppleFSCompressionTypeDataless kmod start
* |                                                                                                                                                                                                                                      console relocated to 0xf0000000
* |                                                                                                                                                                                                                    [ PCI configuration end, bridges 35, devices 11 ]
* |                                                                                                                                                                                                                  com.apple.AppleFSCompressionTypeZlib load succeeded
* |                                                                                                                                                                                                              com.apple.AppleFSCompressionTypeDataless load succeeded
* |                                                                                                                                                                      USBF:    0.190    AppleUSBEHCI::CheckSleepCapability - controller will be unloaded across sleep
* |                                                                                                                                                                      USBF:    0.196    AppleUSBEHCI::CheckSleepCapability - controller will be unloaded across sleep
* |                                                                                                                                                                                     Intel82574L::start - Built Apr 17 2014 23:17:44 -- running on device at b3 d0 f0
* | Got boot device = IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/P2P0@11/IOPP/S5F0@4/AppleAHCI/PRT0@0/IOAHCIDevice@0/AppleAHCIDiskDriver/IOAHCIBlockStorageDevice/IOBlockStorageDriver/VMware Virtual SATA Hard Drive Media/IOGUIDPartitionScheme/Untitled@2
* |                                                                                                                                                                                                                                  BSD root: disk0s2, major 1, minor 2
* |                                                                                                                                                                                                                      hfs: mounted Macintosh HD on device root_device
* |                                                                                                                                                                                                      0x1face000, 0x00000000  Intel82574L::setLinkStatus - not active
* |                                                                                                                         Loaded @ 0xffffff7fadd7a91e: Info 0xffffff7fadd815a0 Name com.vmware.kext.VMwareGfx Version 0168.83.56 build-1688356 at Mar 21 2014 16:25:14
* |                                                                                                                                                                                                                    svga: Start: FB size=0x300000, FIFO size=0x200000
* |                                                                                                                                                                                                                     svga: Start: host_bpp=32, bpp=32, num_displays=2
* |                                                                                                                                                                                                            fb: start: maxWidth 5120 maxHeight 3200 vramSize 16777216
* |                                                                                                                                                                                                                        fb: setDisplayMode: (1) wxh=1024x768, 32 4096
* |                                                                                                                                                                                                                             svga: SetMode: mode w,h=1024, 768 bpp=32
* |                                                                                                                                                                                                                                            svga: SetMode: pitch=4096
* |                                                                                                                                                                                                                         fb: setDisplayMode: Display ID=1, Depth ID=0
* |                                                                                                                                                                                                                 fb: setDisplayMode: wxh=1024x768, bpp=32, pitch=4096
* |                                                                                                                                                                                                                                  gfx: UpdateTraces: Enabling traces.
* |                                                                                                                                                                                                                                                                     
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key $Num (kSMCKeyNotFound)
* |                                                                                                                                                                                             SMC::smcReadKeyAction ERROR $Num kSMCKeyNotFound(0x84) fKeyHashTable=0x0
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key LsNM (kSMCKeyNotFound)
* |                                                                                                                                                                                             SMC::smcReadKeyAction ERROR LsNM kSMCKeyNotFound(0x84) fKeyHashTable=0x0
* |                                                                                                                                                                                             SMC::smcGetLightshowVers ERROR: smcReadKey LsNM failed (kSMCKeyNotFound)
* |                                                                                                                                                                                  SMC::smcPublishLightshowVersion ERROR: smcGetLightshowVers failed (kSMCKeyNotFound)
* |                                                                                                                                                                                        SMC::smcInitHelper ERROR: smcPublishLightshowVersion failed (kSMCKeyNotFound)
* |                                                                                                                                                                                                                                           Previous Shutdown Cause: 0
* |                                                                                                                                                                                            SMC::smcInitHelper ERROR: MMIO regMap == NULL - fall back to old SMC mode
* |                                                                                                                                                                        SMC::smcGetKeyInfoAction ERROR WKTP kSMCSpuriousData(0x81) fKeyHashTable=0x0xffffff8032f5e000
* |                                                                                                                                                                                                          Apple16X50ACPI1: Identified Serial Port on ACPI Device=COMA
* |                                                                                                                                                                                                          Apple16X50ACPI2: Identified Serial Port on ACPI Device=COMB
* |                                                                                                                                                                                                    Apple16X50UARTSync1: Detected 16550AF/C/CF FIFO=16 MaxBaud=115200
* |                                                                                                                                                                                                    Apple16X50UARTSync2: Detected 16550AF/C/CF FIFO=16 MaxBaud=115200
* |                                                                                                                                                                        SMC::smcGetKeyInfoAction ERROR WKTP kSMCSpuriousData(0x81) fKeyHashTable=0x0xffffff8032f5e000
* |                                                                                                                                                                                                               flow_divert_kctl_disconnect (0): disconnecting group 1
* |                                                                                                                                                                                                                                                 Waiting for DSMOS...
* |                                                                                                                                                                                                      0x1face000, 0x00000000  Intel82574L::setLinkStatus - not active
* |                                                                                                                                                                                                                                                                 init
* |                                                                                                                                                                                                                                                                probe
* |                                                                                                                                                                                                                                                                start
* |                                                                                                                                                                                                                                                    DSMOS has arrived
* |                                                                                                                                                                                                                       [IOBluetoothHCIController][start] -- completed
* |                                                                                                                                                                                                                    gfx: powerStateDidChangeTo: The display is awake.
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PC0R (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PM0C (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PO0R (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PZ0F (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PZ0E (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PZ1F (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PZ1E (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PSTR (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key PDTR (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key MSAf (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key MSAj (kSMCKeyNotFound)
* |                                                                                                                                                                                  SMC::smcReadKeyAction ERROR: smcReadData8 failed for key MSPA (kSMCKeySizeMismatch)
* |                                                                                                                                                                        SMC::smcReadKeyAction ERROR MSPA kSMCKeySizeMismatch(0x87) fKeyHashTable=0x0xffffff8032f5e000
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key MSHT (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key DM0T (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key WOr0 (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key WOw0 (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key SBFL (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key TCXC (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key Ts0S (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key TH0F (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key BIMX (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key ACIC (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key MSMD (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key MSMN (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key MSMF (kSMCKeyNotFound)
* |                                                                                                                                                                                      SMC::smcReadKeyAction ERROR: smcReadData8 failed for key DICT (kSMCKeyNotFound)
* |                                                                                                                                               Ethernet [Intel82574L]: Link up on en0, 1-Gigabit, Full-duplex, No flow-control, Debug [796d,ac08,01e1,0200,41e1,7c00]
* |                                                                                                                                                                                                          0x1face000, 0x0000000a  Intel82574L::setLinkStatus - active
* |                                                                                                                                                                                                                                              VM Swap Subsystem is ON
* |                                                                                                                                                             ACPI_SMC_PlatformPlugin::start - waitForService(resourceMatching(AppleIntelCPUPowerManagement) timed out
* |                                                                                                                                                                                      WARNING: IOPlatformPluginUtil : getCPUIDInfo: this is an unknown CPU model 0x3a
* |                                                                                                                                                                                                                 -- power management may be incomplete or unsupported
* |                                                                                                                             memctl: Loaded @ 0xffffff7faedaa1d4: Info 0xffffff7faedae060 Name com.vmware.kext.vmmemctl Version 0168.83.56 built Mar 21 2014 16:25:10
* |                                                                                                                                                                                                                                              memctl: Opening balloon
* |                                                                                                                                                                                                                                  memctl: Instrumenting bug 151304...
* |                                                                                                                                                                                                                                                 memctl: offset 0: 80
* |                                                                                                                                                                                                                                                 memctl: offset 1: 16
* |                                                                                                                                                                                                                                                 memctl: offset 2: 56
* |                                                                                                                                                                                                                                                 memctl: offset 3: 64
* |                                                                                                                                                                                                                                                 memctl: offset 4: 76
* |                                                                                                                                                                                                                                        memctl: Timer thread started.
* |                                                                                                                                                                                                                        Sound assertion in AppleHDAEngine at line 581
* |                                                                                                                                                                     **** [IOBluetoothHostControllerUSBTransport][start] -- completed -- result = TRUE -- 0x3800 ****
* |                                                                                                                    [IOBluetoothHCIController][staticBluetoothHCIControllerTransportShowsUp] -- Received Bluetooth Controller register service notification -- 0x3800
* |                                                                                                                                                                                                                        fb: setDisplayMode: (1) wxh=1024x768, 32 4096
* |                                                                                                                                                                                                                             svga: SetMode: mode w,h=1024, 768 bpp=32
* |                                                                                                                                                                                                                                            svga: SetMode: pitch=4096
* |                                                                                                                                                                                                                         fb: setDisplayMode: Display ID=1, Depth ID=0
* |                                                                                                                                                                                                                 fb: setDisplayMode: wxh=1024x768, bpp=32, pitch=4096
* |                                                                                                        **** [IOBluetoothHostControllerUSBTransport][configurePM] -- ERROR -- waited 30 seconds and still did not get the commandWakeup() notification -- 0x3800 ****
* |                                                                                                                                                                                                              Bluetooth: Adaptive Frequency Hopping is not supported.
* |                                                                                                                                                                                                   [IOBluetoothHCIController::setConfigState] calling registerService
* |                                                                                                       **** [IOBluetoothHCIController][protectedBluetoothHCIControllerTransportShowsUp] -- Connected to the transport successfully -- 0x4a80 -- 0x7800 -- 0x3800 ****
* |                                                                                                                                                                                                                                                                     
* |                                                                                                                                                                                                                                  AppleKeyStore:Sending lock change 0     
```
</details>