### PR TITLE
CLI : pass integers as 0x hexadecimal format in ListRequirement

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -827,7 +827,11 @@ class CommandLine:
                 requirement,
                 volatility3.framework.configuration.requirements.ListRequirement,
             ):
-                additional["type"] = requirement.element_type
+                # Allow a list of integers, specified with the convenient 0x hexadecimal format
+                if requirement.element_type == int:
+                    additional["type"] = lambda x: int(x, 0)
+                else:
+                    additional["type"] = requirement.element_type
                 nargs = "*" if requirement.optional else "+"
                 additional["nargs"] = nargs
             elif isinstance(


### PR DESCRIPTION
Hi,

This PR allows to pass integers in a `ListRequirement` with the "0x" hexadecimal format. Example : 

From : 
```sh 
python3 vol.py -f linux-sample-1.bin linux.proc --pid 8600 --dump --address 140632452800512 140632438251520
```
To : 
```sh
python3 vol.py -f linux-sample-1.bin linux.proc --pid 8600 --dump --address 0x7fe78b64a000 0x7fe78a86a000
```