### PR TITLE
CLI: Reorder logging extra levels

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -265,16 +265,7 @@ class CommandLine:
             rootlog.addHandler(file_logger)
             vollog.info("Logging started")
 
-        for level, level_value in enumerate(
-            [
-                constants.LOGLEVEL_V,
-                constants.LOGLEVEL_VV,
-                constants.LOGLEVEL_VVV,
-                constants.LOGLEVEL_VVVV,
-            ]
-        ):
-            logging.addLevelName(level_value, f"DETAIL {level+1}")
-
+        self.order_extra_verbose_levels()
         if partial_args.verbosity < 3:
             if partial_args.verbosity < 1:
                 sys.tracebacklimit = None
@@ -705,6 +696,17 @@ class CommandLine:
                         config_path, requirement.name
                     )
                     context.config[extended_path] = value
+
+    def order_extra_verbose_levels(self):
+        for level, level_value in enumerate(
+            [
+                constants.LOGLEVEL_V,
+                constants.LOGLEVEL_VV,
+                constants.LOGLEVEL_VVV,
+                constants.LOGLEVEL_VVVV,
+            ]
+        ):
+            logging.addLevelName(level_value, f"DETAIL {level+1}")
 
     def file_handler_class_factory(self, direct=True):
         output_dir = self.output_dir

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -278,9 +278,9 @@ class CommandLine:
         if partial_args.verbosity < 3:
             if partial_args.verbosity < 1:
                 sys.tracebacklimit = None
-            console.setLevel(30 - (partial_args.verbosity * 10))
+            console.setLevel(logging.WARNING - (partial_args.verbosity * 10))
         else:
-            console.setLevel(10 - (partial_args.verbosity - 2))
+            console.setLevel(logging.DEBUG - (partial_args.verbosity - 2))
 
         for level, msg in delayed_logs:
             vollog.log(level, msg)

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -264,6 +264,17 @@ class CommandLine:
             file_logger.setFormatter(file_formatter)
             rootlog.addHandler(file_logger)
             vollog.info("Logging started")
+
+        for level, level_value in enumerate(
+            [
+                constants.LOGLEVEL_V,
+                constants.LOGLEVEL_VV,
+                constants.LOGLEVEL_VVV,
+                constants.LOGLEVEL_VVVV,
+            ]
+        ):
+            logging.addLevelName(level_value, f"DETAIL {level+1}")
+
         if partial_args.verbosity < 3:
             if partial_args.verbosity < 1:
                 sys.tracebacklimit = None

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -197,6 +197,7 @@ class VolShell(cli.CommandLine):
             vollog.addHandler(file_logger)
             vollog.info("Logging started")
 
+        self.order_extra_verbose_levels()
         if partial_args.verbosity < 3:
             console.setLevel(logging.WARNING - (partial_args.verbosity * 10))
         else:

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -198,9 +198,9 @@ class VolShell(cli.CommandLine):
             vollog.info("Logging started")
 
         if partial_args.verbosity < 3:
-            console.setLevel(30 - (partial_args.verbosity * 10))
+            console.setLevel(logging.WARNING - (partial_args.verbosity * 10))
         else:
-            console.setLevel(10 - (partial_args.verbosity - 2))
+            console.setLevel(logging.DEBUG - (partial_args.verbosity - 2))
 
         for level, msg in delayed_logs:
             vollog.log(level, msg)


### PR DESCRIPTION
Hi,

This PR adds custom logging headers for extra verbose levels (`-vvv` to `-vvvvvvv`), and reorders them incrementally :
_Level 9_ becomes _DETAIL 1_
_Level 8_ becomes _DETAIL 2_
_Level 7_ becomes _DETAIL 3_
_Level 6_ becomes _DETAIL 4_

 Example : 

```
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
DETAIL 4 volatility3.framework.automagic.mac: Mac find_aslr returned: 0
DETAIL 3 volatility3.framework.automagic.mac: Invalid kalsr_shift found at offset: 397252468
```

I also changed two hardcoded external constants to the appropriate `logging` constants.