### PR TITLE
Add threads and suspicious_threads plugins. Condense code for re-use

### DIFF
--- a/volatility3/framework/plugins/windows/suspicious_threads.py
+++ b/volatility3/framework/plugins/windows/suspicious_threads.py
@@ -1,0 +1,201 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List
+from volatility3.framework import renderers, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import pslist, threads, vadinfo, thrdscan
+
+vollog = logging.getLogger(__name__)
+
+
+class SupsiciousThreads(interfaces.plugins.PluginInterface):
+    """Lists suspicious userland process threads"""
+
+    _required_framework_version = (2, 4, 0)
+    _version = (2, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                description="Filter on specific process IDs",
+                element_type=int,
+                optional=True,
+            ),
+            requirements.PluginRequirement(
+                name="threads", plugin=threads.Threads, version=(1, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="vadinfo", component=vadinfo.VadInfo, version=(2, 0, 0)
+            ),
+        ]
+
+    def _get_ranges(self, kernel, all_ranges, proc):
+        """
+        Maintains a hash table so each process' VADs
+        are only enumerated once per plugin run
+        """
+        key = proc.vol.offset
+
+        if key not in all_ranges:
+            all_ranges[key] = []
+
+            for vad in proc.get_vad_root().traverse():
+                fn = vad.get_file_name()
+                if not isinstance(fn, str) or not fn:
+                    fn = None
+
+                protection_string = vad.get_protection(
+                    vadinfo.VadInfo.protect_values(
+                        self.context, kernel.layer_name, kernel.symbol_table_name
+                    ),
+                    vadinfo.winnt_protections,
+                )
+
+                all_ranges[key].append(
+                    (vad.get_start(), vad.get_end(), protection_string, fn)
+                )
+
+        return all_ranges[key]
+
+    def _get_range(self, ranges, address):
+        for start, end, protection_string, fn in ranges:
+            if start <= address < end:
+                return start, protection_string, fn
+
+        return None, None, None
+
+    def _check_thread_address(self, exe_path, ranges, thread_address):
+        vad_base, prot, vad_path = self._get_range(ranges, thread_address)
+
+        # threads outside of a VAD means either smear from this thread or this process' VAD tree
+        if vad_base is None:
+            return
+
+        if vad_path is None:
+            # set this so checks after report the non file backed region in the path column
+            vad_path = "<Non-File Backed Region>"
+
+            yield (
+                vad_path,
+                "This thread started execution in the VAD starting at base address ({:#x}), which is not backed by a file".format(
+                    vad_base
+                ),
+            )
+
+        if prot != "PAGE_EXECUTE_WRITECOPY":
+            yield (
+                vad_path,
+                "VAD at base address ({:#x}) hosting this thread has an unexpected starting protection {}".format(
+                    vad_base, prot
+                ),
+            )
+
+        if (
+            exe_path
+            and vad_path.lower().endswith(".exe")
+            and (vad_path.lower() != exe_path.lower())
+        ):
+            yield (
+                vad_path,
+                "VAD at base address ({:#x}) hosting this thread maps an application executable that is not the process exectuable".format(
+                    vad_base
+                ),
+            )
+
+    def _enumerate_processes(self, kernel, all_ranges):
+        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+
+        for proc in pslist.PsList.list_processes(
+            context=self.context,
+            layer_name=kernel.layer_name,
+            symbol_table=kernel.symbol_table_name,
+            filter_func=filter_func,
+        ):
+            ranges = self._get_ranges(kernel, all_ranges, proc)
+
+            # smeared vads or process is terminating
+            if len(all_ranges[proc.vol.offset]) < 5:
+                continue
+
+            pid = proc.UniqueProcessId
+            proc_name = utility.array_to_string(proc.ImageFileName)
+
+            _, __, exe_path = self._get_range(ranges, proc.SectionBaseAddress)
+            if not isinstance(exe_path, str):
+                exe_path = None
+
+            yield proc, pid, proc_name, exe_path, ranges
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        all_ranges = {}
+
+        for proc, pid, proc_name, exe_path, ranges in self._enumerate_processes(
+            kernel, all_ranges
+        ):
+            # processes often schedule multiple threads at the same address
+            # there is no benefit to checking the same address more than once per process
+            checked = set()
+
+            for thread in threads.Threads.list_threads(kernel, proc):
+                # do not process if a thread is exited or terminated (4 = Terminated)
+                if thread.ExitTime.QuadPart > 0 or thread.Tcb.State == 4:
+                    continue
+
+                # bail if accessing the threads members causes a page fault
+                info = thrdscan.ThrdScan.gather_thread_info(thread)
+                if not info:
+                    continue
+
+                tid, start_address = info[2], info[3]
+
+                addresses = [
+                    (start_address, "Start"),
+                    (thread.Win32StartAddress, "Win32Start"),
+                ]
+
+                for address, context in addresses:
+                    if address in checked:
+                        continue
+                    checked.add(address)
+
+                    for vad_path, note in self._check_thread_address(
+                        exe_path, ranges, address
+                    ):
+                        yield 0, (
+                            proc_name,
+                            pid,
+                            tid,
+                            context,
+                            format_hints.Hex(address),
+                            vad_path,
+                            note,
+                        )
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Process", str),
+                ("PID", int),
+                ("TID", int),
+                ("Context", str),
+                ("Address", format_hints.Hex),
+                ("VAD Path", str),
+                ("Note", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -1,0 +1,80 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import Callable, List, Generator, Iterable, Type, Optional
+
+from volatility3.framework import renderers, interfaces, constants, exceptions
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import pslist, thrdscan
+
+vollog = logging.getLogger(__name__)
+
+
+class Threads(thrdscan.ThrdScan):
+    """Lists process threads"""
+
+    _required_framework_version = (2, 4, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                description="Filter on specific process IDs",
+                element_type=int,
+                optional=True,
+            ),
+            requirements.PluginRequirement(
+                name="thrdscan", plugin=thrdscan.ThrdScan, version=(1, 0, 0)
+            ),
+        ]
+
+    @classmethod
+    def list_threads(
+        cls, kernel, proc: interfaces.objects.ObjectInterface
+    ) -> Generator[interfaces.objects.ObjectInterface, None, None]:
+        """Lists the Threads of a specific process.
+
+        Args:
+            proc: _EPROCESS object from which to list the VADs
+            filter_func: Function to take a virtual address descriptor value and return True if it should be filtered out
+
+        Returns:
+            A list of threads based on the process and filtered based on the filter function
+        """
+        seen = set()
+        for thread in proc.ThreadListHead.to_list(
+            f"{kernel.symbol_table_name}{constants.BANG}_ETHREAD", "ThreadListEntry"
+        ):
+            if thread.vol.offset in seen:
+                break
+            seen.add(thread.vol.offset)
+            yield thread
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+        kernel_layer = self.context.layers[kernel.layer_name]
+
+        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+
+        for proc in pslist.PsList.list_processes(
+            context=self.context,
+            layer_name=kernel.layer_name,
+            symbol_table=kernel.symbol_table_name,
+            filter_func=filter_func,
+        ):
+            for thread in self.list_threads(kernel, proc):
+                info = self.gather_thread_info(thread)
+                if info:
+                    yield (0, info)

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -3,12 +3,10 @@
 #
 
 import logging
