### PR TITLE
Add a new getcellroutine plugin that reports hooked GetCellRoutine ha…

### DIFF
--- a/volatility3/framework/plugins/windows/registry/getcellroutine.py
+++ b/volatility3/framework/plugins/windows/registry/getcellroutine.py
@@ -1,0 +1,97 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List
+
+from volatility3.framework import constants, exceptions, interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import ssdt
+from volatility3.plugins.windows.registry import hivelist
+
+vollog = logging.getLogger(__name__)
+
+class GetCellRoutine(interfaces.plugins.PluginInterface):
+    """ Reports registry hives with a hooked GetCellRoutine handler """
+
+    _required_framework_version = (2, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.PluginRequirement(
+                name="hivelist", plugin=hivelist.HiveList, version=(1, 0, 0)
+            ),
+            requirements.PluginRequirement(
+                name="ssdt", plugin=ssdt.SSDT, version=(1, 0, 0)
+            ),
+     ]
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        collection = ssdt.SSDT.build_module_collection(
+            self.context, kernel.layer_name, kernel.symbol_table_name
+        )
+
+        # walk each hive and validate that the GetCellRoutine handler
+        # is inside of the kernel (ntoskrnl)
+        for hive_object in hivelist.HiveList.list_hives(
+            context=self.context,
+            base_config_path=self.config_path,
+            layer_name=kernel.layer_name,
+            symbol_table=kernel.symbol_table_name
+        ):
+            hive = hive_object.hive
+
+            try:
+                cellroutine = hive.GetCellRoutine
+            except exceptions.InvalidAddressException:
+                continue
+
+            module_symbols = list(
+                collection.get_module_symbols_by_absolute_location(cellroutine)
+            )
+
+            if module_symbols:
+                for module_name, _ in module_symbols:
+                    # GetCellRoutine handlers should only be in the kernel
+                    if module_name not in constants.windows.KERNEL_MODULE_NAMES:
+                        yield (
+                            0,
+                            (
+                                format_hints.Hex(hive.vol.offset),
+                                hive_object.get_name() or "",
+                                module_name,
+                                format_hints.Hex(cellroutine)
+                            )
+                        )
+            # Doesn't map to any module...
+            else:
+                yield (
+                    0,
+                    (
+                        format_hints.Hex(hive.vol.offset),
+                        hive_object.get_name() or "",
+                        renderers.NotAvailableValue(),
+                        format_hints.Hex(cellroutine)
+                    )
+                )
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Hive Offset", renderers.format_hints.Hex),
+                ("Hive Name", str),
+                ("GetCellRoutine Module", str),
+                ("GetCellRoutine Handler", renderers.format_hints.Hex)
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/windows/registry/getcellroutine.py
+++ b/volatility3/framework/plugins/windows/registry/getcellroutine.py
@@ -14,7 +14,7 @@ from volatility3.plugins.windows.registry import hivelist
 vollog = logging.getLogger(__name__)
 
 class GetCellRoutine(interfaces.plugins.PluginInterface):
-    """ Reports registry hives with a hooked GetCellRoutine handler """
+    """Reports registry hives with a hooked GetCellRoutine handler"""
 
     _required_framework_version = (2, 0, 0)
 
@@ -32,7 +32,7 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
             requirements.PluginRequirement(
                 name="ssdt", plugin=ssdt.SSDT, version=(1, 0, 0)
             ),
-     ]
+        ]
 
     def _generator(self):
         kernel = self.context.modules[self.config["kernel"]]
@@ -47,7 +47,7 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
             context=self.context,
             base_config_path=self.config_path,
             layer_name=kernel.layer_name,
-            symbol_table=kernel.symbol_table_name
+            symbol_table=kernel.symbol_table_name,
         ):
             hive = hive_object.hive
 
@@ -70,7 +70,7 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
                                 format_hints.Hex(hive.vol.offset),
                                 hive_object.get_name() or "",
                                 module_name,
-                                format_hints.Hex(cellroutine)
+                                format_hints.Hex(cellroutine),
                             )
                         )
             # Doesn't map to any module...
@@ -81,7 +81,7 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
                         format_hints.Hex(hive.vol.offset),
                         hive_object.get_name() or "",
                         renderers.NotAvailableValue(),
-                        format_hints.Hex(cellroutine)
+                        format_hints.Hex(cellroutine),
                     )
                 )
 

--- a/volatility3/framework/plugins/windows/registry/getcellroutine.py
+++ b/volatility3/framework/plugins/windows/registry/getcellroutine.py
@@ -71,7 +71,7 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
                                 hive_object.get_name() or "",
                                 module_name,
                                 format_hints.Hex(cellroutine),
-                            )
+                            ),
                         )
             # Doesn't map to any module...
             else:
@@ -82,7 +82,7 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
                         hive_object.get_name() or "",
                         renderers.NotAvailableValue(),
                         format_hints.Hex(cellroutine),
-                    )
+                    ),
                 )
 
     def run(self):
@@ -91,7 +91,7 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
                 ("Hive Offset", renderers.format_hints.Hex),
                 ("Hive Name", str),
                 ("GetCellRoutine Module", str),
-                ("GetCellRoutine Handler", renderers.format_hints.Hex)
+                ("GetCellRoutine Handler", renderers.format_hints.Hex),
             ],
             self._generator(),
         )

--- a/volatility3/framework/plugins/windows/registry/getcellroutine.py
+++ b/volatility3/framework/plugins/windows/registry/getcellroutine.py
@@ -13,6 +13,7 @@ from volatility3.plugins.windows.registry import hivelist
 
 vollog = logging.getLogger(__name__)
 
+
 class GetCellRoutine(interfaces.plugins.PluginInterface):
     """Reports registry hives with a hooked GetCellRoutine handler"""
 

--- a/volatility3/framework/plugins/windows/registry/getcellroutine.py
+++ b/volatility3/framework/plugins/windows/registry/getcellroutine.py
@@ -1,4 +1,4 @@
-# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 


### PR DESCRIPTION
…ndlers of memory mapped Windows registry hives

This detects real-world rootkits such as https://www.fortinet.com/blog/threat-research/deep-panda-log4shell-fire-chili-rootkits, which is shown here:

```
$ python3 vol.py -r pretty -f crtsys.lime windows.registry.getcellroutine
Volatility 3 Framework 2.7.0
Formatting...0.00		PDB scanning finished                        
  |    Hive Offset |                Hive Name | GetCellRoutine Module | GetCellRoutine Handler
* | 0x9a869403d000 | \REGISTRY\MACHINE\SYSTEM |                crtsys |         0xf800f85d4cf0
```