### PR TITLE
Symbol Tables: additional APIs

### DIFF
--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -292,6 +292,13 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
     def has_enumeration(self, name: str) -> bool:
         """Determines whether an enumeration is present in the module's symbol table."""
 
+    def update_symbol_address(
+        self, name: str, updated_address: int
+    ) -> "interfaces.symbols.SymbolInterface":
+        """Updates the symbol's address, given its name.
+        Invalidates any existing cache entry for this specific symbol.
+        """
+
     def symbols(self) -> List:
         """Lists the symbols contained in the symbol table for this module"""
 

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -302,6 +302,9 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
     def symbols(self) -> List:
         """Lists the symbols contained in the symbol table for this module"""
 
+    def symbols_as_dict(self) -> Dict:
+        """Returns a dict of the symbols names and their corresponding SymbolInterface."""
+
     def get_symbols_by_absolute_location(self, offset: int, size: int = 0) -> List[str]:
         """Returns the symbols within table_name (or this module if not specified) that live at the specified
         absolute offset provided."""

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -121,7 +121,7 @@ class BaseSymbolTableInterface:
         )
 
     @property
-    def symbols_as_dict(self) -> Dict[str, interfaces.symbols.SymbolInterface]:
+    def symbols_as_dict(self) -> Dict[str, SymbolInterface]:
         """Returns a dict of the symbols names and their corresponding SymbolInterface."""
         raise NotImplementedError(
             "Abstract property symbols_as_dict not implemented by subclass."

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -259,6 +259,16 @@ class BaseSymbolTableInterface:
         """Clears the symbol cache of this symbol table."""
         pass
 
+    # ## Functions to manipulate symbols
+    def update_symbol_address(self, name: str, updated_address: int) -> SymbolInterface:
+        """Updates the symbol's address, given its name.
+        Invalidates any existing cache entry for this specific symbol.
+        If the symbol isn't found, it raises a SymbolError exception.
+        """
+        raise NotImplementedError(
+            "Abstract property update_symbol_address not implemented by subclass."
+        )
+
 
 class SymbolSpaceInterface(collections.abc.Mapping):
     """An interface for the container that holds all the symbol-containing

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -121,6 +121,13 @@ class BaseSymbolTableInterface:
         )
 
     @property
+    def symbols_as_dict(self) -> Dict[str, int]:
+        """Returns a dict of the symbols names and their corresponding SymbolInterface."""
+        raise NotImplementedError(
+            "Abstract property symbols_as_dict not implemented by subclass."
+        )
+
+    @property
     def symbols(self) -> Iterable[str]:
         """Returns an iterator of the Symbol names."""
         raise NotImplementedError(

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -121,7 +121,7 @@ class BaseSymbolTableInterface:
         )
 
     @property
-    def symbols_as_dict(self) -> Dict[str, int]:
+    def symbols_as_dict(self) -> Dict[str, interfaces.symbols.SymbolInterface]:
         """Returns a dict of the symbols names and their corresponding SymbolInterface."""
         raise NotImplementedError(
             "Abstract property symbols_as_dict not implemented by subclass."


### PR DESCRIPTION
Hi 👋,

This PR introduces two additional APIs for symbol tables :

- `symbols_as_dict` : get the entire symbol table as a dictionary (name:symbol_object). It is useful to quickly iterate on all the values, and faster than doing `[symbol_table.get_symbol(symbol) for symbol in symbol_table.symbols]`
- `update_symbol_address` : update a symbol address in the symbol table. This is only applicable to the context, and does not modify the ISF. It also takes care of invalidating the cache. 

I will use these features in a future Pull Request, related to macOS, to circumvent a new format in the kernel that slides some symbols with an additional offset. 

I look forward to your comments and reviews !