### PR TITLE
Linux: Replace uses of specific types with the more generic pointer

### DIFF
--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -159,7 +159,10 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
 
             # This we get for free
             aslr_shift = (
-                init_task.files.cast("pointer")
+                int.from_bytes(
+                    init_task.files.cast("bytes", length=init_task.files.vol.size),
+                    byteorder=init_task.files.vol.data_format.byteorder,
+                )
                 - module.get_symbol("init_files").address
             )
             kaslr_shift = init_task_address - cls.virtual_to_physical_address(

--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -159,7 +159,7 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
 
             # This we get for free
             aslr_shift = (
-                init_task.files.cast("long unsigned int")
+                init_task.files.cast("pointer")
                 - module.get_symbol("init_files").address
             )
             kaslr_shift = init_task_address - cls.virtual_to_physical_address(

--- a/volatility3/framework/plugins/linux/kmsg.py
+++ b/volatility3/framework/plugins/linux/kmsg.py
@@ -66,7 +66,7 @@ class ABCKmsg(ABC):
         self._config = config
         self.vmlinux = context.modules[self._config["kernel"]]
         self.layer_name = self.vmlinux.layer_name  # type: ignore
-        self.long_unsigned_int_size = self.vmlinux.get_type("long unsigned int").size
+        self.long_unsigned_int_size = self.vmlinux.get_type("pointer").size
 
     @classmethod
     def run_all(


### PR DESCRIPTION
Attempts to fix #1041 by changing hard coded types into the more general pointer (since the type is usually for a pointer).  This is due to LLVM producing a different base type.  It doesn't necessarily resolve the situation permanently, but it should alleviate the main situations where it arises.