### PR TITLE
Generic: Add vmscan plugin

### DIFF
--- a/volatility3/framework/plugins/vmscan.py
+++ b/volatility3/framework/plugins/vmscan.py
@@ -1,0 +1,217 @@
+# This file is Copyright 2023 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import enum
+import logging
+import os
+import struct
+from typing import Dict, List
+
+from volatility3.framework import constants, exceptions, interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import configuration, plugins
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.symbols import intermed
+
+vollog = logging.getLogger(__name__)
+
+
+class VMCSTest(enum.IntFlag):
+    VMCS_ABORT_INVALID = enum.auto()
+    VMCS_LINK_PTR_IS_NOT_FS = enum.auto()
+    VMCS_HOST_CR4_NO_VTX = enum.auto()
+    VMCS_CR3_IS_ZERO = enum.auto()
+    VMCS_GUEST_CR4_RESERVED = enum.auto()
+
+
+class PageStartScanner(interfaces.layers.ScannerInterface):
+    def __init__(self, signatures: List[bytes], page_size: int = 0x1000):
+        super().__init__()
+        if not len(signatures):
+            raise ValueError("No signatures passed to constructor")
+        self._siglen = len(signatures[0])
+        for item in signatures:
+            if len(item) != self._siglen:
+                raise ValueError(
+                    "Signatures of different lengths passed to PageStartScanner"
+                )
+        self._signatures = signatures
+        self._page_size = page_size
+
+    def __call__(self, data: bytes, data_offset: int):
+        """Scans only the start of every page, to see whether a signature is present or not"""
+        for page_start in range(
+            data_offset % self._page_size, len(data), self._page_size
+        ):
+            if data[page_start : page_start + self._siglen] in self._signatures:
+                yield (
+                    page_start + data_offset,
+                    data[page_start : page_start + self._siglen],
+                )
+
+
+class Vmscan(plugins.PluginInterface):
+    """Scans for Intel VT-d structues and generates VM volatility configs for them"""
+
+    _required_framework_version = (2, 2, 0)
+    _version = (1, 0, 0)
+
+    STRICTLY_REQUIRED_TESTS = {
+        VMCSTest.VMCS_ABORT_INVALID,
+        VMCSTest.VMCS_LINK_PTR_IS_NOT_FS,
+        VMCSTest.VMCS_HOST_CR4_NO_VTX,
+    }
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.TranslationLayerRequirement(
+                name="primary", description="Physical base memory layer"
+            ),
+            requirements.IntRequirement(
+                name="log-threshold",
+                description="Number of criteria failed to log to debug output",
+                default=2,
+                optional=True,
+            ),
+        ]
+
+    # Scan for VMCS structures based on the known VMCS structures
+    # found in symbols/vmcs directory
+
+    def _gather_vmcs_structures(
+        self, context: interfaces.context.ContextInterface, config_path: str
+    ) -> Dict[bytes, str]:
+        """Enumerate all JSON files containing VMCS information and return the structures
+        Signatures can be generated using data extracted using the vmcs_layout tool at
+        https://github.com/google/rekall/tree/master/tools/linux/vmcs_layout
+
+        Args:
+            context: The volatility context to work against
+            config_path: The location to store symbol table configurations under
+
+        Returns:
+            A dictionary of pattern bytes to the string representation of the architecture
+        """
+        filenames = intermed.IntermediateSymbolTable.file_symbol_url(
+            os.path.join("generic", "vmcs")
+        )
+        table_names = []
+        for filename in filenames:
+            base_name = os.path.basename(filename).split(".")[0]
+            table_name = intermed.IntermediateSymbolTable.create(
+                context,
+                configuration.path_join(config_path, "vmcs"),
+                os.path.join("generic", "vmcs"),
+                filename=base_name,
+            )
+            table_names.append(table_name)
+
+        result = {}
+        for table_name in table_names:
+            symbol_table = context.symbol_space[table_name]
+            revision_id = struct.pack(
+                "<I", int(symbol_table.get_symbol("revision_id").constant_data)
+            )
+            result[revision_id] = table_name
+
+        return result
+
+    @classmethod
+    def _verify_vmcs_page(
+        self,
+        context: interfaces.context.ContextInterface,
+        vmcs: interfaces.objects.ObjectInterface,
+    ) -> List[str]:
+        """Runs tests to verify whether a block of data is a VMCS page
+        Some tests based on the Hypervisor Memory Forensics paper by
+        Mariano Graziano, Andrea Lanzi and Davide Balzarotti
+
+        Args:
+            context: The volatility context to be used for this call
+            vmcs: The instantiated VMCS object to verify
+
+        Returns:
+            The list of failed criteria that the VMCS did not meet
+        """
+
+        # The VMCS should have been constructed on the physical layer (even a nested VMCS)
+        physical_layer_name = vmcs.vol.layer_name
+
+        failed_tests: VMCSTest = VMCSTest(0)
+        # The abort field must be valid (generally 0, although other abort codes may exist)
+        if context.layers[physical_layer_name].read(vmcs.vol.offset + 4, 4) not in [
+            b"\x00\x00\x00\x00"
+        ]:
+            failed_tests |= VMCSTest.VMCS_ABORT_INVALID
+        # The vmcs link pointer is supposed to always be set
+        if vmcs.vmcs_link_ptr != 0xFFFFFFFFFFFFFFFF:
+            failed_tests |= VMCSTest.VMCS_LINK_PTR_IS_NOT_FS
+        # To have a VMCS the host needs the VTx bit set in CR4, this can false positive often when all bits are set
+        if (vmcs.host_cr4 & 1 << 13) == 0:
+            failed_tests |= VMCSTest.VMCS_HOST_CR4_NO_VTX
+        # The guest CR3 is *exceptionally* unlikely to be 0 and the guest cr4 is likely to have some bits unset
+        if (vmcs.guest_cr3 == 0) or (vmcs.host_cr3 == 0):
+            failed_tests |= VMCSTest.VMCS_CR3_IS_ZERO
+        # CR4 registers have certain bits reserved that should not be set
+        if vmcs.guest_cr4 & 0xFFFFFFFFFF889000:
+            failed_tests |= VMCSTest.VMCS_GUEST_CR4_RESERVED
+
+        if failed_tests and failed_tests.name:
+            failed_list = failed_tests.name.split("|")
+            return failed_list
+
+        return []
+
+    def _generator(self):
+        # Gather VMCS structures
+        structures = self._gather_vmcs_structures(self.context, self.config_path)
+        # Scan memory for them
+        layer = self.context.layers[self.config["primary"]]
+
+        # Try to move down to the highest physical layer
+        if layer.config.get("memory_layer"):
+            layer = self.context.layers[layer.config["memory_layer"]]
+
+        # Run the scan
+        for offset, match in layer.scan(
+            self.context,
+            PageStartScanner(list(structures.keys())),
+            self._progress_callback,
+        ):
+            try:
+                vmcs = self.context.object(
+                    structures[match] + constants.BANG + "_VMCS",
+                    layer.name,
+                    offset=offset,
+                )
+                failed_list = self._verify_vmcs_page(self.context, vmcs)
+                if not failed_list:
+                    yield (
+                        0,
+                        (
+                            structures[match],
+                            format_hints.Hex(vmcs.vol.offset),
+                            format_hints.Hex(vmcs.ept),
+                            format_hints.Hex(vmcs.guest_cr3),
+                        ),
+                    )
+                    if len(failed_list) <= self.config["log-threshold"]:
+                        vollog.debug(
+                            f"Potential {structures[match]} VMCS found at {vmcs.vol.offset:x} with failed criteria: {failed_list}"
+                        )
+            except (exceptions.InvalidAddressException, AttributeError):
+                # Not what we're looking for
+                continue
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Architecture", str),
+                ("VMCS Physical offset", format_hints.Hex),
+                ("EPT", format_hints.Hex),
+                ("Guest CR3", format_hints.Hex),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/vmscan.py
+++ b/volatility3/framework/plugins/vmscan.py
@@ -120,7 +120,7 @@ class Vmscan(plugins.PluginInterface):
 
     @classmethod
     def _verify_vmcs_page(
-        self,
+        cls,
         context: interfaces.context.ContextInterface,
         vmcs: interfaces.objects.ObjectInterface,
     ) -> List[str]:

