### PR TITLE
Add new resident data displaying plugin. Scan in correct layer. Condense code and remove duplication. Fix bugs

### DIFF
--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -105,7 +105,9 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 # There is no field that has a count of Attributes
                 # Keep Attempting to read attributes until we get an invalid attr_header.AttrType
                 while attr.Attr_Header.AttrType.is_valid_choice:
-                    for record in attr_callback(record_map, mft_record, attr, symbol_table):
+                    for record in attr_callback(
+                        record_map, mft_record, attr, symbol_table
+                    ):
                         yield record
 
                     # If there's no advancement the loop will never end, so break it now
@@ -357,7 +359,9 @@ class ADS(interfaces.plugins.PluginInterface):
         attr: interfaces.objects.ObjectInterface,
         symbol_table,
     ):
-        return MFTScan.parse_data_records(record_map, mft_record, attr, symbol_table, False)
+        return MFTScan.parse_data_records(
+            record_map, mft_record, attr, symbol_table, False
+        )
 
     def _generator(self):
         for (
@@ -421,7 +425,9 @@ class ResidentData(interfaces.plugins.PluginInterface):
         attr: interfaces.objects.ObjectInterface,
         symbol_table,
     ):
-        return MFTScan.parse_data_records(record_map, mft_record, attr, symbol_table, True)
+        return MFTScan.parse_data_records(
+            record_map, mft_record, attr, symbol_table, True
+        )
 
     def _generator(self):
         for (

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -105,9 +105,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 # There is no field that has a count of Attributes
                 # Keep Attempting to read attributes until we get an invalid attr_header.AttrType
                 while attr.Attr_Header.AttrType.is_valid_choice:
-                    yield from attr_callback(
-                        record_map, mft_record, attr, symbol_table
-                    )
+                    yield from attr_callback(record_map, mft_record, attr, symbol_table)
 
                     # If there's no advancement the loop will never end, so break it now
                     if attr.Attr_Header.Length == 0:
@@ -271,7 +269,10 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     def _generator(self):
         for record in self.enumerate_mft_records(
-            self.context, self.config_path, self.config["primary"], self.parse_mft_records
+            self.context,
+            self.config_path,
+            self.config["primary"],
+            self.parse_mft_records,
         ):
             yield record
 
@@ -352,7 +353,10 @@ class ADS(interfaces.plugins.PluginInterface):
             ads_name,
             content,
         ) in MFTScan.enumerate_mft_records(
-            self.context, self.config_path, self.config["primary"], self.parse_ads_data_records
+            self.context,
+            self.config_path,
+            self.config["primary"],
+            self.parse_ads_data_records,
         ):
             yield (
                 0,
@@ -418,7 +422,10 @@ class ResidentData(interfaces.plugins.PluginInterface):
             _,
             content,
         ) in MFTScan.enumerate_mft_records(
-            self.context, self.config_path, self.config["primary"], self.parse_first_data_records
+            self.context,
+            self.config_path,
+            self.config["primary"],
+            self.parse_first_data_records,
         ):
             yield (0, (offset, rec_type, rec_num, attr_type, file_name, content))
 

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -56,7 +56,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             class_types={
                 "FILE_NAME_ENTRY": mft.MFTFileName,
                 "MFT_ENTRY": mft.MFTEntry,
-                "ATTRIBUTE": mft.MFTAttribute
+                "ATTRIBUTE": mft.MFTAttribute,
             },
         )
 

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -44,7 +44,17 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         ]
 
     def enumerate_mft_records(self, attr_callback):
-        phys_layer = self.context.layers[self.config["primary"]].config["memory_layer"]
+        try:
+            primary = self.context.layers[self.config["primary"]]
+        except KeyError:
+            vollog.error("Unable to obtain primary layer for scanning. Please file a bug on GitHub about this issue.")
+            return
+
+        try:
+            phys_layer = primary.config["memory_layer"]
+        except KeyError:
+            vollog.error("Unable to obtain memory layer from primary layer. Please file a bug on GitHub about this issue.")
+            return
 
         layer = self.context.layers[phys_layer]
 

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -215,11 +215,11 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             content = renderers.NotAvailableValue()
 
         yield (
-            format_hints.Hex(record_map[mft_record.RecordNumber][2]),
+            format_hints.Hex(record_map[mft_record.vol.offset][2]),
             mft_record.get_signature(),
             mft_record.RecordNumber,
             attr.Attr_Header.AttrType.lookup(),
-            record_map[mft_record.RecordNumber][0],
+            record_map[mft_record.vol.offset][0],
             ads_name,
             content,
         )
