### PR TITLE
macOS: Plugin enhancements for latest kernel compatibility

### DIFF
--- a/volatility3/framework/plugins/mac/kevents.py
+++ b/volatility3/framework/plugins/mac/kevents.py
@@ -184,18 +184,29 @@ class Kevents(interfaces.plugins.PluginInterface):
         for task_name, pid, kn in self.list_kernel_events(
             self.context, self.config["kernel"], filter_func=filter_func
         ):
-            filter_index = kn.kn_kevent.filter * -1
+            if hasattr(kn.kn_kevent, "filter"):
+                filter = kn.kn_kevent.filter
+            elif hasattr(kn.kn_kevent, "kei_filter"):
+                filter = kn.kn_kevent.kei_filter
+            filter_index = filter * -1
             if filter_index in self.event_types:
                 filter_name = self.event_types[filter_index]
             else:
                 continue
 
             try:
-                ident = kn.kn_kevent.ident
+                if hasattr(kn.kn_kevent, "ident"):
+                    ident = kn.kn_kevent.ident
+                elif hasattr(kn.kn_kevent, "kei_ident"):
+                    ident = kn.kn_kevent.kei_ident
             except exceptions.InvalidAddressException:
                 continue
 
-            context = self._parse_flags(filter_index, kn.kn_sfflags)
+            if hasattr(kn, "kn_sfflags"):
+                sfflags = kn.kn_sfflags
+            elif hasattr(kn.kn_kevent, "kei_sfflags"):
+                sfflags = kn.kn_kevent.kei_sfflags
+            context = self._parse_flags(filter_index, sfflags)
 
             yield (0, (pid, task_name, ident, filter_name, context))
 

--- a/volatility3/framework/plugins/mac/netstat.py
+++ b/volatility3/framework/plugins/mac/netstat.py
@@ -74,14 +74,20 @@ class Netstat(plugins.PluginInterface):
             for filp, _, _ in mac.MacUtilities.files_descriptors_for_process(
                 context, context.modules[kernel_module_name].symbol_table_name, task
             ):
+                if hasattr(filp, "f_fglob"):
+                    glob = filp.f_fglob
+                elif hasattr(filp, "fp_glob"):
+                    glob = filp.fp_glob
+                else:
+                    raise AttributeError("fileglob", "f_fglob || fp_glob")
+
                 try:
-                    ftype = filp.f_fglob.get_fg_type()
+                    ftype = glob.get_fg_type()
                 except exceptions.InvalidAddressException:
                     continue
 
                 if ftype != "SOCKET":
                     continue
-
                 try:
                     socket = filp.f_fglob.fg_data.dereference().cast("socket")
                 except exceptions.InvalidAddressException:

--- a/volatility3/framework/plugins/mac/netstat.py
+++ b/volatility3/framework/plugins/mac/netstat.py
@@ -8,7 +8,7 @@ from typing import Iterable, Callable, Tuple
 from volatility3.framework import exceptions, renderers, interfaces
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
-from volatility3.framework.objects import utility
+from volatility3.framework.objects import utility, Pointer
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import mac
 from volatility3.plugins.mac import pslist
@@ -89,7 +89,12 @@ class Netstat(plugins.PluginInterface):
                 if ftype != "SOCKET":
                     continue
                 try:
-                    socket = filp.f_fglob.fg_data.dereference().cast("socket")
+                    if type(glob.fg_data) == Pointer:
+                        socket = glob.fg_data.dereference().cast("socket")
+                    else:
+                        socket = context.modules[kernel_module_name].object(
+                            "socket", glob.fg_data, absolute=True
+                        )
                 except exceptions.InvalidAddressException:
                     continue
 

--- a/volatility3/framework/plugins/mac/pslist.py
+++ b/volatility3/framework/plugins/mac/pslist.py
@@ -200,7 +200,10 @@ class PsList(interfaces.plugins.PluginInterface):
                 seen[task.vol.offset] = 1
 
             try:
