### PR TITLE
macOS: Latest kernels support

### DIFF
--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -129,9 +129,7 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
                 context.config[
                     cls.join(config_path, MacSymbolFinder.banner_config_key)
                 ] = str(banner, "latin-1")
-                symbol_cache.SqliteCache(identifiers_path).get_identifier_dictionary(
-                    operating_system="mac"
-                )
+
                 layer_class = intel.Intel32e
                 # If an mh_fileset_config exists, this means the KernelCache is in an MH_FILESET format
                 mh_fileset_config = context.config.branch(

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -7,7 +7,7 @@ import os
 import struct
 from typing import Optional
 
-from volatility3.framework import constants, exceptions, interfaces, layers
+from volatility3.framework import constants, exceptions, interfaces
 from volatility3.framework.automagic import symbol_cache, symbol_finder
 from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import intel, scanners

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -78,13 +78,13 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
             isf_path = mac_banners.get(banner, None)
             if isf_path:
                 table_name = context.symbol_space.free_table_name("MacintelStacker")
-                table = mac.MacKernelIntermedSymbols(
+                symbol_table = mac.MacKernelIntermedSymbols(
                     context=context,
-                    config_path=join("temporary", table_name),
+                    config_path=cls.join("temporary", table_name),
                     name=table_name,
                     isf_url=isf_path,
                 )
-                context.symbol_space.append(table)
+                context.symbol_space.append(symbol_table)
                 kaslr_shift = cls.find_aslr(
                     context=context,
                     symbol_table=table_name,

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -255,9 +255,6 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
                 config_path = cls.join(
                     MacSymbolFinder.mh_fileset_config_path_prefix, symbol_table
                 )
-                context.config[cls.join(config_path, "mh_fileset_kernel_cache_check")] = (
-                    mh_fileset_kernel_cache_check
-                )
                 context.config[cls.join(config_path, "vm_kernel_slide")] = (
                     vm_kernel_slide_candidate
                 )
@@ -265,7 +262,10 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
                 context.config[cls.join(config_path, "kernel_end")] = etext
 
             aslr_shift = aslr_shift_candidate
-            vollog.log(constants.LOGLEVEL_VVVV, f"Mac find_aslr found \"vm_kernel_slide\" to be: {hex(vm_kernel_slide_candidate)}")
+            vollog.log(
+                constants.LOGLEVEL_VVVV,
+                f'Mac find_aslr found "vm_kernel_slide" to be: {hex(vm_kernel_slide_candidate)}',
+            )
 
             break
         vollog.log(

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -6,7 +6,7 @@ import logging
 import os
 import struct
 import re
-from typing import Optional
+from typing import Optional, Generator
 
 from volatility3.framework import constants, exceptions, interfaces
 from volatility3.framework.automagic import symbol_cache, symbol_finder
@@ -375,7 +375,7 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
         context: interfaces.context.ContextInterface,
         layer_name: str,
         progress_callback: constants.ProgressCallback,
-    ):
+    ) -> Generator[int, None, None]:
         """
         References :
          - https://github.com/apple-open-source/macos/blob/10.8/xnu/osfmk/x86_64/lowmem_vectors.c#L78

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -139,7 +139,7 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
                 new_layer.config["kernel_virtual_offset"] = kaslr_shift
 
             if new_layer and dtb:
-                vollog.debug(f"DTB was found at: 0x{dtb:0x}")
+                vollog.debug(f"DTB was found at: {hex(dtb)}")
                 return new_layer
         vollog.debug("No suitable mac banner could be matched")
         return None

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -19,6 +19,8 @@ vollog = logging.getLogger(__name__)
 class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 35
     exclusion_list = ["windows", "linux"]
+    join = interfaces.configuration.path_join
+    _KERNEL_MIN_ADDRESS = 0xFFFFFF8000000000
 
     @classmethod
     def stack(
@@ -41,7 +43,6 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
         # Bail out by default unless we can stack properly
         layer = context.layers[layer_name]
         new_layer = None
-        join = interfaces.configuration.path_join
 
         # Never stack on top of an intel layer
         # FIXME: Find a way to improve this check

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -399,3 +399,6 @@ class MacSymbolFinder(symbol_finder.SymbolFinder):
     find_aslr = MacIntelStacker.find_aslr
     symbol_class = "volatility3.framework.symbols.mac.MacKernelIntermedSymbols"
     exclusion_list = ["windows", "linux"]
+    mh_fileset_config_path_prefix = interfaces.configuration.path_join(
+        "temporary", "MacIntelMhFilesetHelper"
+    )

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -234,8 +234,8 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
     def virtual_to_physical_address(cls, addr: int) -> int:
         """Converts a virtual mac address to a physical one (does not account
         of ASLR)"""
-        if addr > 0xFFFFFF8000000000:
-            addr = addr - 0xFFFFFF8000000000
+        if addr > cls._KERNEL_MIN_ADDRESS:
+            addr = addr - cls._KERNEL_MIN_ADDRESS
         else:
             addr = addr - 0xFF8000000000
 

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -62,10 +62,16 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
             )
             return None
 
+        seen_banners = []
         mss = scanners.MultiStringScanner([x for x in mac_banners if x])
         for banner_offset, banner in layer.scan(
             context=context, scanner=mss, progress_callback=progress_callback
         ):
+            # No need to try stackers on the same banner more than once
+            if banner in seen_banners:
+                continue
+            else:
+                seen_banners.append(banner)
             dtb = None
             vollog.debug(f"Identified banner: {repr(banner)}")
 

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -135,7 +135,7 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
                 mh_fileset_config = context.config.branch(
                     cls.join(MacSymbolFinder.mh_fileset_config_path_prefix, table_name)
                 )
-                if mh_fileset_config != {}:
+                if mh_fileset_config:
                     for key, value in mh_fileset_config.items():
                         context.config[cls.join(config_path, key)] = value
                     layer_class = intel.MacIntelMhFilesetKernelCache

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -219,15 +219,20 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
             if vm_kernel_slide_candidate & 0xFFF != 0:
                 continue
 
-            minor_string = context.layers[layer_name].read(
-                version_minor_phys_offset + tmp_aslr_shift, 4
+            # Banner related symbols have been slid by vm_kernel_slide
+            module_vm_kernel_slide = context.module(
+                symbol_table,
+                layer_name,
+                vm_kernel_slide_candidate - cls._KERNEL_MIN_ADDRESS,
             )
-            minor = struct.unpack("<I", minor_string)[0]
 
-            if minor != banner_minor:
+            # Verify ASLR with major and minor versions of banner
+            major = module_vm_kernel_slide.object_from_symbol("version_major")
+            if major != banner_major_version:
                 continue
 
-            if tmp_aslr_shift & 0xFFF != 0:
+            minor = module_vm_kernel_slide.object_from_symbol("version_minor")
+            if minor != banner_minor_version:
                 continue
 
             aslr_shift = tmp_aslr_shift & 0xFFFFFFFF

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -235,11 +235,31 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
             if minor != banner_minor_version:
                 continue
 
-            aslr_shift = tmp_aslr_shift & 0xFFFFFFFF
+            if mh_fileset_kernel_cache_check:
+                # Kernel __TEXT section start and end
+                stext = module.object_from_symbol("stext")
+                etext = module.object_from_symbol("etext")
+
+                config_path = cls.join(
+                    MacSymbolFinder.mh_fileset_config_path_prefix, symbol_table
+                )
+                context.config[cls.join(config_path, "mh_fileset_kernel_cache_check")] = (
+                    mh_fileset_kernel_cache_check
+                )
+                context.config[cls.join(config_path, "vm_kernel_slide")] = (
+                    vm_kernel_slide_candidate
+                )
+                context.config[cls.join(config_path, "kernel_start")] = stext
+                context.config[cls.join(config_path, "kernel_end")] = etext
+
+            aslr_shift = aslr_shift_candidate
+            vollog.log(constants.LOGLEVEL_VVVV, f"Mac find_aslr found \"vm_kernel_slide\" to be: {hex(vm_kernel_slide_candidate)}")
+
             break
-
-        vollog.log(constants.LOGLEVEL_VVVV, f"Mac find_aslr returned: {aslr_shift:0x}")
-
+        vollog.log(
+            constants.LOGLEVEL_VVVV,
+            f"Mac find_aslr returned: {hex(aslr_shift)}",
+        )
         return aslr_shift
 
     @classmethod

--- a/volatility3/framework/automagic/module.py
+++ b/volatility3/framework/automagic/module.py
@@ -62,5 +62,17 @@ class KernelModule(interfaces.automagic.AutomagicInterface):
                 offset = context.config[layer_kvo_config_path]
                 context.config[offset_config_path] = offset
 
+                # macOS KernelCache module override
+                layer_class_config_path = interfaces.configuration.path_join(
+                    new_config_path, req, "class"
+                )
+                layer_class_str = context.config[layer_class_config_path]
+                if (
+                    layer_class_str
+                    == "volatility3.framework.layers.intel.MacIntelMhFilesetKernelCache"
+                ):
+                    context.config[
+                        interfaces.configuration.path_join(new_config_path, "class")
+                    ] = "volatility3.framework.contexts.MacOSKernelCacheSupportModule"
         # Now construct the module based on the sub-requirements
         requirement.construct(context, config_path)

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -576,22 +576,18 @@ class MacOSKernelCacheSupportModule(Module):
         if size < 0:
             raise ValueError("Size must be strictly non-negative")
 
-        kernelcache_module_list = list(
-            self._context.symbol_space.get_symbols_by_location(
-                offset=offset - self._offset,
-                size=size,
-                table_name=self.symbol_table_name,
-            )
-        )
-        not_kernelcache_module_list = list(
-            self._context.symbol_space.get_symbols_by_location(
-                offset=offset - self._vm_kernel_slide,
-                size=size,
-                table_name=self.symbol_table_name,
-            )
-        )
+        if self._is_offset_in_kernel_boundaries(offset=offset, absolute=True):
+            slide_offset = self._vm_kernel_slide
+        else:
+            slide_offset = self._offset
 
-        return kernelcache_module_list + not_kernelcache_module_list
+        return list(
+            self._context.symbol_space.get_symbols_by_location(
+                offset=offset - slide_offset,
+                size=size,
+                table_name=self.symbol_table_name,
+            )
+        )
 
     @property
     def not_kernelcache_module(self) -> Module:

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -462,3 +462,146 @@ class ConfigurableModule(Module, interfaces.configuration.ConfigurableInterface)
         Module.__init__(
             self, context, name, layer_name, offset, symbol_table_name, layer_name
         )
+
+
+class MacOSKernelCacheSupportModule(Module):
+    """
+    If the MH_FILESET KernelCache support is ON, header addresses in all mach-o segments and sections
+    of the MH_FILESET are slid by a specific offset. This is problematic, as some kernel symbols, typically
+    contained in an external ISF file, won't be correctly readable with a sole KASLR shift.
+    The original "kernel" module is the "KernelCache" module, but for compatibility reasons
+    it is still named "kernel".
+    To circumvent this, we create an additional module object, in this context, with the
+    "vm_kernel_slide" shift as offset. Doing so, we are able to detect which slide to use,
+    depending on a provided symbol address.
+    """
+
+    def __init__(
+        self, context: interfaces.context.ContextInterface, config_path: str, name: str
+    ) -> None:
+        super().__init__(context, config_path, name)
+
+        pathjoin = interfaces.configuration.path_join
+        context.config[pathjoin(config_path, "vm_kernel_slide")] = context.config[
+            pathjoin(config_path, self.layer_name, "vm_kernel_slide")
+        ]
+        context.config[pathjoin(config_path, "kernel_start")] = (
+            context.config[pathjoin(config_path, self.layer_name, "kernel_start")]
+            & self.context.layers[self.layer_name].address_mask
+        )
+        context.config[pathjoin(config_path, "kernel_end")] = (
+            context.config[pathjoin(config_path, self.layer_name, "kernel_end")]
+            & self.context.layers[self.layer_name].address_mask
+        )
+
+        # Instantiate generic Kernel module, with "vm_kernel_slide" as offset
+        not_kernelcache_module_name = interfaces.configuration.path_join(
+            self.name, "not_kernelcache"
+        )
+        self._not_kernelcache_module = Module.create(
+            context=context,
+            module_name=not_kernelcache_module_name,
+            layer_name=self.layer_name,
+            offset=self._vm_kernel_slide,
+            symbol_table_name=self.symbol_table_name,
+        )
+
+    def _is_offset_in_kernel_boundaries(self, offset: int) -> bool:
+        """Determine if an offset, typically a symbol address, locates in kernel __TEXT
+        boundaries, by adding "vm_kernel_slide" shift to it."""
+        return self._kernel_start <= offset + self._vm_kernel_slide <= self._kernel_end
+
+    def object(
+        self,
+        object_type: str,
+        offset: int = None,
+        native_layer_name: Optional[str] = None,
+        absolute: bool = False,
+        **kwargs,
+    ) -> "interfaces.objects.ObjectInterface":
+
+        # Construct the object on the appropriate module
+        if self._is_offset_in_kernel_boundaries(offset=offset):
+            module = self.not_kernelcache_module
+        else:
+            module = super()
+
+        return module.object(
+            object_type=object_type,
+            offset=offset,
+            native_layer_name=native_layer_name,
+            absolute=absolute,
+            **kwargs,
+        )
+
+    def object_from_symbol(
+        self,
+        symbol_name: str,
+        native_layer_name: Optional[str] = None,
+        absolute: bool = False,
+        object_type: Optional[Union[str, "interfaces.objects.ObjectInterface"]] = None,
+        **kwargs,
+    ) -> "interfaces.objects.ObjectInterface":
+        if constants.BANG not in symbol_name:
+            tmp_symbol_name = self.symbol_table_name + constants.BANG + symbol_name
+        else:
+            raise ValueError(
+                "Cannot reference another module when constructing an object"
+            )
+
+        # Only set the offset if type is Symbol and we were given a name, not a template
+        tmp_symbol_val = self._context.symbol_space.get_symbol(tmp_symbol_name)
+        offset = tmp_symbol_val.address
+
+        # Construct the object on the appropriate module
+        if self._is_offset_in_kernel_boundaries(offset=offset):
+            module = self.not_kernelcache_module
+        else:
+            module = super()
+
+        return module.object_from_symbol(
+            symbol_name=symbol_name,
+            native_layer_name=native_layer_name,
+            absolute=absolute,
+            object_type=object_type,
+            **kwargs,
+        )
+
+    def get_symbols_by_absolute_location(self, offset: int, size: int = 0) -> List[str]:
+        """Returns the symbols within this module that live at the specified
+        absolute offset provided."""
+        if size < 0:
+            raise ValueError("Size must be strictly non-negative")
+
+        kernelcache_module_list = list(
+            self._context.symbol_space.get_symbols_by_location(
+                offset=offset - self._offset,
+                size=size,
+                table_name=self.symbol_table_name,
+            )
+        )
+        not_kernelcache_module_list = list(
+            self._context.symbol_space.get_symbols_by_location(
+                offset=offset - self._vm_kernel_slide,
+                size=size,
+                table_name=self.symbol_table_name,
+            )
+        )
+
+        return kernelcache_module_list + not_kernelcache_module_list
+
+    @property
+    def not_kernelcache_module(self) -> Module:
+        return self._not_kernelcache_module
+
+    @property
+    def _vm_kernel_slide(self) -> int:
+        return self.config["vm_kernel_slide"]
+
+    @property
+    def _kernel_start(self) -> int:
+        return self.config["kernel_start"]
+
+    @property
+    def _kernel_end(self) -> int:
+        return self.config["kernel_end"]

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -474,6 +474,9 @@ class MacOSKernelCacheSupportModule(Module):
     To circumvent this, we create an additional module object, in this context, with the
     "vm_kernel_slide" shift as offset. Doing so, we are able to detect which slide to use,
     depending on a provided symbol address.
+
+    Additional reference, on the stage where the KernelCache is given an additional slide :
+     - https://github.com/apple-open-source/macos/blob/14.3/xnu/osfmk/i386/i386_init.c#L621
     """
 
     def __init__(

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -507,11 +507,6 @@ class MacIntelMhFilesetKernelCache(Intel32e):
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return super().get_requirements() + [
-            requirements.BooleanRequirement(
-                name="mh_fileset_kernel_cache_check",
-                optional=False,
-                description="Implicit key to determine if a MacIntel layer embeds a MH_FILESET KernelCache.",
-            ),
             requirements.IntRequirement(
                 name="vm_kernel_slide",
                 optional=False,

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -501,3 +501,30 @@ class WindowsIntel32e(WindowsMixin, Intel32e):
 
     def _translate(self, offset: int) -> Tuple[int, int, str]:
         return self._translate_swap(self, offset, self._bits_per_register // 2)
+
+
+class MacIntelMhFilesetKernelCache(Intel32e):
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return super().get_requirements() + [
+            requirements.BooleanRequirement(
+                name="mh_fileset_kernel_cache_check",
+                optional=False,
+                description="Implicit key to determine if a MacIntel layer embeds a MH_FILESET KernelCache.",
+            ),
+            requirements.IntRequirement(
+                name="vm_kernel_slide",
+                optional=False,
+                description='"vm_kernel_slide" kernel symbol value.',
+            ),
+            requirements.IntRequirement(
+                name="kernel_start",
+                optional=False,
+                description='kernel _TEXT section start, typically obtained via kernel symbol "stext".',
+            ),
+            requirements.IntRequirement(
+                name="kernel_end",
+                optional=False,
+                description='kernel _TEXT section end, typically obtained via kernel symbol "etext".',
+            ),
+        ]

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -15,7 +15,9 @@ vollog = logging.getLogger(__name__)
 class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):
     provides = {"type": "interface"}
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(
+        self, do_i386_kernel_cache_unslide: bool = True, *args, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
 
         self.set_type_class("proc", extensions.proc)
@@ -33,6 +35,80 @@ class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         # https://developer.apple.com/documentation/kernel/queue_head_t
         self.set_type_class("queue_entry", extensions.queue_entry)
         self.optional_set_type_class("queue_head_t", extensions.queue_entry)
+        # If a kernel layer exists, we want to check if an MH_FILESET kernel cache
+        # was detected. If so, we need to unslide the concerned kernel symbols.
+        config_path_without_last_part = self.config_path.rsplit(
+            self.context.config.separator, 1
+        )[0]
+        kernel_layer_config_path = path_join(
+            config_path_without_last_part, "layer_name"
+        )
+        if (
+            self.context.config.get(
+                path_join(kernel_layer_config_path, "mh_fileset_kernel_cache_check")
+            )
+            and do_i386_kernel_cache_unslide
+        ):
+            vm_kernel_slide = self.context.config[
+                path_join(kernel_layer_config_path, "vm_kernel_slide")
+            ]
+            kaslr_shift = self.context.config[
+                path_join(kernel_layer_config_path, "kernel_virtual_offset")
+            ]
+            kernel_start = self.context.config[
+                path_join(kernel_layer_config_path, "kernel_start")
+            ]
+            kernel_end = self.context.config[
+                path_join(kernel_layer_config_path, "kernel_end")
+            ]
+            self.i386_kernel_cache_unslide_symbols(
+                vm_kernel_slide, kaslr_shift, kernel_start, kernel_end
+            )
+
+    def i386_kernel_cache_unslide_symbols(
+        self,
+        vm_kernel_slide: int,
+        kaslr_shift: int,
+        kernel_start: int,
+        kernel_end: int,
+    ) -> Tuple[int, int]:
+        """
+        If the MH_FILESET KernelCache support is ON, header addresses in all mach-o segments and sections
+        of the MH_FILESET are slid by a specific offset. This is problematic, as some kernel symbols, typically
+        contained in an external ISF file, won't be correctly readable with a sole KASLR shift.
+        To circumvent this, we unslide every symbol address determined to be part of the KernelCache
+        in a position reachable by KASLR shift. This only affects the current symbol table.
+        """
+
+        # This is equivalent to the "slide" value from :
+        # https://github.com/apple-open-source/macos/blob/14.3/xnu/osfmk/i386/i386_init.c#L621
+        slide = vm_kernel_slide - kaslr_shift
+        if slide == 0:
+            return 0, 0
+        """
+        Addresses slid by i386_slide_and_rebase_image's slide are now in the kernelcache.
+        We want each symbol address to be slidable by aslr_slide, for the global context.
+        In this sense, we will slide concerned addresses references back to their original positions.
+        """
+        # Check if a symbol, slid by vm_kernel_slide, is located in the kernel _TEXT boundaries.
+        # Using symbols_as_dict method (fewer function calls) and a one liner offers a huge performance boost
+        to_slide = []
+        [
+            to_slide.append((sym_name, sym["address"]))
+            for sym_name, sym in self.symbols_as_dict.items()
+            if kernel_start <= sym["address"] + vm_kernel_slide <= kernel_end
+        ]
+        [
+            self.update_symbol_address(sym_name, sym_address + slide)
+            for sym_name, sym_address in to_slide
+        ]
+        to_slide_len = len(to_slide)
+        if to_slide_len != 0:
+            vollog.log(
+                constants.LOGLEVEL_VVVV,
+                f"{to_slide_len} symbols located in the MH_FILESET KernelCache were rebased with offset {hex(slide)}, to be reachable by KASLR shift.",
+            )
+        return slide, to_slide_len
 
 
 class MacUtilities(interfaces.configuration.VersionableInterface):

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -1,11 +1,15 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
+import logging
 from typing import Iterator, Any, Iterable, List, Tuple, Set
 
 from volatility3.framework import interfaces, objects, exceptions, constants
 from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.mac import extensions
+from volatility3.framework.interfaces.configuration import path_join
+
+vollog = logging.getLogger(__name__)
 
 
 class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -1,15 +1,11 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-import logging
 from typing import Iterator, Any, Iterable, List, Tuple, Set
 
 from volatility3.framework import interfaces, objects, exceptions, constants
 from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.mac import extensions
-from volatility3.framework.interfaces.configuration import path_join
-
-vollog = logging.getLogger(__name__)
 
 
 class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):


### PR DESCRIPTION
Hello 👋,

This Pull Request aims to refactor the macOS x86/64 automagic layer stacking, as well as support for a recent kernel functionality named "KernelCache".

These changes only add APIs to the framework, without modifying inputs/outputs of existing ones.

Tested on kernels : 

- `10.9.3_build-13D65`
- `10.12.6_build-16G29`
- `10.15.7_build-19H15`
- `12.0.1_build-21A559`
- `13.6.4_build-22G513`
- `14.0_build-23A5257q`

Justifications are given, in the form of a comment or a link to the official darwin source code.

## Details

### KernelCache 

> The kernelcache is a pre-compiled and pre-linked version of the XNU kernel, with essential device drivers and kernel extensions. It is stored in a compressed format and is decompressed into memory during the boot process. The kernelcache facilitates faster booting by having a ready-to-use version of the kernel and essential drivers available, thereby reducing the time and resources that would otherwise be spent loading and dynamically linking these components at startup. 

source (french) : https://book.hacktricks.xyz/v/fr/macos-hardening/macos-security-and-privilege-escalation/mac-os-architecture#kernelcache

This feature impacts symbol resolving, as some need to be shifted with the "classical" KASLR shift, and some with the "vm_kernel_slide" shift. The current shift determining method, via `darwin banner` scanning, was actually calculating the "vm_kernel_slide" shift, from which it wasn't possible to also determine the KASLR shift. The new implementation takes advantage of the `lowGlo` kernel structure, which is consistent and available in old and recent kernels, and reveals the KASLR shift value. Banner scanning was also proven to be a bit slower, and more redundant, in its logic.

As discussed in #1114, a new macOS kernel module was added to the framework, which takes care of determining which slide to use to correctly resolve a symbol. Automagic is able to detect and instantiate it automatically, as well.


### Additional changes

Some variable names and logics were changed in the mac stacker, to be more straight to the point, while keeping the API compatibility.

---

If you possess any macOS X samples, please feel free to merge this PR in your local installation, and give feedback !