### PR TITLE
Layers - Several fixes around maximum_address and chunk sizes

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -789,8 +789,16 @@ class CommandLine:
                 if self._file.closed:
                     return None
 
-                self._file.close()
                 output_filename = self._get_final_filename()
+
+                # Update the filename, which may have changed if a file with
+                # the same name already existed. This needs to be done before
+                # closing the file, otherwise FileHandlerInterface will raise
+                # an exception. Also, the preferred_filename setter only allows
+                #  a specific set of characters, where '/' is not in that list
+                self.preferred_filename = os.path.basename(output_filename)
+
+                self._file.close()
                 os.rename(self._name, output_filename)
 
         if direct:

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -716,19 +716,17 @@ class CommandLine:
                 """Gets the final filename"""
                 if output_dir is None:
                     raise TypeError("Output directory is not a string")
+
                 os.makedirs(output_dir, exist_ok=True)
 
-                pref_name_array = self.preferred_filename.split(".")
-                filename, extension = (
-                    os.path.join(output_dir, ".".join(pref_name_array[:-1])),
-                    pref_name_array[-1],
-                )
-                output_filename = f"{filename}.{extension}"
+                output_filename = os.path.join(output_dir, self.preferred_filename)
+                filename, extension = os.path.splitext(output_filename)
 
                 counter = 1
                 while os.path.exists(output_filename):
-                    output_filename = f"{filename}-{counter}.{extension}"
+                    output_filename = f"{filename}-{counter}{extension}"
                     counter += 1
+
                 return output_filename
 
         class CLIMemFileHandler(io.BytesIO, CLIFileHandler):

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -790,8 +790,8 @@ class CommandLine:
                     return None
 
                 self._file.close()
-                output_filename = self._get_final_filename()
-                os.rename(self._name, output_filename)
+                self._output_filename = self._get_final_filename()
+                os.rename(self._name, self._output_filename)
 
         if direct:
             return CLIDirectFileHandler

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -790,8 +790,8 @@ class CommandLine:
                     return None
 
                 self._file.close()
-                self._output_filename = self._get_final_filename()
-                os.rename(self._name, self._output_filename)
+                output_filename = self._get_final_filename()
+                os.rename(self._name, output_filename)
 
         if direct:
             return CLIDirectFileHandler

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -180,7 +180,7 @@ class Intel(linear.LinearlyMappedLayer):
         position = self._initial_position
         entry = self._initial_entry
 
-        if self.minimum_address > offset > self.maximum_address:
+        if not (self.minimum_address <= offset <= self.maximum_address):
             raise exceptions.PagedInvalidAddressException(
                 self.name,
                 offset,

--- a/volatility3/framework/layers/segmented.py
+++ b/volatility3/framework/layers/segmented.py
@@ -152,7 +152,7 @@ class NonLinearlySegmentedLayer(
             raise ValueError("SegmentedLayer must contain some segments")
         if self._maxaddr is None:
             mapped, _, length, _ = self._segments[-1]
-            self._maxaddr = mapped + length
+            self._maxaddr = mapped + length - 1
         return self._maxaddr
 
     @property

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -18,7 +18,7 @@ class LayerWriter(plugins.PluginInterface):
     default_block_size = 0x500000
 
     _required_framework_version = (2, 0, 0)
-    _version = (2, 0, 0)
+    _version = (2, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -81,7 +81,7 @@ class LayerWriter(plugins.PluginInterface):
 
         file_handle = open_method(preferred_name)
         for i in range(0, layer.maximum_address, chunk_size):
-            current_chunk_size = min(chunk_size, layer.maximum_address - i)
+            current_chunk_size = min(chunk_size, layer.maximum_address + 1 - i)
             data = layer.read(i, current_chunk_size, pad=True)
             file_handle.write(data)
             if progress_callback:

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -41,6 +41,7 @@ class LayerWriter(plugins.PluginInterface):
             requirements.StringRequirement(
                 name="output",
                 description="Output filename",
+                optional=True,
             ),
             requirements.ListRequirement(
                 name="layers",

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -38,6 +38,10 @@ class LayerWriter(plugins.PluginInterface):
                 default=False,
                 optional=True,
             ),
+            requirements.StringRequirement(
+                name="output",
+                description="Output filename",
+            ),
             requirements.ListRequirement(
                 name="layers",
                 element_type=str,

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -115,6 +115,10 @@ class LayerWriter(plugins.PluginInterface):
                             progress_callback=self._progress_callback,
                         )
                         file_handle.close()
+
+                        # Update the filename, which may have changed if a file
+                        # with the same name already existed.
+                        output_name = file_handle.preferred_filename
                     except IOError as excp:
                         yield 0, (f"Layer cannot be written to {output_name}: {excp}",)
 

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -115,9 +115,7 @@ class LayerWriter(plugins.PluginInterface):
                         )
                         file_handle.close()
                     except IOError as excp:
-                        yield 0, (
-                            f"Layer cannot be written to {self.config['output_name']}: {excp}",
-                        )
+                        yield 0, (f"Layer cannot be written to {output_name}: {excp}",)
 
                     yield 0, (f"Layer has been written to {output_name}",)
 

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -115,7 +115,6 @@ class LayerWriter(plugins.PluginInterface):
                             progress_callback=self._progress_callback,
                         )
                         file_handle.close()
-                        output_name = file_handle._output_filename
                     except IOError as excp:
                         yield 0, (f"Layer cannot be written to {output_name}: {excp}",)
 

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -119,6 +119,7 @@ class LayerWriter(plugins.PluginInterface):
                             progress_callback=self._progress_callback,
                         )
                         file_handle.close()
