### PR TITLE
Bulk out Module support for specific requirements

### DIFF
--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -14,6 +14,7 @@ import logging
 from typing import Callable, Iterable, List, Optional, Set, Tuple, Union
 
 from volatility3.framework import constants, interfaces, symbols, exceptions
+from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import templates
 
 vollog = logging.getLogger(__name__)
@@ -225,6 +226,20 @@ class Module(interfaces.context.ModuleInterface):
         context.config[config_path] = return_val.name
         # Add the module to the context modules collection
         return return_val
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        """Returns a list of Requirement objects for this type of layer."""
+        return [
+            requirements.IntRequirement(name="offset", optional=False),
+            requirements.TranslationLayerRequirement(name="layer_name", optional=False),
+            requirements.TranslationLayerRequirement(
+                name="native_layer_name", optional=True
+            ),
+            requirements.SymbolTableRequirement(
+                name="symbol_table_name", optional=False
+            ),
+        ]
 
     def object(
         self,

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -157,6 +157,10 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
         super().__init__(context, config_path)
         self._module_name = name
 
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        """Returns a list of Requirement objects for this type of layer."""
+
     @property
     def _layer_name(self) -> str:
         return self.config["layer_name"]
@@ -175,7 +179,6 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
 
     def build_configuration(self) -> "interfaces.configuration.HierarchicalDict":
         """Builds the configuration dictionary for this specific Module"""
-
         config = super().build_configuration()
 
         config["offset"] = self.config["offset"]


### PR DESCRIPTION
This should ensure that modules more explicitly state what requirements they have which should also allow that to be recorded more accurately in the configuration when needed.

@Abyss-W4tcher please could you test this (after adding your own requirements to your new Module type) and report back whether the values you need get stored appropriately or not.