-                proc = task.bsd_info.dereference().cast("proc")
+                if hasattr(task, "bsd_info"):
+                    proc = task.bsd_info.dereference().cast("proc")
+                elif hasattr(task, "bsd_info_ro"):
+                    proc = task.bsd_info_ro.pr_proc.dereference()
             except exceptions.InvalidAddressException:
                 continue
 

--- a/volatility3/framework/plugins/mac/timers.py
+++ b/volatility3/framework/plugins/mac/timers.py
@@ -58,7 +58,6 @@ class Timers(plugins.PluginInterface):
             self.context, kernel.layer_name, kernel, mods
         )
 
-
         if kernel.has_type("call_entry"):
             timer_struct = TimerStructure(
                 type_name="call_entry",

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -209,7 +209,8 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
                     path = vnode.full_path()
                 elif ftype:
                     path = f"<{ftype.lower()}>"
-
+                else:
+                    path = "UNKNOWN"
                 yield f, path, fd_num
 
     @classmethod

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -18,7 +18,6 @@ class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("fileglob", extensions.fileglob)
         self.set_type_class("vnode", extensions.vnode)
         self.set_type_class("vm_map_entry", extensions.vm_map_entry)
-        # FIXME: Issue #848
         self.optional_set_type_class("vm_map_object", extensions.vm_map_object)
         self.set_type_class("socket", extensions.socket)
         self.set_type_class("inpcb", extensions.inpcb)

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -151,7 +151,10 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
         """
 
         try:
-            num_fds = task.p_fd.fd_lastfile
+            if hasattr(task.p_fd, "fd_lastfile"):
+                num_fds = task.p_fd.fd_lastfile
+            elif hasattr(task.p_fd, "fd_afterlast"):
+                num_fds = task.p_fd.fd_afterlast
         except exceptions.InvalidAddressException:
             num_fds = 1024
 

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -182,8 +182,14 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
 
         for fd_num, f in enumerate(fds):
             if f != 0:
+                if hasattr(f, "f_fglob"):
+                    glob = f.f_fglob
+                elif hasattr(f, "fp_glob"):
+                    glob = f.fp_glob
+                else:
+                    raise AttributeError("fileglob", "f_fglob || fp_glob")
                 try:
-                    ftype = f.f_fglob.get_fg_type()
+                    ftype = glob.get_fg_type()
                 except exceptions.InvalidAddressException:
                     continue
 

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -179,7 +179,12 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
         fds = objects.utility.array_of_pointers(
             table_addr, count=num_fds, subtype=file_type, context=context
         )
-
+        kernel_config_path = context.layers[
+            glob.vol.layer_name
+        ].config_path.rsplit(context.config.separator, 1)[0]
+        kernel_module = context.modules[
+            context.config[kernel_config_path]
+        ]
         for fd_num, f in enumerate(fds):
             if f != 0:
                 if hasattr(f, "f_fglob"):
@@ -198,9 +203,7 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
                         vnode = glob.fg_data.dereference().cast("vnode")
                     else:
                         # On macOS 14+ versions, glob.fg_data is an uintptr_t
-                        # ASLR is not applied with casting,
-                        # Hardcoding "kernel" string as there isn't a way to get the proper config key ?
-                        vnode = context.modules["kernel"].object(
+                        vnode = kernel_module.object(
                             "vnode", glob.fg_data, absolute=True
                         )
                     path = vnode.full_path()

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -69,7 +69,7 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
         cls,
         context: interfaces.context.ContextInterface,
         layer_name: str,
-        kernel,  # ikelos - how to type this??
+        kernel: interfaces.context.ModuleInterface,
         mods_list: Iterator[Any],
     ):
         try:

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -18,7 +18,8 @@ class MacKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("fileglob", extensions.fileglob)
         self.set_type_class("vnode", extensions.vnode)
         self.set_type_class("vm_map_entry", extensions.vm_map_entry)
-        self.set_type_class("vm_map_object", extensions.vm_map_object)
+        # FIXME: Issue #848
+        self.optional_set_type_class("vm_map_object", extensions.vm_map_object)
         self.set_type_class("socket", extensions.socket)
         self.set_type_class("inpcb", extensions.inpcb)
         self.set_type_class("ifnet", extensions.ifnet)

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -180,7 +180,7 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
             table_addr, count=num_fds, subtype=file_type, context=context
         )
         kernel_config_path = context.layers[
-            glob.vol.layer_name
+            task.vol.layer_name
         ].config_path.rsplit(context.config.separator, 1)[0]
         kernel_module = context.modules[
             context.config[kernel_config_path]

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -194,7 +194,15 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
                     continue
 
                 if ftype == "VNODE":
-                    vnode = f.f_fglob.fg_data.dereference().cast("vnode")
+                    if type(glob.fg_data) == objects.Pointer:
+                        vnode = glob.fg_data.dereference().cast("vnode")
+                    else:
+                        # On macOS 14+ versions, glob.fg_data is an uintptr_t
+                        # ASLR is not applied with casting,
+                        # Hardcoding "kernel" string as there isn't a way to get the proper config key ?
+                        vnode = context.modules["kernel"].object(
+                            "vnode", glob.fg_data, absolute=True
+                        )
                     path = vnode.full_path()
                 elif ftype:
                     path = f"<{ftype.lower()}>"

--- a/volatility3/framework/symbols/mac/__init__.py
+++ b/volatility3/framework/symbols/mac/__init__.py
@@ -179,12 +179,10 @@ class MacUtilities(interfaces.configuration.VersionableInterface):
         fds = objects.utility.array_of_pointers(
             table_addr, count=num_fds, subtype=file_type, context=context
         )
-        kernel_config_path = context.layers[
-            task.vol.layer_name
-        ].config_path.rsplit(context.config.separator, 1)[0]
-        kernel_module = context.modules[
-            context.config[kernel_config_path]
-        ]
+        kernel_config_path = context.layers[task.vol.layer_name].config_path.rsplit(
+            context.config.separator, 1
+        )[0]
+        kernel_module = context.modules[context.config[kernel_config_path]]
         for fd_num, f in enumerate(fds):
             if f != 0:
                 if hasattr(f, "f_fglob"):

--- a/volatility3/framework/symbols/mac/extensions/__init__.py
+++ b/volatility3/framework/symbols/mac/extensions/__init__.py
@@ -333,7 +333,11 @@ class vm_map_entry(objects.StructType):
             return "sub_map"
 
         # based on find_vnode_object
-        tmp_object = self.get_object()
+        try:
+            tmp_object = self.get_object()
+        except exceptions.InvalidAddressException:
+            return None
+
         if type(tmp_object) == vm_map_object:
             vnode_object = tmp_object.get_map_object()
         else:

--- a/volatility3/framework/symbols/mac/extensions/__init__.py
+++ b/volatility3/framework/symbols/mac/extensions/__init__.py
@@ -3,6 +3,7 @@
 #
 import contextlib
 import logging
+import struct
 from typing import Generator, Iterable, Optional, Set, Tuple
 
 from volatility3.framework import constants, exceptions, interfaces, objects

--- a/volatility3/framework/symbols/mac/extensions/__init__.py
+++ b/volatility3/framework/symbols/mac/extensions/__init__.py
@@ -333,7 +333,12 @@ class vm_map_entry(objects.StructType):
             return "sub_map"
 
         # based on find_vnode_object
-        vnode_object = self.get_object().get_map_object()
+        tmp_object = self.get_object()
+        if type(tmp_object) == vm_map_object:
+            vnode_object = tmp_object.get_map_object()
+        else:
+            vnode_object = tmp_object
+
         if vnode_object == 0:
             return None
 

--- a/volatility3/framework/symbols/mac/extensions/__init__.py
+++ b/volatility3/framework/symbols/mac/extensions/__init__.py
@@ -15,7 +15,11 @@ vollog = logging.getLogger(__name__)
 
 class proc(generic.GenericIntelProcess):
     def get_task(self):
-        return self.task.dereference().cast("task")
+        if hasattr(self, "p_proc_ro"):
+            task = self.p_proc_ro.pr_task.dereference()
+        else:
+            task = self.task.dereference().cast("task")
+        return task
 
     def add_process_layer(
         self, config_prefix: str = None, preferred_name: str = None


### PR DESCRIPTION
Hi 👋,

This Pull Request provides updates to existing macOS plugins, for compatibility with recent kernels. It indirectly depends on the work produced in #1115. It is marked as "Draft" for now, but is available for anyone to try !

Instead of opening one PR for each change, I thought it would be easier to track down the global update here.

Changes are mostly small fixes on types and structures naming changes, while keeping the compatibility for older kernels. A couple reworks were necessary for some plugins, and extensions.

Tested on kernels : 

- `10.9.3_build-13D65`
- `10.12.6_build-16G29`
- `10.15.7_build-19H15`
- `12.0.1_build-21A559`
- `13.6.4_build-22G513`
- `14.0_build-23A5257q`

Plugins version haven't been bumped for now.

## Details

Here are the justifications, in the form of a before/after on kernel structures  : 

### volatility3/framework/symbols/mac/__init__.py

filedesc :
- https://github.com/apple-open-source/macos/blob/10.9.3/xnu/bsd/sys/filedesc.h#L90
- https://github.com/apple-open-source/macos/blob/14.3/xnu/bsd/sys/filedesc.h#L123

fileproc : 
- https://github.com/apple-open-source/macos/blob/10.9.3/xnu/bsd/sys/file_internal.h#L91
- https://github.com/apple-open-source/macos/blob/14.3/xnu/bsd/sys/file_internal.h#L120

fileglob : 

- https://github.com/apple-open-source/macos/blob/12.0.1/xnu/bsd/sys/file_internal.h#L185
- https://github.com/apple-open-source/macos/blob/14.3/xnu/bsd/sys/file_internal.h#L187

vnode : 

- https://github.com/apple-open-source/macos/blob/10.9.3/xnu/bsd/sys/vnode_internal.h#L127
- https://github.com/apple-open-source/macos/blob/14.3/xnu/bsd/sys/vnode_internal.h#L159

### mac.pslist 

bsd_info :

- https://github.com/apple-open-source/macos/blob/10.9.3/xnu/osfmk/kern/task.h#L234
- https://github.com/apple-open-source/macos/blob/14.3/xnu/osfmk/kern/task.h#L275

### mac.kevents 

- https://github.com/apple-open-source/macos/blob/14.3/xnu/bsd/sys/event_private.h#L467

### mac.list_files 

Recursive logic was updated to an iterative one, as `"maximum recursion depth exceeded in comparison"` were encountered when deep recursion occured.

### volatility3/framework/symbols/mac/extensions/__init__.py

proc (impacts `mac.pslist`) : 

- https://github.com/apple-open-source/macos/blob/14.3/xnu/bsd/sys/proc_internal.h#L262

#### mac.malfind 

Fixes #848. As `vm_map_object` was removed from the kernel, updates on the logic to get `vm_object` from a `vm_map_entry` were done. See : 

- https://github.com/apple-open-source/macos/blob/12.0.1/xnu/osfmk/vm/vm_map.h#L140
- https://github.com/apple-open-source/macos/blob/14.3/xnu/osfmk/vm/vm_map.h#L239

Here is an article brieflly talking about it :

https://saaramar.github.io/kmem_guard_t_blogpost/#bookkeeping

### mac.timers

/!\ _1-1 changes were done, but results don't seem really useful/accurate in recent kernels_

- https://github.com/apple-open-source/macos/blob/10.9.3/xnu/osfmk/kern/call_entry.h#L45
- https://github.com/apple-open-source/macos/blob/14.3/xnu/osfmk/kern/timer_call.h
