### PR TITLE
Windows: Add max PID and thread count options for filtering processes

### DIFF
--- a/volatility3/framework/plugins/windows/psscan.py
+++ b/volatility3/framework/plugins/windows/psscan.py
@@ -57,6 +57,18 @@ class PsScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 default=False,
                 optional=True,
             ),
+            requirements.IntRequirement(
+                name="maxPid",
+                description="List processes with ID <= maxPid",
+                default=1000000,
+                optional=True,
+            ),
+            requirements.IntRequirement(
+                name="maxThreads",
+                description="List processes with thread count < maxThreads",
+                default=100000,
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -260,6 +272,13 @@ class PsScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             kernel.symbol_table_name,
             filter_func=pslist.PsList.create_pid_filter(self.config.get("pid", None)),
         ):
+            # Filter out processes with PID > maxPid (default=1000000)
+            if proc.UniqueProcessId > self.config.get("maxPid"):
+                continue
+            # Filter out processes with thread count >= maxThreads (default=100000)
+            if proc.ActiveThreads >= self.config.get("maxThreads"):
+                continue
+
             file_output = "Disabled"
             if self.config["dump"]:
                 # windows 10 objects (maybe others in the future) are already in virtual memory


### PR DESCRIPTION
This PR adds additional flags, `--maxPid` and `--maxThreads`, to filter down the output of the `windows.psscan` plugin.

Using the `--maxPid` flag followed by an integer `n` will only output process info for processes that have a PID <= `n`.

Using the `--maxThreads` flag followed by an integer `n` will only output process info for processes that have a thread count < `n`.

This PR also adds default cap values for the PID and thread count, with the PID being capped at 1000000 by default and the thread count being capped at 100000. Therefore, a process with a PID > 1000000 and/or thread count >= 100000 will now be filtered out by default. This filters out a lot of the junk process results and users are able to set these values higher/lower using the `--maxPid` and `--maxThreads` flags if desired.

Manual testing was performed on multiple windows memory images to verify the expected behavior.