### PR TITLE
Prevent duplicate processing of the same file object

### DIFF
--- a/volatility3/framework/plugins/windows/dumpfiles.py
+++ b/volatility3/framework/plugins/windows/dumpfiles.py
@@ -244,6 +244,8 @@ class DumpFiles(interfaces.plugins.PluginInterface):
                 symbol_table=kernel.symbol_table_name,
             )
 
+            dumped_files = set()
+
             for proc in procs:
                 try:
                     object_table = proc.ObjectTable
@@ -266,6 +268,10 @@ class DumpFiles(interfaces.plugins.PluginInterface):
                                     continue
                                 if not file_re.search(name):
                                     continue
+
+                            if file_obj.vol.offset in dumped_files:
+                                continue
+                            dumped_files.add(file_obj.vol.offset)
 
                             for result in self.process_file_object(
                                 self.context, kernel.layer_name, self.open, file_obj
@@ -302,6 +308,10 @@ class DumpFiles(interfaces.plugins.PluginInterface):
                                 continue
                             if not file_re.search(name):
                                 continue
+
+                        if file_obj.vol.offset in dumped_files:
+                            continue
+                        dumped_files.add(file_obj.vol.offset)
 
                         for result in self.process_file_object(
                             self.context, kernel.layer_name, self.open, file_obj


### PR DESCRIPTION
When testing dumpfiles, I noticed significant slowdown across many samples. While looking into the root cause, I saw where dumpfiles will re-process FILE_OBJECT instances even if its already processed them. This causes major slowdowns on Win10+ systems where "kernel" processes, such as Registry, map the same file multiple times. The following shows duplicate mapping of the SOFTWARE hive, which is large, by this process in a sample:

```
$ python3 vol.py -q -f data.lime windows.vadinfo --pid 68 | grep -c SOFTWARE
36
```

Running dumpfiles as it is now makes duplicate files for all the repeats even though they will have the same content:

```
$ md5sum out2/*SOFTWARE*dat
8eddb77468b8094a76c03495cddb4025  out2/file.0xbe0506ec7e80.0xbe0506ae4690.DataSectionObject.SOFTWARE-1.dat
8eddb77468b8094a76c03495cddb4025  out2/file.0xbe0506ec7e80.0xbe0506ae4690.DataSectionObject.SOFTWARE-2.dat
8eddb77468b8094a76c03495cddb4025  out2/file.0xbe0506ec7e80.0xbe0506ae4690.DataSectionObject.SOFTWARE-3.dat
8eddb77468b8094a76c03495cddb4025  out2/file.0xbe0506ec7e80.0xbe0506ae4690.DataSectionObject.SOFTWARE-4.dat
[snip]
```

With my patch, each file is only extracted once, saving significant disk space and processing time:

```
$ md5sum out2/*SOFTWARE*dat
8eddb77468b8094a76c03495cddb4025  out2/file.0xbe0506ec7e80.0xbe0506ae4690.DataSectionObject.SOFTWARE.dat
```