+                        output_name = file_handle._output_filename
                     except IOError as excp:
                         yield 0, (f"Layer cannot be written to {output_name}: {excp}",)
 

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -38,11 +38,6 @@ class LayerWriter(plugins.PluginInterface):
                 default=False,
                 optional=True,
             ),
-            requirements.StringRequirement(
-                name="output",
-                description="Output filename",
-                optional=True,
-            ),
             requirements.ListRequirement(
                 name="layers",
                 element_type=str,

--- a/volatility3/framework/plugins/layerwriter.py
+++ b/volatility3/framework/plugins/layerwriter.py
@@ -95,7 +95,7 @@ class LayerWriter(plugins.PluginInterface):
             if not self.config["layers"]:
                 self.config["layers"] = []
                 for name in self.context.layers:
-                    if not self.context.layers[name].metadata.get("mapped", False):
+                    if "mapped" not in self.context.layers[name].metadata:
                         self.config["layers"] = [name]
 
             for name in self.config["layers"]:
@@ -103,7 +103,8 @@ class LayerWriter(plugins.PluginInterface):
                 if name not in self.context.layers:
                     yield 0, (f"Layer Name {name} does not exist",)
                 else:
-                    output_name = self.config.get("output", ".".join([name, "raw"]))
+                    default_output_name = f"{name}.raw"
+                    output_name = self.config.get("output", default_output_name)
                     try:
                         file_handle = self.write_layer(
                             self.context,


### PR DESCRIPTION
## `maximum_address` fixes in several layers
I think there are still other places to fix but I haven't fixed everything as testing it will be massive. I think we should review all occurrences of `layer.maximum_address` and where we calculate the data size based on that value. There are other places where I suspect it's being used incorrectly. To mention just a few:
- [PdbMSFStream::maximum_address](https://github.com/volatilityfoundation/volatility3/blob/1c5c57e1550f156844543ff2e54660095e75eb2c/volatility3/framework/layers/msf.py#L257) looks like it's also wrongly calculated as `len(self._pages) * self._pdb_layer.page_size` should be the next byte following the `maximum_address`.
- Additionally, there are other places that require double-checking. For instance, everywhere the `maximum_address` is in a while condition but the value is not included in the address range i.e.: [lime](https://github.com/volatilityfoundation/volatility3/blob/1c5c57e1550f156844543ff2e54660095e75eb2c/volatility3/framework/layers/lime.py#L45),  or [avml](https://github.com/volatilityfoundation/volatility3/blob/1c5c57e1550f156844543ff2e54660095e75eb2c/volatility3/framework/layers/avml.py#L102). Technically looks wrong but I think these could still be ok because they are expecting more than 1 byte to read anyway. So it should mean that the layer/file is truncated/bad format/etc.
## CommandLine: file_handler_class_factory ->CLIFileHandler
- Fixed issue when the filename doesn't contain an extension: ~~For instance, if we call the LayerWriter plugin with --output aaa ... it creates a .aaa (hidden filename in linux). Next iterations using the same argument will generate -1.aaa, -2.aaa, etc. instead of aaa, aaa-1, and aaa-2 respectively.~~
- ~~Stored the real filename created in `file_handle._output_filename`. That way we can know the final filename including both the "--output-dir" and the "--output" values and its "-1", "-2", etc (if used). Otherwise, the filename reported will be incorrect (and old version of this file), which could result in inaccurate analysis. _Unfortunately, the final filename is determined when the file is closed, which might lead to some controversy regarding its implementation._~~
- EDIT: Stored the real filename (only the base name) created in `file_handle.preferred_filename`. Otherwise, the filename reported will be incorrect (an old version of this file), which could result in inaccurate analysis. The final filename will contain the layer name. i.e. `primary.raw`, `primary-1.raw`, etc
## LayerWriter plugin. Several fixes
~~- Fixed missing `--output` argument and other bugs, plus some code improvements.~~