@@ -239,31 +239,29 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         Suports returning the first/main $DATA as well as however many
         ADS records a file might have
         """
-        rec_num = mft_record.RecordNumber
-        if rec_num not in record_map:
+        if mft_record.vol.offset not in record_map:
             # file name, DATA count, offset
-            record_map[rec_num] = [renderers.NotAvailableValue(), 0, None]
-
+            record_map[mft_record.vol.offset] = [renderers.NotAvailableValue(), 0, None]
         if attr.Attr_Header.AttrType.lookup() == "FILE_NAME":
             fn_object = symbol_table + constants.BANG + "FILE_NAME_ENTRY"
             attr_data = attr.Attr_Data.cast(fn_object)
             rec_name = attr_data.get_full_name()
-            record_map[rec_num][0] = rec_name
+            record_map[mft_record.vol.offset][0] = rec_name
         elif attr.Attr_Header.AttrType.lookup() == "DATA":
             # first data
-            record_map[rec_num][2] = attr.Attr_Data.vol.offset
+            record_map[mft_record.vol.offset][2] = attr.Attr_Data.vol.offset
 
             display_data = False
 
             # first DATA attribute of this record
-            if record_map[rec_num][1] == 0:
+            if record_map[mft_record.vol.offset][1] == 0:
                 if return_first_record:
                     display_data = True
 
-                record_map[rec_num][1] = 1
+                record_map[mft_record.vol.offset][1] = 1
 
             # at the second DATA attribute of this record
-            elif record_map[rec_num][1] == 1 and not return_first_record:
+            elif record_map[mft_record.vol.offset][1] == 1 and not return_first_record:
                 print("at second record")
                 display_data = True
 

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -47,13 +47,17 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         try:
             primary = self.context.layers[self.config["primary"]]
         except KeyError:
-            vollog.error("Unable to obtain primary layer for scanning. Please file a bug on GitHub about this issue.")
+            vollog.error(
+                "Unable to obtain primary layer for scanning. Please file a bug on GitHub about this issue."
+            )
             return
 
         try:
             phys_layer = primary.config["memory_layer"]
         except KeyError:
-            vollog.error("Unable to obtain memory layer from primary layer. Please file a bug on GitHub about this issue.")
+            vollog.error(
+                "Unable to obtain memory layer from primary layer. Please file a bug on GitHub about this issue."
+            )
             return
 
         layer = self.context.layers[phys_layer]

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -20,6 +20,10 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     _required_framework_version = (2, 0, 0)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._record_map = {}
+
     @classmethod
     def get_requirements(cls):
         return [
@@ -33,8 +37,10 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             ),
         ]
 
-    def _generator(self):
-        layer = self.context.layers[self.config["primary"]]
+    def enumerate_mft_records(self, attr_callback):
+        phys_layer = self.context.layers[self.config["primary"]].config["memory_layer"]
+
+        layer = self.context.layers[phys_layer]
 
         # Yara Rule to scan for MFT Header Signatures
         rules = yarascan.YaraScan.process_yara_options(
@@ -47,87 +53,36 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             config_path=self.config_path,
             sub_path="windows",
             filename="mft",
-            class_types={"FILE_NAME_ENTRY": mft.MFTFileName, "MFT_ENTRY": mft.MFTEntry},
+            class_types={"FILE_NAME_ENTRY": mft.MFTFileName, "MFT_ENTRY": mft.MFTEntry, "ATTRIBUTE": mft.MFTAttribute},
         )
 
         # get each of the individual Field Sets
-        mft_object = symbol_table + constants.BANG + "MFT_ENTRY"
-        attribute_object = symbol_table + constants.BANG + "ATTRIBUTE"
-        si_object = symbol_table + constants.BANG + "STANDARD_INFORMATION_ENTRY"
-        fn_object = symbol_table + constants.BANG + "FILE_NAME_ENTRY"
+        self.mft_object = symbol_table + constants.BANG + "MFT_ENTRY"
+        self.attribute_object = symbol_table + constants.BANG + "ATTRIBUTE"
+        self.si_object = symbol_table + constants.BANG + "STANDARD_INFORMATION_ENTRY"
+        self.fn_object = symbol_table + constants.BANG + "FILE_NAME_ENTRY"
 
         # Scan the layer for Raw MFT records and parse the fields
-        for offset, _rule_name, _name, _value in layer.scan(
+        for offset, _, _, _ in layer.scan(
             context=self.context, scanner=yarascan.YaraScanner(rules=rules)
         ):
-            with contextlib.suppress(exceptions.PagedInvalidAddressException):
+            with contextlib.suppress(exceptions.InvalidAddressException):
                 mft_record = self.context.object(
-                    mft_object, offset=offset, layer_name=layer.name
+                    self.mft_object, offset=offset, layer_name=layer.name
                 )
                 # We will update this on each pass in the next loop and use it as the new offset.
                 attr_base_offset = mft_record.FirstAttrOffset
                 attr = self.context.object(
-                    attribute_object,
+                    self.attribute_object,
                     offset=offset + attr_base_offset,
                     layer_name=layer.name,
                 )
 
                 # There is no field that has a count of Attributes
                 # Keep Attempting to read attributes until we get an invalid attr_header.AttrType
-
                 while attr.Attr_Header.AttrType.is_valid_choice:
-                    vollog.debug(f"Attr Type: {attr.Attr_Header.AttrType.lookup()}")
-
-                    # MFT Flags determine the file type or dir
-                    # If we don't have a valid enum, coerce to hex so we can keep the record
-                    try:
-                        mft_flag = mft_record.Flags.lookup()
-                    except ValueError:
-                        mft_flag = hex(mft_record.Flags)
-
-                    # Standard Information Attribute
-                    if attr.Attr_Header.AttrType.lookup() == "STANDARD_INFORMATION":
-                        attr_data = attr.Attr_Data.cast(si_object)
-                        yield 0, (
-                            format_hints.Hex(attr_data.vol.offset),
-                            mft_record.get_signature(),
-                            mft_record.RecordNumber,
-                            mft_record.LinkCount,
-                            mft_flag,
-                            renderers.NotApplicableValue(),
-                            attr.Attr_Header.AttrType.lookup(),
-                            conversion.wintime_to_datetime(attr_data.CreationTime),
-                            conversion.wintime_to_datetime(attr_data.ModifiedTime),
-                            conversion.wintime_to_datetime(attr_data.UpdatedTime),
-                            conversion.wintime_to_datetime(attr_data.AccessedTime),
-                            renderers.NotApplicableValue(),
-                        )
-
-                    # File Name Attribute
-                    if attr.Attr_Header.AttrType.lookup() == "FILE_NAME":
-                        attr_data = attr.Attr_Data.cast(fn_object)
-                        file_name = attr_data.get_full_name()
-
-                        # If we don't have a valid enum, coerce to hex so we can keep the record
-                        try:
-                            permissions = attr_data.Flags.lookup()
-                        except ValueError:
-                            permissions = hex(attr_data.Flags)
-
-                        yield 1, (
-                            format_hints.Hex(attr_data.vol.offset),
-                            mft_record.get_signature(),
-                            mft_record.RecordNumber,
-                            mft_record.LinkCount,
-                            mft_flag,
-                            permissions,
-                            attr.Attr_Header.AttrType.lookup(),
-                            conversion.wintime_to_datetime(attr_data.CreationTime),
-                            conversion.wintime_to_datetime(attr_data.ModifiedTime),
-                            conversion.wintime_to_datetime(attr_data.UpdatedTime),
-                            conversion.wintime_to_datetime(attr_data.AccessedTime),
-                            file_name,
-                        )
+                    for record in attr_callback(mft_record, attr):
+                        yield record
 
                     # If there's no advancement the loop will never end, so break it now
                     if attr.Attr_Header.Length == 0:
@@ -135,11 +90,68 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
                     # Update the base offset to point to the next attribute
                     attr_base_offset += attr.Attr_Header.Length
+                    # Get the next attribute
                     attr = self.context.object(
-                        attribute_object,
+                        self.attribute_object,
                         offset=offset + attr_base_offset,
                         layer_name=layer.name,
                     )
+
+    def parse_mft_records(self, mft_record, attr):
+        # MFT Flags determine the file type or dir
+        # If we don't have a valid enum, coerce to hex so we can keep the record
+        try:
+            mft_flag = mft_record.Flags.lookup()
+        except ValueError:
+            mft_flag = hex(mft_record.Flags)
+
+        # Standard Information Attribute
+        if attr.Attr_Header.AttrType.lookup() == "STANDARD_INFORMATION":
+            attr_data = attr.Attr_Data.cast(self.si_object)
+            yield 0, (
+                format_hints.Hex(attr_data.vol.offset),
+                mft_record.get_signature(),
+                mft_record.RecordNumber,
+                mft_record.LinkCount,
+                mft_flag,
+                renderers.NotApplicableValue(),
+                attr.Attr_Header.AttrType.lookup(),
+                conversion.wintime_to_datetime(attr_data.CreationTime),
+                conversion.wintime_to_datetime(attr_data.ModifiedTime),
+                conversion.wintime_to_datetime(attr_data.UpdatedTime),
+                conversion.wintime_to_datetime(attr_data.AccessedTime),
+                renderers.NotApplicableValue(),
+            )
+
+        # File Name Attribute
+        elif attr.Attr_Header.AttrType.lookup() == "FILE_NAME":
+            attr_data = attr.Attr_Data.cast(self.fn_object)
+            file_name = attr_data.get_full_name()
+
+            # If we don't have a valid enum, coerce to hex so we can keep the record
+            try:
+                permissions = attr_data.Flags.lookup()
+            except ValueError:
+                permissions = hex(attr_data.Flags)
+
+            yield 1, (
+                format_hints.Hex(attr_data.vol.offset),
+                mft_record.get_signature(),
+                mft_record.RecordNumber,
+                mft_record.LinkCount,
+                mft_flag,
+                permissions,
+                attr.Attr_Header.AttrType.lookup(),
+                conversion.wintime_to_datetime(attr_data.CreationTime),
+                conversion.wintime_to_datetime(attr_data.ModifiedTime),
+                conversion.wintime_to_datetime(attr_data.UpdatedTime),
+                conversion.wintime_to_datetime(attr_data.AccessedTime),
+                file_name,
+            )
+
+    def _generator(self):
+        for record in self.enumerate_mft_records(self.parse_mft_records):
+            yield record
 
     def generate_timeline(self):
         for row in self._generator():
@@ -173,127 +185,98 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             self._generator(),
         )
 
-
-class ADS(interfaces.plugins.PluginInterface):
+class ADS(MFTScan):
     """Scans for Alternate Data Stream"""
 
     _required_framework_version = (2, 0, 0)
 
-    @classmethod
-    def get_requirements(cls):
-        return [
-            requirements.TranslationLayerRequirement(
-                name="primary",
-                description="Memory layer for the kernel",
-                architectures=["Intel32", "Intel64"],
-            ),
-            requirements.VersionRequirement(
-                name="yarascanner", component=yarascan.YaraScanner, version=(2, 0, 0)
-            ),
-        ]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # which DATA attribute should be displayed
+        self._display_first_data = False
+
+    def _parse_data_record(self, mft_record, attr):
+        if attr.Attr_Header.NonResidentFlag:
+            return
+
+        # regular $DATA
+        if self._display_first_data:
+            content = attr.get_resident_filecontent()
+            if content:
+                content = format_hints.HexBytes(content)
+            else:
+                content = renderers.NotAvailableValue()
+
+            yield 0, (
+                format_hints.Hex(self._record_map[mft_record.RecordNumber][2]),
+                mft_record.get_signature(),
+                mft_record.RecordNumber,
+                attr.Attr_Header.AttrType.lookup(),
+                self._record_map[mft_record.RecordNumber][0],
+                content,
+            )
+
+        # ADS $DATA
+        elif attr.Attr_Header.NameLength > 0:
+            ads_name = attr.get_resident_filename()
+            if not ads_name:
+                ads_name = renderers.NotAvailableValue()
+
+            content = attr.get_resident_filecontent()
+            if content:
+                content = format_hints.HexBytes(content)
+            else:
+                content = renderers.NotAvailableValue()
+
+            yield 0, (
+                format_hints.Hex(self._record_map[mft_record.RecordNumber][2]),
+                mft_record.get_signature(),
+                mft_record.RecordNumber,
+                attr.Attr_Header.AttrType.lookup(),
+                self._record_map[mft_record.RecordNumber][0],
+                ads_name,
+                content,
+            )
+
+    def parse_data_records(self, mft_record, attr):
+        rec_num = mft_record.RecordNumber
+        if rec_num not in self._record_map:
+                                        # file name, DATA count, offset
+            self._record_map[rec_num] = [renderers.NotAvailableValue(), 0, None]
+
+        if attr.Attr_Header.AttrType.lookup() == "FILE_NAME":
+            attr_data = attr.Attr_Data.cast(self.fn_object)
+            rec_name = attr_data.get_full_name()
+            self._record_map[rec_num][0] = rec_name
+        elif attr.Attr_Header.AttrType.lookup() == "DATA":
+            # first data
+            self._record_map[rec_num][2] = attr.Attr_Data.vol.offset
+
+            display_data = False
+
+            # first DATA attribute of this record
+            if self._record_map[rec_num][1] == 0:
+                if self._display_first_data:
+                    display_data = True
+                else:
+                    self._record_map[rec_num][1] = 1
+
+            # at the second DATA attribute of this record
+            elif not self._display_first_data:
+                display_data = True
+
+            if display_data:
+                for record in self._parse_data_record(
+                    mft_record, attr
+                ):
+                    yield record
 
     def _generator(self):
-        layer = self.context.layers[self.config["primary"]]
-
-        # Yara Rule to scan for MFT Header Signatures
-        rules = yarascan.YaraScan.process_yara_options(
-            {"yara_string": "/FILE0|FILE\\*|BAAD/"}
-        )
-
-        # Read in the Symbol File
-        symbol_table = intermed.IntermediateSymbolTable.create(
-            context=self.context,
-            config_path=self.config_path,
-            sub_path="windows",
-            filename="mft",
-            class_types={
-                "MFT_ENTRY": mft.MFTEntry,
-                "FILE_NAME_ENTRY": mft.MFTFileName,
-                "ATTRIBUTE": mft.MFTAttribute,
-            },
-        )
-
-        # get each of the individual Field Sets
-        mft_object = symbol_table + constants.BANG + "MFT_ENTRY"
-        attribute_object = symbol_table + constants.BANG + "ATTRIBUTE"
-        fn_object = symbol_table + constants.BANG + "FILE_NAME_ENTRY"
-
-        # Scan the layer for Raw MFT records and parse the fields
-        for offset, _rule_name, _name, _value in layer.scan(
-            context=self.context, scanner=yarascan.YaraScanner(rules=rules)
+        for record in self.enumerate_mft_records(
+            self.parse_data_records
         ):
-            with contextlib.suppress(exceptions.PagedInvalidAddressException):
-                mft_record = self.context.object(
-                    mft_object, offset=offset, layer_name=layer.name
-                )
-                # We will update this on each pass in the next loop and use it as the new offset.
-                attr_base_offset = mft_record.FirstAttrOffset
-
-                attr = self.context.object(
-                    attribute_object,
-                    offset=offset + attr_base_offset,
-                    layer_name=layer.name,
-                )
-
-                # There is no field that has a count of Attributes
-                # Keep Attempting to read attributes until we get an invalid attr.AttrType
-                is_ads = False
-                file_name = renderers.NotAvailableValue
-                # The First $DATA Attr is the 'principal' file itself not the ADS
-                while attr.Attr_Header.AttrType.is_valid_choice:
-                    if attr.Attr_Header.AttrType.lookup() == "FILE_NAME":
-                        attr_data = attr.Attr_Data.cast(fn_object)
-                        file_name = attr_data.get_full_name()
-                    if attr.Attr_Header.AttrType.lookup() == "DATA":
-                        if is_ads:
-                            if not attr.Attr_Header.NonResidentFlag:
-                                # Resident files are the most interesting.
-                                if attr.Attr_Header.NameLength > 0:
-                                    ads_name = attr.get_resident_filename()
-                                    if not ads_name:
-                                        ads_name = renderers.NotAvailableValue
-
-                                    content = attr.get_resident_filecontent()
-                                    if content:
-                                        # Preparing for Disassembly
-                                        disasm = interfaces.renderers.BaseAbsentValue
-                                        architecture = layer.metadata.get(
-                                            "architecture", None
-                                        )
-                                        if architecture:
-                                            disasm = interfaces.renderers.Disassembly(
-                                                content, 0, architecture.lower()
-                                            )
-                                        content = format_hints.HexBytes(content)
-                                    else:
-                                        content = renderers.NotAvailableValue()
-                                        disasm = interfaces.renderers.BaseAbsentValue()
-
-                                    yield 0, (
-                                        format_hints.Hex(attr_data.vol.offset),
-                                        mft_record.get_signature(),
-                                        mft_record.RecordNumber,
-                                        attr.Attr_Header.AttrType.lookup(),
-                                        file_name,
-                                        ads_name,
-                                        content,
-                                        disasm,
-                                    )
-                        else:
-                            is_ads = True
-
-                    # If there's no advancement the loop will never end, so break it now
-                    if attr.Attr_Header.Length == 0:
-                        break
-
-                    # Update the base offset to point to the next attribute
-                    attr_base_offset += attr.Attr_Header.Length
-                    # Get the next attribute
-                    attr = self.context.object(
-                        attribute_object,
-                        offset=offset + attr_base_offset,
-                        layer_name=layer.name,
-                    )
+            yield record
 
     def run(self):
         return renderers.TreeGrid(
@@ -305,7 +288,31 @@ class ADS(interfaces.plugins.PluginInterface):
                 ("Filename", str),
                 ("ADS Filename", str),
                 ("Hexdump", format_hints.HexBytes),
-                ("Disasm", interfaces.renderers.Disassembly),
             ],
             self._generator(),
         )
+
+class ResidentData(ADS):
+    """Scans for Alternate Data Stream"""
+
+    _required_framework_version = (2, 0, 0)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # which DATA attribute should be displayed
+        self._display_first_data = True
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Offset", format_hints.Hex),
+                ("Record Type", str),
+                ("Record Number", int),
+                ("MFT Type", str),
+                ("Filename", str),
+                ("Hexdump", format_hints.HexBytes),
+            ],
+            self._generator(),
+        )
+

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -42,7 +42,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         context: interfaces.context.ContextInterface,
         config: interfaces.configuration.HierarchicalDict,
         config_path: str,
-        attr_callback
+        attr_callback,
     ) -> interfaces.objects.ObjectInterface:
         try:
             primary = context.layers[config["primary"]]

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -53,7 +53,11 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             config_path=self.config_path,
             sub_path="windows",
             filename="mft",
-            class_types={"FILE_NAME_ENTRY": mft.MFTFileName, "MFT_ENTRY": mft.MFTEntry, "ATTRIBUTE": mft.MFTAttribute},
+            class_types={
+                "FILE_NAME_ENTRY": mft.MFTFileName,
+                "MFT_ENTRY": mft.MFTEntry,
+                "ATTRIBUTE": mft.MFTAttribute
+            },
         )
 
         # get each of the individual Field Sets
@@ -185,6 +189,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             self._generator(),
         )
 
+
 class ADS(MFTScan):
     """Scans for Alternate Data Stream"""
 
@@ -242,7 +247,7 @@ class ADS(MFTScan):
     def parse_data_records(self, mft_record, attr):
         rec_num = mft_record.RecordNumber
         if rec_num not in self._record_map:
-                                        # file name, DATA count, offset
+            # file name, DATA count, offset
             self._record_map[rec_num] = [renderers.NotAvailableValue(), 0, None]
 
         if attr.Attr_Header.AttrType.lookup() == "FILE_NAME":
@@ -267,15 +272,11 @@ class ADS(MFTScan):
                 display_data = True
 
             if display_data:
-                for record in self._parse_data_record(
-                    mft_record, attr
-                ):
+                for record in self._parse_data_record(mft_record, attr):
                     yield record
 
     def _generator(self):
-        for record in self.enumerate_mft_records(
-            self.parse_data_records
-        ):
+        for record in self.enumerate_mft_records(self.parse_data_records):
             yield record
 
     def run(self):
@@ -291,6 +292,7 @@ class ADS(MFTScan):
             ],
             self._generator(),
         )
+
 
 class ResidentData(ADS):
     """Scans for Alternate Data Stream"""
@@ -315,4 +317,3 @@ class ResidentData(ADS):
             ],
             self._generator(),
         )
-


### PR DESCRIPTION
This MR performs a number of tasks related to the mftscan file and MFT-related functionatlity:

1) Fixes bugs, such as incorrect instantiation of absent values

2) Creates a unified and inheritable code flow for plugins that want to parse MFT records and their attributes.

3) Previously, ADSscan and MFTScan scanned in the kernel virtual address space, which is incorrect and caused in many samples over half the entries to be missed. These scans should occur in the physical address space.

4) Stops printing a disassembly of ADS data, which makes no sense anyway and made the output strange.

4) Adds a new plugin, ResidentData, in the file that hexdumps all of the resident data of a file (the first $DATA attribute). This inherits and uses a combined implementation of $DATA attribute access from the ADS plugin, which displays the second (and third and fourth ..., if present) $DATA attribute. Volatility 2 displayed resident data inline with the regular MFTscan type output, but this was confusing and would break grep results.