### PR TITLE
Add a default 0 value to macb columns to avoid mactime not reporting …

### DIFF
--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -183,16 +183,16 @@ class Timeliner(interfaces.plugins.PluginInterface):
                                     plugin_name,
                                     self._sanitize_body_format(item),
                                     self._text_format(
-                                        times.get(TimeLinerType.ACCESSED, "")
+                                        times.get(TimeLinerType.ACCESSED, "0")
                                     ),
                                     self._text_format(
-                                        times.get(TimeLinerType.MODIFIED, "")
+                                        times.get(TimeLinerType.MODIFIED, "0")
                                     ),
                                     self._text_format(
-                                        times.get(TimeLinerType.CHANGED, "")
+                                        times.get(TimeLinerType.CHANGED, "0")
                                     ),
                                     self._text_format(
-                                        times.get(TimeLinerType.CREATED, "")
+                                        times.get(TimeLinerType.CREATED, "0")
                                     ),
                                 )
                             )


### PR DESCRIPTION
…timeline entries

I noticed this issue when creating timelines and looking for process related entries in the mactime output. In the current code, the output of process plugins (pslist, psscan) is not included in the output files of body-file processing tools like mactime.
 
I later determined that the root cause was a very similar issue to this old ticket:

https://github.com/volatilityfoundation/volatility3/issues/542

In 542, the fix was to fill in non-timestamp columns that a plugin may not fill in as otherwise mactime (and other body file parsers) will ignore the line and not report it in the final timeline output. Processes are still not reported by mactime with the current vol3 code though as if a plugin does not fill in all columns, such as pslist only filling in the create (birth) time, then vol3 leaves the other columns as empty - making mactime skip them. My patch forces a default of 0 for these entries so the related lines will be included by body file processing tool.