-from typing import Callable, List, Generator, Iterable, Type, Optional
+from typing import List, Generator
 
-from volatility3.framework import renderers, interfaces, constants, exceptions
+from volatility3.framework import interfaces, constants
 from volatility3.framework.configuration import requirements
-from volatility3.framework.objects import utility
-from volatility3.framework.renderers import format_hints
 from volatility3.plugins.windows import pslist, thrdscan
 
 vollog = logging.getLogger(__name__)
@@ -64,7 +62,6 @@ class Threads(thrdscan.ThrdScan):
 
     def _generator(self):
         kernel = self.context.modules[self.config["kernel"]]
-        kernel_layer = self.context.layers[kernel.layer_name]
 
         filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
 


### PR DESCRIPTION
This MR condenses code from thrdscan so that it is more usable and also  two important plugins:

1) threads - Mimics the vol2 plugin by allowing enumeration of the threads from a specific process

2) suspicious_threads - Uses the threads plugin to enumerate each processes' threads and then performs checks for malicious threads. The following shows partial output of the plugin against a sample infected with PlugX:

```
# python3.8 vol.py -f plugx.lime windows.suspicious_threads                  
Process	PID	TID	Context	Address	VAD Path	Note

RasTls.exe	6176	3500	Win32Start	0x46813a	<Non-File Backed Region>	This thread started execution in the VAD starting at base address (0x450000), which is not backed by a file
RasTls.exe	6176	3500	Win32Start	0x46813a	<Non-File Backed Region>	VAD at base address (0x450000) hosting this thread has an unexpected starting protection PAGE_EXECUTE_READWRITE
RasTls.exe	6176	6224	Win32Start	0x468e61	<Non-File Backed Region>	This thread started execution in the VAD starting at base address (0x450000), which is not backed by a file
RasTls.exe	6176	6224	Win32Start	0x468e61	<Non-File Backed Region>	VAD at base address (0x450000) hosting this thread has an unexpected starting protection PAGE_EXECUTE_READWRITE
RasTls.exe	6176	660	Win32Start	0x4696d0	<Non-File Backed Region>	This thread started execution in the VAD starting at base address (0x450000), which is not backed by a file
RasTls.exe	6176	660	Win32Start	0x4696d0	<Non-File Backed Region>	VAD at base address (0x450000) hosting this thread has an unexpected starting protection PAGE_EXECUTE_READWRITE
RasTls.exe	6176	6216	Win32Start	0x46973a	<Non-File Backed Region>	This thread started execution in the VAD starting at base address (0x450000), which is not backed by a file
```