### PR TITLE
add full and dev extras

### DIFF
--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -29,12 +29,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel
+        pip install build
 
     - name: Build PyPi packages
       run: |
-        python setup.py sdist --formats=gztar,zip
-        python setup.py bdist_wheel
+        python -m build
 
     - name: Archive dist
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,13 +18,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install Cmake
-        pip install setuptools wheel
+        pip install build
         pip install -r ./test/requirements-testing.txt
 
     - name: Build PyPi packages
       run: |
-        python setup.py sdist --formats=gztar,zip
-        python setup.py bdist_wheel
+        python -m build
 
     - name: Download images
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ config*.json
 # Pyinstaller files
 build
 dist
+*.egg-info
 
 # Environments
 .env

--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ Volatility 3 requires Python 3.7.0 or later. To install the most minimal set of 
 pip3 install -r requirements-minimal.txt
 ```
 
-Alternately, the minimal packages will be installed automatically when Volatility 3 is installed using setup.py. However, as noted in the Quick Start section below, Volatility 3 does not *need* to be installed via setup.py prior to using it.
+Alternately, the minimal packages will be installed automatically when Volatility 3 is installed using pip. However, as noted in the Quick Start section below, Volatility 3 does not *need* to be installed prior to using it.
 
 ```shell
-python3 setup.py build 
-python3 setup.py install
+pip3 install .
 ```
 
 To enable the full range of Volatility 3 functionality, use a command like the one below. For partial functionality, comment out any unnecessary packages in [requirements.txt](requirements.txt) prior to running the command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "volatility3"
+description = "Memory forensics framework"
+keywords = ["volatility", "memory", "forensics", "framework", "windows", "linux", "volshell"]
+readme = "README.md"
+authors = [
+    { name = "Volatility Foundation", email = "volatility@volatilityfoundation.org" },
+]
+requires-python = ">=3.7.0"
+license = { text = "VSL" }
+dynamic = ["dependencies", "optional-dependencies", "version"]
+
+[project.urls]
+Homepage = "https://github.com/volatilityfoundation/volatility3/"
+"Bug Tracker" = "https://github.com/volatilityfoundation/volatility3/issues"
+Documentation = "https://volatility3.readthedocs.io/"
+"Source Code" = "https://github.com/volatilityfoundation/volatility3"
+
+[project.scripts]
+vol = "volatility3.cli:main"
+volshell = "volatility3.cli.volshell:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "volatility3.framework.constants._version.PACKAGE_VERSION" }
+dependencies = { file = "requirements-minimal.txt" }
+
+[tool.setuptools.packages.find]
+include = ["volatility3*"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ capstone>=3.0.5
 pycryptodome
 
 # This is required for memory acquisition via leechcore/pcileech.
-leechcorepyc>=2.4.0
+leechcorepyc>=2.4.0; sys_platform != 'darwin'
 
 # This is required for memory analysis on a Amazon/MinIO S3 and Google Cloud object storage
 gcsfs>=2023.1.0

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 
-def get_install_requires():
+def get_requires(filename):
     requirements = []
-    with open("requirements-minimal.txt", "r", encoding="utf-8") as fh:
+    with open(filename, "r", encoding="utf-8") as fh:
         for line in fh.readlines():
             stripped_line = line.strip()
-            if stripped_line == "" or stripped_line.startswith("#"):
+            if stripped_line == "" or stripped_line.startswith(("#", "-r")):
                 continue
             requirements.append(stripped_line)
     return requirements
@@ -49,5 +49,9 @@ setuptools.setup(
             "volshell = volatility3.cli.volshell:main",
         ],
     },
-    install_requires=get_install_requires(),
+    install_requires=get_requires("requirements-minimal.txt"),
+    extras_require={
+        "dev": get_requires("requirements-dev.txt"),
+        "full": get_requires("requirements.txt"),
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,6 @@
 
 import setuptools
 
-from volatility3.framework import constants
-
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
-
 
 def get_requires(filename):
     requirements = []
@@ -22,34 +17,6 @@ def get_requires(filename):
 
 
 setuptools.setup(
-    name="volatility3",
-    description="Memory forensics framework",
-    version=constants.PACKAGE_VERSION,
-    license="VSL",
-    keywords="volatility memory forensics framework windows linux volshell",
-    author="Volatility Foundation",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author_email="volatility@volatilityfoundation.org",
-    url="https://github.com/volatilityfoundation/volatility3/",
-    project_urls={
-        "Bug Tracker": "https://github.com/volatilityfoundation/volatility3/issues",
-        "Documentation": "https://volatility3.readthedocs.io/",
-        "Source Code": "https://github.com/volatilityfoundation/volatility3",
-    },
-    packages=setuptools.find_namespace_packages(
-        include=["volatility3", "volatility3.*"]
-    ),
-    package_dir={"volatility3": "volatility3"},
-    python_requires=">=3.7.0",
-    include_package_data=True,
-    entry_points={
-        "console_scripts": [
-            "vol = volatility3.cli:main",
-            "volshell = volatility3.cli.volshell:main",
-        ],
-    },
-    install_requires=get_requires("requirements-minimal.txt"),
     extras_require={
         "dev": get_requires("requirements-dev.txt"),
         "full": get_requires("requirements.txt"),

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -14,6 +14,13 @@ from typing import Callable, Optional
 
 import volatility3.framework.constants.linux
 import volatility3.framework.constants.windows
+from volatility3.framework.constants._version import (
+    PACKAGE_VERSION,
+    VERSION_MAJOR,
+    VERSION_MINOR,
+    VERSION_PATCH,
+    VERSION_SUFFIX,
+)
 
 PLUGINS_PATH = [
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "plugins")),
@@ -41,20 +48,6 @@ if hasattr(sys, "frozen") and sys.frozen:
 
 BANG = "!"
 """Constant used to delimit table names from type names when referring to a symbol"""
-
-# We use the SemVer 2.0.0 versioning scheme
-VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 7  # Number of changes that only add to the interface
-VERSION_PATCH = 1  # Number of changes that do not change the interface
-VERSION_SUFFIX = ""
-
-# TODO: At version 2.0.0, remove the symbol_shift feature
-
-PACKAGE_VERSION = (
-    ".".join([str(x) for x in [VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH]])
-    + VERSION_SUFFIX
-)
-"""The canonical version of the volatility3 package"""
 
 AUTOMAGIC_CONFIG_PATH = "automagic"
 """The root section within the context configuration for automagic values"""

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,0 +1,13 @@
+# We use the SemVer 2.0.0 versioning scheme
+VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
+VERSION_MINOR = 7  # Number of changes that only add to the interface
+VERSION_PATCH = 1  # Number of changes that do not change the interface
+VERSION_SUFFIX = ""
+
+# TODO: At version 2.0.0, remove the symbol_shift feature
+
+PACKAGE_VERSION = (
+    ".".join([str(x) for x in [VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH]])
+    + VERSION_SUFFIX
+)
+"""The canonical version of the volatility3 package"""

--- a/volatility3/framework/interfaces/automagic.py
+++ b/volatility3/framework/interfaces/automagic.py
@@ -50,7 +50,7 @@ class AutomagicInterface(
         context: interfaces.context.ContextInterface,
         config_path: str,
         *args,
-        **kwargs
+        **kwargs,
     ) -> None:
         super().__init__(context, config_path)
         for requirement in self.get_requirements():


### PR DESCRIPTION
This does two main things, split into separate commits. Main motivation for the PR is the first commit:

- Adds a `full` extra mapping to requirements.txt so users can `pip install volatility3[full]`
  - We can't install `leechcorepyc` on macos since [it's unsupported](https://github.com/ufrisk/LeechCore/issues/36)
  - We must strip the `-r` lines since they are not PEP 508 compliant
- Adds a `dev` extra mapping to requirements-dev.txt so devs can `pip install -e .[dev]`

Second commit migrates all static metadata to pyproject.toml (the modern [replacement for setup.py](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/)). Two things to note:

- When setuptools reads the dynamic `version`, `volatility3` won't be importable (due to build isolation) so I've moved the version constants to a separate file
- I had to keep `setup.py` around just to strip to strip the `-r` lines for the new extras. If you don't mind changing the dev workflow from `pip3 install -r requirements-dev.txt` to `pip3 install -e .[dev]`, we could remove `setup.py` entirely
