### PR TITLE
Adding --output-filename command line option like in Vol2.

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -446,6 +446,10 @@ class CommandLine:
                 	parser.error(
                 		f"Cannot write output file: file {args.output_filename[0]} already exists"
                 	)
+                else:
+                    args.output_filename = open(args.output_filename, 'w', encoding='utf-8')
+            else:
+                args.output_filename = sys.stdout
 
             if args.write_config:
                 vollog.warning(
@@ -476,7 +480,10 @@ class CommandLine:
         try:
             # Construct and run the plugin
             if constructed:
-                renderers[args.renderer](output_filename = args.output_filename).render(constructed.run())
+                grid = constructed.run()
+                renderer = renderers[args.renderer](args.output_filename)
+                renderer.filter = text_filter.CLIFilter(grid, args.filters)
+                renderer.render(grid)
         except exceptions.VolatilityException as excp:
             self.process_exceptions(excp)
 

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -240,6 +240,12 @@ class CommandLine:
             default=[],
             action="append",
         )
+        parser.add_argument(
+            "--output-filename",
+            help="Write output in this file (like in Volatility2). Default is stdout.",
+            default=None,
+            type=str
+        )
 
         parser.set_defaults(**default_config)
 
@@ -433,6 +439,9 @@ class CommandLine:
                 progress_callback,
                 self.file_handler_class_factory(),
             )
+            
+            if args.output_filename:
+                vollog.debug("Output file is set as", args.output_filename[0])
 
             if args.write_config:
                 vollog.warning(
@@ -463,10 +472,7 @@ class CommandLine:
         try:
             # Construct and run the plugin
             if constructed:
-                grid = constructed.run()
-                renderer = renderers[args.renderer]()
-                renderer.filter = text_filter.CLIFilter(grid, args.filters)
-                renderer.render(grid)
+                renderers[args.renderer](output_filename = args.output_filename).render(constructed.run())
         except exceptions.VolatilityException as excp:
             self.process_exceptions(excp)
 

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -242,7 +242,7 @@ class CommandLine:
         )
         parser.add_argument(
             "--output-filename",
-            help="Write output in this file (like in Volatility2). Default is stdout.",
+            help="Write output in this file. Default is stdout.",
             default=None,
             type=str
         )
@@ -441,7 +441,11 @@ class CommandLine:
             )
             
             if args.output_filename:
-                vollog.debug("Output file is set as", args.output_filename[0])
+                vollog.debug("Output file is set as {args.output_filename[0]}")
+                if os.path.exists(os.path.abspath(args.output_filename[0])):
+                	parser.error(
+                		f"Cannot write output file: file {args.output_filename[0]} already exists"
+                	)
 
             if args.write_config:
                 vollog.warning(

--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -165,7 +165,10 @@ class QuickTextRenderer(CLIRenderer):
         """
         # TODO: Docstrings
         # TODO: Improve text output
-        outfd = sys.stdout
+        if self.output_filename:
+        	outfd = open(self.output_filename, 'w', encoding="utf-8")
+        else:
+        	outfd = sys.stdout
 
         line = []
         for column in grid.columns:
@@ -239,7 +242,10 @@ class CSVRenderer(CLIRenderer):
         Args:
             grid: The TreeGrid object to render
         """
-        outfd = sys.stdout
+        if self.output_filename:
+            outfd = open(self.output_filename, 'w', encoding="utf-8")
+        else:
+            outfd = sys.stdout
 
         header_list = ["TreeDepth"]
         for column in grid.columns:
@@ -289,7 +295,10 @@ class PrettyTextRenderer(CLIRenderer):
         """
         # TODO: Docstrings
         # TODO: Improve text output
-        outfd = sys.stdout
+        if self.output_filename:
+            outfd = open(self.output_filename, 'w', encoding="utf-8")
+        else:
+            outfd = sys.stdout
 
         sys.stderr.write("Formatting...\n")
 
@@ -417,7 +426,10 @@ class JsonRenderer(CLIRenderer):
         outfd.write("{}\n".format(json.dumps(result, indent=2, sort_keys=True)))
 
     def render(self, grid: interfaces.renderers.TreeGrid):
-        outfd = sys.stdout
+        if self.output_filename:
+            outfd = open(self.output_filename, 'w', encoding="utf-8")
+        else:
+            outfd = sys.stdout
 
         outfd.write("\n")
         final_output: Tuple[
@@ -462,6 +474,10 @@ class JsonLinesRenderer(JsonRenderer):
 
     def output_result(self, outfd, result):
         """Outputs the JSON results as JSON lines"""
+        if self.output_filename:
+            outfd = open(self.output_filename, 'w', encoding="utf-8")
+        else:
+            outfd = sys.stdout
         for line in result:
             outfd.write(json.dumps(line, sort_keys=True))
             outfd.write("\n")

--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -134,7 +134,7 @@ class CLIRenderer(interfaces.renderers.Renderer):
     """Class to add specific requirements for CLI renderers.
     
     Args:
-        output_filename (optionnal): The name of the output file to save the output of a module inside 
+        output_filename (optionnal): The output file descriptor to save the output of a module inside 
     """
 
     name = "unnamed"


### PR DESCRIPTION
With this option, Vol3 can produce by itself an output file. It can be useful in some cases, especially when Vol3 is launched by other tools which don't support output redirection operator ">". Usable with --output=<json|csv|text> to set the output format.