### PR TITLE
Add PEDump plugin

### DIFF
--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -256,12 +256,13 @@ class Module(interfaces.context.ModuleInterface):
         if not absolute:
             offset += self._offset
 
-        # Ensure we don't use a layer_name other than the module's, why would anyone do that?
-        if "layer_name" in kwargs:
-            del kwargs["layer_name"]
+        # We have to allow using an alternative layer name due to pool scanners switching
+        # to the memory layer for scanning samples prior to Windows 10.
+        layer_name = kwargs.pop("layer_name", self._layer_name)
+
         return self._context.object(
             object_type=object_type,
-            layer_name=self._layer_name,
+            layer_name=layer_name,
             offset=offset,
             native_layer_name=native_layer_name or self._native_layer_name,
             **kwargs,

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -96,12 +96,13 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
     def get_summary_header(self) -> interfaces.objects.ObjectInterface:
         return self.context.object(
             self._crash_common_table_name + constants.BANG + "_SUMMARY_DUMP",
-            offset=0x1000 * self.headerpages,
+            offset=self._page_size * self.headerpages,
             layer_name=self._base_layer,
         )
 
     def _load_segments(self) -> None:
-        """Loads up the segments from the meta_layer."""
+        """Loads up the segments from the meta_layer.
+        A segment is a set of contiguous memory pages."""
 
         segments = []
 
@@ -119,70 +120,88 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
             for run in header.PhysicalMemoryBlockBuffer.Run:
                 segments.append(
                     (
-                        run.BasePage * 0x1000,
-                        offset * 0x1000,
-                        run.PageCount * 0x1000,
-                        run.PageCount * 0x1000,
+                        run.BasePage * self._page_size,
+                        offset * self._page_size,
+                        run.PageCount * self._page_size,
+                        run.PageCount * self._page_size,
                     )
                 )
                 offset += run.PageCount
 
         elif self.dump_type == 0x05:
             summary_header = self.get_summary_header()
-            first_bit = None  # First bit in a run
-            first_offset = 0  # File offset of first bit
-            last_bit_seen = 0  # Most recent bit processed
-            offset = summary_header.HeaderSize  # Size of file headers
-            buffer_char = summary_header.get_buffer_char()
-            buffer_long = summary_header.get_buffer_long()
-
-            for outer_index in range(0, ((summary_header.BitmapSize + 31) // 32)):
-                if buffer_long[outer_index] == 0:
-                    if first_bit is not None:
-                        last_bit = ((outer_index - 1) * 32) + 31
-                        segment_length = (last_bit - first_bit + 1) * 0x1000
+            seg_first_bit = None  # First bit in a run
+            seg_first_offset = 0  # File offset of first bit
+            offset = (
+                summary_header.HeaderSize
+            )  # Offset to the start of actual memory dump
+            ulong_bitmap_array = summary_header.get_buffer_long()
+            # outer_index points to a 32 bits array inside a list of arrays,
+            # each bit indicating a page mapping state
+            for outer_index in range(0, ulong_bitmap_array.vol.count):
+                ulong_bitmap = ulong_bitmap_array[outer_index]
+                # All pages in this 32 bits array are mapped (speedup iteration process)
+                if ulong_bitmap == 0xFFFFFFFF:
+                    # New segment
+                    if seg_first_bit is None:
+                        seg_first_offset = offset
+                        seg_first_bit = outer_index * 32
+                    offset += 32 * self._page_size
+                # No pages in this 32 bits array are mapped (speedup iteration process)
+                elif ulong_bitmap == 0:
+                    # End of segment
+                    if seg_first_bit is not None:
+                        last_bit = (outer_index - 1) * 32 + 31
+                        segment_length = (
+                            last_bit - seg_first_bit + 1
+                        ) * self._page_size
                         segments.append(
                             (
-                                first_bit * 0x1000,
-                                first_offset,
+                                seg_first_bit * self._page_size,
+                                seg_first_offset,
                                 segment_length,
                                 segment_length,
                             )
                         )
-                        first_bit = None
-                elif buffer_long[outer_index] == 0xFFFFFFFF:
-                    if first_bit is None:
-                        first_offset = offset
-                        first_bit = outer_index * 32
-                    offset = offset + (32 * 0x1000)
+                        seg_first_bit = None
+                # Some pages in this 32 bits array are mapped and some aren't
                 else:
-                    for inner_index in range(0, 32):
-                        bit_addr = outer_index * 32 + inner_index
-                        if (buffer_char[bit_addr >> 3] >> (bit_addr & 0x7)) & 1:
-                            if first_bit is None:
-                                first_offset = offset
-                                first_bit = bit_addr
-                            offset = offset + 0x1000
+                    for inner_bit_position in range(0, 32):
+                        current_bit = outer_index * 32 + inner_bit_position
+                        page_mapped = ulong_bitmap & (1 << inner_bit_position)
+                        if page_mapped:
+                            # New segment
+                            if seg_first_bit is None:
+                                seg_first_offset = offset
+                                seg_first_bit = current_bit
+                            offset += self._page_size
                         else:
-                            if first_bit is not None:
+                            # End of segment
+                            if seg_first_bit is not None:
                                 segment_length = (
-                                    (bit_addr - 1) - first_bit + 1
-                                ) * 0x1000
+                                    current_bit - 1 - seg_first_bit + 1
+                                ) * self._page_size
                                 segments.append(
                                     (
-                                        first_bit * 0x1000,
-                                        first_offset,
+                                        seg_first_bit * self._page_size,
+                                        seg_first_offset,
                                         segment_length,
                                         segment_length,
                                     )
                                 )
-                                first_bit = None
-                last_bit_seen = (outer_index * 32) + 31
+                                seg_first_bit = None
+            else:
+                last_bit_seen = outer_index * 32 + 31
 
-            if first_bit is not None:
-                segment_length = (last_bit_seen - first_bit + 1) * 0x1000
+            if seg_first_bit is not None:
+                segment_length = (last_bit_seen - seg_first_bit + 1) * self._page_size
                 segments.append(
-                    (first_bit * 0x1000, first_offset, segment_length, segment_length)
+                    (
+                        seg_first_bit * self._page_size,
+                        seg_first_offset,
+                        segment_length,
+                        segment_length,
+                    )
                 )
         else:
             vollog.log(

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -190,7 +190,6 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
                                     )
                                 )
                                 seg_first_bit = None
-            else:
                 last_bit_seen = outer_index * 32 + 31
 
             if seg_first_bit is not None:

--- a/volatility3/framework/plugins/windows/pedump.py
+++ b/volatility3/framework/plugins/windows/pedump.py
@@ -1,0 +1,178 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+import logging
+from typing import List
+
+from volatility3.framework import constants, exceptions, interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.symbols import intermed
+from volatility3.framework.symbols.windows.extensions import pe
+from volatility3.plugins.windows import pslist, modules
+
+vollog = logging.getLogger(__name__)
+
+
+class PEDump(interfaces.plugins.PluginInterface):
+    """Allows extracting PE Files from a specific address in a specific address space"""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                element_type=int,
+                description="Process IDs to include (all other processes are excluded)",
+                optional=True,
+            ),
+            requirements.IntRequirement(
+                name="base",
+                description="Base address to reconstruct a PE file",
+                optional=False,
+            ),
+            requirements.BooleanRequirement(
+                name="kernel_module",
+                description="Extract from kernel address space.",
+                default=False,
+                optional=True,
+            ),
+        ]
+
+    def _write_pe(self, pe_table_name, layer_name, proc_offset, pid):
+        try:
+            file_handle = self.open(
+                "PE.{:#x}.{:d}.{:#x}.dmp".format(
+                    proc_offset,
+                    pid,
+                    self.config["base"],
+                )
+            )
+
+            dos_header = self.context.object(
+                pe_table_name + constants.BANG + "_IMAGE_DOS_HEADER",
+                offset=self.config["base"],
+                layer_name=layer_name,
+            )
+
+            for offset, data in dos_header.reconstruct():
+                file_handle.seek(offset)
+                file_handle.write(data)
+        except (
+            IOError,
+            exceptions.VolatilityException,
+            OverflowError,
+            ValueError,
+        ) as excp:
+            vollog.debug(f"Unable to dump dll at offset {self.config['base']}: {excp}")
+            return None
+
+        file_handle.close()
+        return file_handle.preferred_filename
+
+    def _dump_kernel(self, _, pe_table_name, session_layers):
+        session_layer_name = modules.Modules.find_session_layer(
+            self.context, session_layers, self.config["base"]
+        )
+
+        if session_layer_name:
+            system_pid = 4
+
+            file_output = self._write_pe(
+                pe_table_name,
+                session_layer_name,
+                0,
+                system_pid,
+            )
+
+            if file_output:
+                yield system_pid, "Kernel", file_output
+        else:
+            vollog.warning(
+                "Unable to find a session layer with the provided base address mapped in the kernel."
+            )
+
+    def _dump_processes(self, kernel, pe_table_name, _):
+        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+        kernel = self.context.modules[self.config["kernel"]]
+
+        for proc in pslist.PsList.list_processes(
+            context=self.context,
+            layer_name=kernel.layer_name,
+            symbol_table=kernel.symbol_table_name,
+            filter_func=filter_func,
+        ):
+            pid = proc.UniqueProcessId
+            proc_name = proc.ImageFileName.cast(
+                "string",
+                max_length=proc.ImageFileName.vol.count,
+                errors="replace",
+            )
+            proc_layer_name = proc.add_process_layer()
+
+            file_output = self._write_pe(
+                pe_table_name,
+                proc_layer_name,
+                proc.vol.offset,
+                pid,
+            )
+
+            if file_output:
+                yield pid, proc_name, file_output
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        pe_table_name = intermed.IntermediateSymbolTable.create(
+            self.context, self.config_path, "windows", "pe", class_types=pe.class_types
+        )
+
+        if self.config["kernel_module"] and self.config["pid"]:
+            vollog.error("Only --kernel_module or --pid should be set. Not both")
+            return
+
+        if not self.config["kernel_module"] and not self.config["pid"]:
+            vollog.error("--kernel_module or --pid must be set")
+            return
+
+        if self.config["kernel_module"]:
+            session_layers = modules.Modules.get_session_layers(
+                self.context, kernel.layer_name, kernel.symbol_table_name
+            )
+            method = self._dump_kernel
+        else:
+            session_layers = None
+            method = self._dump_processes
+
+        for pid, proc_name, file_output in method(
+            kernel, pe_table_name, session_layers
+        ):
+            yield (
+                0,
+                (
+                    pid,
+                    proc_name,
+                    file_output,
+                ),
+            )
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("PID", int),
+                ("Process", str),
+                ("File output", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/windows/suspicious_threads.py
+++ b/volatility3/framework/plugins/windows/suspicious_threads.py
@@ -1,0 +1,201 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List
+from volatility3.framework import renderers, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import pslist, threads, vadinfo, thrdscan
+
+vollog = logging.getLogger(__name__)
+
+
+class SupsiciousThreads(interfaces.plugins.PluginInterface):
+    """Lists suspicious userland process threads"""
+
+    _required_framework_version = (2, 4, 0)
+    _version = (2, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                description="Filter on specific process IDs",
+                element_type=int,
+                optional=True,
+            ),
+            requirements.PluginRequirement(
+                name="threads", plugin=threads.Threads, version=(1, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="vadinfo", component=vadinfo.VadInfo, version=(2, 0, 0)
+            ),
+        ]
+
+    def _get_ranges(self, kernel, all_ranges, proc):
+        """
+        Maintains a hash table so each process' VADs
+        are only enumerated once per plugin run
+        """
+        key = proc.vol.offset
+
+        if key not in all_ranges:
+            all_ranges[key] = []
+
+            for vad in proc.get_vad_root().traverse():
+                fn = vad.get_file_name()
+                if not isinstance(fn, str) or not fn:
+                    fn = None
+
+                protection_string = vad.get_protection(
+                    vadinfo.VadInfo.protect_values(
+                        self.context, kernel.layer_name, kernel.symbol_table_name
+                    ),
+                    vadinfo.winnt_protections,
+                )
+
+                all_ranges[key].append(
+                    (vad.get_start(), vad.get_end(), protection_string, fn)
+                )
+
+        return all_ranges[key]
+
+    def _get_range(self, ranges, address):
+        for start, end, protection_string, fn in ranges:
+            if start <= address < end:
+                return start, protection_string, fn
+
+        return None, None, None
+
+    def _check_thread_address(self, exe_path, ranges, thread_address):
+        vad_base, prot, vad_path = self._get_range(ranges, thread_address)
+
+        # threads outside of a VAD means either smear from this thread or this process' VAD tree
+        if vad_base is None:
+            return
+
+        if vad_path is None:
+            # set this so checks after report the non file backed region in the path column
+            vad_path = "<Non-File Backed Region>"
+
+            yield (
+                vad_path,
+                "This thread started execution in the VAD starting at base address ({:#x}), which is not backed by a file".format(
+                    vad_base
+                ),
+            )
+
+        if prot != "PAGE_EXECUTE_WRITECOPY":
+            yield (
+                vad_path,
+                "VAD at base address ({:#x}) hosting this thread has an unexpected starting protection {}".format(
+                    vad_base, prot
+                ),
+            )
+
+        if (
+            exe_path
+            and vad_path.lower().endswith(".exe")
+            and (vad_path.lower() != exe_path.lower())
+        ):
+            yield (
+                vad_path,
+                "VAD at base address ({:#x}) hosting this thread maps an application executable that is not the process exectuable".format(
+                    vad_base
+                ),
+            )
+
+    def _enumerate_processes(self, kernel, all_ranges):
+        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+
+        for proc in pslist.PsList.list_processes(
+            context=self.context,
+            layer_name=kernel.layer_name,
+            symbol_table=kernel.symbol_table_name,
+            filter_func=filter_func,
+        ):
+            ranges = self._get_ranges(kernel, all_ranges, proc)
+
+            # smeared vads or process is terminating
+            if len(all_ranges[proc.vol.offset]) < 5:
+                continue
+
+            pid = proc.UniqueProcessId
+            proc_name = utility.array_to_string(proc.ImageFileName)
+
+            _, __, exe_path = self._get_range(ranges, proc.SectionBaseAddress)
+            if not isinstance(exe_path, str):
+                exe_path = None
+
+            yield proc, pid, proc_name, exe_path, ranges
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        all_ranges = {}
+
+        for proc, pid, proc_name, exe_path, ranges in self._enumerate_processes(
+            kernel, all_ranges
+        ):
+            # processes often schedule multiple threads at the same address
+            # there is no benefit to checking the same address more than once per process
+            checked = set()
+
+            for thread in threads.Threads.list_threads(kernel, proc):
+                # do not process if a thread is exited or terminated (4 = Terminated)
+                if thread.ExitTime.QuadPart > 0 or thread.Tcb.State == 4:
+                    continue
+
+                # bail if accessing the threads members causes a page fault
+                info = thrdscan.ThrdScan.gather_thread_info(thread)
+                if not info:
+                    continue
+
+                tid, start_address = info[2], info[3]
+
+                addresses = [
+                    (start_address, "Start"),
+                    (thread.Win32StartAddress, "Win32Start"),
+                ]
+
+                for address, context in addresses:
+                    if address in checked:
+                        continue
+                    checked.add(address)
+
+                    for vad_path, note in self._check_thread_address(
+                        exe_path, ranges, address
+                    ):
+                        yield 0, (
+                            proc_name,
+                            pid,
+                            tid,
+                            context,
+                            format_hints.Hex(address),
+                            vad_path,
+                            note,
+                        )
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Process", str),
+                ("PID", int),
+                ("TID", int),
+                ("Context", str),
+                ("Address", format_hints.Hex),
+                ("VAD Path", str),
+                ("Note", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -1,0 +1,80 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import Callable, List, Generator, Iterable, Type, Optional
+
+from volatility3.framework import renderers, interfaces, constants, exceptions
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import pslist, thrdscan
+
+vollog = logging.getLogger(__name__)
+
+
+class Threads(thrdscan.ThrdScan):
+    """Lists process threads"""
+
+    _required_framework_version = (2, 4, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                description="Filter on specific process IDs",
+                element_type=int,
+                optional=True,
+            ),
+            requirements.PluginRequirement(
+                name="thrdscan", plugin=thrdscan.ThrdScan, version=(1, 0, 0)
+            ),
+        ]
+
+    @classmethod
+    def list_threads(
+        cls, kernel, proc: interfaces.objects.ObjectInterface
+    ) -> Generator[interfaces.objects.ObjectInterface, None, None]:
+        """Lists the Threads of a specific process.
+
+        Args:
+            proc: _EPROCESS object from which to list the VADs
+            filter_func: Function to take a virtual address descriptor value and return True if it should be filtered out
+
+        Returns:
+            A list of threads based on the process and filtered based on the filter function
+        """
+        seen = set()
+        for thread in proc.ThreadListHead.to_list(
+            f"{kernel.symbol_table_name}{constants.BANG}_ETHREAD", "ThreadListEntry"
+        ):
+            if thread.vol.offset in seen:
+                break
+            seen.add(thread.vol.offset)
+            yield thread
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+        kernel_layer = self.context.layers[kernel.layer_name]
+
+        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+
+        for proc in pslist.PsList.list_processes(
+            context=self.context,
+            layer_name=kernel.layer_name,
+            symbol_table=kernel.symbol_table_name,
+            filter_func=filter_func,
+        ):
+            for thread in self.list_threads(kernel, proc):
+                info = self.gather_thread_info(thread)
+                if info:
+                    yield (0, info)

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -3,12 +3,10 @@
 #
 
 import logging
-from typing import Callable, List, Generator, Iterable, Type, Optional
+from typing import List, Generator
 
-from volatility3.framework import renderers, interfaces, constants, exceptions
+from volatility3.framework import interfaces, constants
 from volatility3.framework.configuration import requirements
-from volatility3.framework.objects import utility
-from volatility3.framework.renderers import format_hints
 from volatility3.plugins.windows import pslist, thrdscan
 
 vollog = logging.getLogger(__name__)
@@ -64,7 +62,6 @@ class Threads(thrdscan.ThrdScan):
 
     def _generator(self):
         kernel = self.context.modules[self.config["kernel"]]
-        kernel_layer = self.context.layers[kernel.layer_name]
 
         filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
 

--- a/volatility3/framework/plugins/windows/virtmap.py
+++ b/volatility3/framework/plugins/windows/virtmap.py
@@ -78,7 +78,7 @@ class VirtMap(interfaces.plugins.PluginInterface):
                 )
             else:
                 raise exceptions.SymbolError(
-                    None, module.name, "Required structures not found"
+                    "SystemVaRegions", module.name, "Required structures not found"
                 )
         elif module.has_symbol("MiSystemVaType"):
             system_range_start = module.object(
@@ -99,7 +99,7 @@ class VirtMap(interfaces.plugins.PluginInterface):
             )
         else:
             raise exceptions.SymbolError(
-                None, module.name, "Required structures not found"
+                "MiVisibleState", module.name, "Required structures not found"
             )
 
         return result


### PR DESCRIPTION
This PR adds the PEDump plugin, which provides the ability for an analyst to fully reconstruct an executable from any address within any process or the kernel.

Currently, Volatility 3 provides the `--dump` option for various plugins, but they are based upon the related executables being referenced from a well known data structure (kernel module list, process list, dlllist, etc.). In investigations involving reflectively loaded (memory only) DLLs and kernel drivers, Volatility 3 currently provides no method to reconstruct these.

Volatility 2 provided separate plugins for this capability (dlldump and moddump), but they are a bit awkward as they would either enumerate all of the DLLs or kernel modules by default, but otherwise have specialized, single purpose use if `--base` was set. It was also extra strange as dlldump was really geared towards DLLs tracked with a LDR_DATA_TABLE_ENTRY structure, which reflectively loaded ones don't get since they load themselves as opposed to using LoadLibary.

For these reasons, I broke the functionality out into its own plugin so people investigating a variety of code injection techniques can quickly get the malicious executables of out process or kernel memory.
