### PR TITLE
Correctly check for a failed read

### DIFF
--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -162,7 +162,9 @@ class Handles(interfaces.plugins.PluginInterface):
                 return None
 
             try:
-                data = self.context.layers.read(virtual_layer_name, kvo + func_addr, 0x200)
+                data = self.context.layers.read(
+                    virtual_layer_name, kvo + func_addr, 0x200
+                )
             except exceptions.InvalidAddressException:
                 return None
 

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -161,8 +161,9 @@ class Handles(interfaces.plugins.PluginInterface):
             except exceptions.SymbolError:
                 return None
 
-            data = self.context.layers.read(virtual_layer_name, kvo + func_addr, 0x200)
-            if data is None:
+            try:
+                data = self.context.layers.read(virtual_layer_name, kvo + func_addr, 0x200)
+            except exceptions.InvalidAddressException:
                 return None
 
             md = capstone.Cs(capstone.CS_ARCH_X86, capstone.CS_MODE_64)


### PR DESCRIPTION
A backtrace was triggered in handles testing due to this read() call being checked for None instead of properly in a try/except.