--- a/volatility3/symbols/generic/vmcs/haswell-architecture.json
+++ b/volatility3/symbols/generic/vmcs/haswell-architecture.json
@@ -1,0 +1,131 @@
+{
+  "base_types": {
+    "pointer": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 8
+    },
+    "unsigned char": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 1
+    },
+    "unsigned long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 4
+    },
+    "unsigned long long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 8
+    },
+    "unsigned short": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 2
+    }
+  },
+  "enums": {},
+  "metadata": {
+    "format": "6.1.0",
+    "producer": {
+      "datetime": "2021-07-31T17:37:28.313255",
+      "name": "vmextract-by-hand",
+      "version": "0.0.1"
+    }
+  },
+  "symbols": {
+    "revision_id": {
+      "address": 0,
+      "constant_data": "MTg="
+    }
+  },
+  "user_types": {
+    "_VMCS": {
+      "fields": {
+        "ept": {
+          "offset": 320,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "executive_vmcs_ptr": {
+          "offset": 208,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "guest_cr3": {
+          "offset": 528,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "guest_cr4": {
+          "offset": 536,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "guest_pdpte": {
+          "offset": 544,
+          "type": {
+            "count": 4,
+            "kind": "array",
+            "subtype": {
+              "kind": "struct",
+              "name": "unsigned long long"
+            }
+          }
+        },
+        "guest_physical_addr": {
+          "offset": 328,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "host_cr3": {
+          "offset": 816,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "host_cr4": {
+          "offset": 824,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "vmcs_link_ptr": {
+          "offset": 248,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned long long"
+          }
+        },
+        "vpid": {
+          "offset": 206,
+          "type": {
+            "kind": "struct",
+            "name": "unsigned short"
+          }
+        }
+      },
+      "kind": "struct",
+      "size": 4096
+    }
+  }
+}

--- a/volatility3/symbols/generic/vmcs/skylake-architecture.json
+++ b/volatility3/symbols/generic/vmcs/skylake-architecture.json
@@ -1,0 +1,131 @@
+{
+    "base_types": {
+        "pointer": {
+            "endian": "little",
+            "kind": "int",
+            "signed": false,
+            "size": 8
+        },
+        "unsigned char": {
+            "endian": "little",
+            "kind": "int",
+            "signed": false,
+            "size": 1
+        },
+        "unsigned long": {
+            "endian": "little",
+            "kind": "int",
+            "signed": false,
+            "size": 4
+        },
+        "unsigned long long": {
+            "endian": "little",
+            "kind": "int",
+            "signed": false,
+            "size": 8
+        },
+        "unsigned short": {
+            "endian": "little",
+            "kind": "int",
+            "signed": false,
+            "size": 2
+        }
+    },
+    "enums": {},
+    "metadata": {
+        "format": "6.1.0",
+        "producer": {
+            "datetime": "2021-07-16T16:21:01.062423",
+            "name": "vmextract-by-hand",
+            "version": "0.0.1"
+        }
+    },
+    "symbols": {
+        "revision_id": {
+            "address": 0,
+            "constant_data": "NA=="
+        }
+    },
+    "user_types": {
+        "_VMCS": {
+            "fields": {
+                "ept": {
+                    "offset": 320,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "executive_vmcs_ptr": {
+                    "offset": 208,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "guest_cr3": {
+                    "offset": 528,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "guest_cr4": {
+                    "offset": 536,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "guest_pdpte": {
+                    "offset": 544,
+                    "type": {
+                        "count": 4,
+                        "kind": "array",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "unsigned long long"
+                        }
+                    }
+                },
+                "guest_physical_addr": {
+                    "offset": 328,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "host_cr3": {
+                    "offset": 816,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "host_cr4": {
+                    "offset": 824,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "vmcs_link_ptr": {
+                    "offset": 248,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned long long"
+                    }
+                },
+                "vpid": {
+                    "offset": 206,
+                    "type": {
+                        "kind": "struct",
+                        "name": "unsigned short"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 4096
+        }
+    }
+}


### PR DESCRIPTION
Adds in a vmscan plugin that will search for a VMCS structure using profile information (currently profiles only exist for skylake and haswell architectures, but more can be added).  After we've found the VMCS location, we can determine the page table and load a layer on top of it, but we'll need to figure out how to then let people run plugins against those virtual images.  Probably by a config, but the config system may need rejigging to support partial information (layer) without an prepopulated module or symbol table...

Doesn't need everyone to review it, just not sure who's got the most knowledge of VMCS or Intel VT-d...