### PR TITLE
#1175 - initial unloadedmodules plugin

### DIFF
--- a/volatility3/framework/plugins/windows/unloadedmodules.py
+++ b/volatility3/framework/plugins/windows/unloadedmodules.py
@@ -10,6 +10,7 @@ from volatility3.framework import constants
 from volatility3.framework import interfaces, symbols
 from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import configuration
 from volatility3.framework.renderers import format_hints, conversion
 from volatility3.framework.symbols import intermed
 from volatility3.plugins import timeliner
@@ -60,7 +61,7 @@ class UnloadedModules(interfaces.plugins.PluginInterface, timeliner.TimeLinerInt
 
         return intermed.IntermediateSymbolTable.create(
             context,
-            config_path,
+            configuration.path_join(config_path, "unloadedmodules"),
             "windows",
             symbol_filename,
             native_types=native_types,

--- a/volatility3/framework/plugins/windows/unloadedmodules.py
+++ b/volatility3/framework/plugins/windows/unloadedmodules.py
@@ -1,0 +1,159 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import datetime
+from typing import List, Iterable
+
+from volatility3.framework import constants
+from volatility3.framework import interfaces, symbols
+from volatility3.framework import renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.renderers import format_hints, conversion
+from volatility3.framework.symbols import intermed
+from volatility3.plugins import timeliner
+
+vollog = logging.getLogger(__name__)
+
+
+class UnloadedModules(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
+    """Lists the unloaded kernel modules."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+        ]
+
+    @staticmethod
+    def create_unloadedmodules_table(
+        context: interfaces.context.ContextInterface,
+        symbol_table: str,
+        config_path: str,
+    ) -> str:
+        """Creates a symbol table for the unloaded modules.
+
+        Args:
+            context: The context to retrieve required elements (layers, symbol tables) from
+            symbol_table: The name of an existing symbol table containing the kernel symbols
+            config_path: The configuration path within the context of the symbol table to create
+
+        Returns:
+            The name of the constructed unloaded modules table
+        """
+        native_types = context.symbol_space[symbol_table].natives
+        is_64bit = symbols.symbol_table_is_64bit(context, symbol_table)
+        table_mapping = {"nt_symbols": symbol_table}
+
+        if is_64bit:
+            symbol_filename = "unloadedmodules-x64"
+        else:
+            symbol_filename = "unloadedmodules-x86"
+
+        return intermed.IntermediateSymbolTable.create(
+            context,
+            config_path,
+            "windows",
+            symbol_filename,
+            native_types=native_types,
+            table_mapping=table_mapping,
+        )
+
+    @classmethod
+    def list_unloadedmodules(
+        cls,
+        context: interfaces.context.ContextInterface,
+        layer_name: str,
+        symbol_table: str,
+        unloadedmodule_table_name: str,
+    ) -> Iterable[interfaces.objects.ObjectInterface]:
+        """Lists all the unloaded modules in the primary layer.
+
+        Args:
+            context: The context to retrieve required elements (layers, symbol tables) from
+            layer_name: The name of the layer on which to operate
+            symbol_table: The name of the table containing the kernel symbols
+
+        Returns:
+            A list of Unloaded Modules as retrieved from MmUnloadedDrivers
+        """
+
+        kvo = context.layers[layer_name].config["kernel_virtual_offset"]
+        ntkrnlmp = context.module(symbol_table, layer_name=layer_name, offset=kvo)
+        unloadedmodules_offset = ntkrnlmp.get_symbol("MmUnloadedDrivers").address
+        unloadedmodules = ntkrnlmp.object(
+            object_type="pointer",
+            offset=unloadedmodules_offset,
+            subtype="array",
+        )
+        is_64bit = symbols.symbol_table_is_64bit(context, symbol_table)
+
+        if is_64bit:
+            unloaded_count_type = "unsigned long long"
+        else:
+            unloaded_count_type = "unsigned long"
+
+        last_unloadedmodule_offset = ntkrnlmp.get_symbol("MmLastUnloadedDriver").address
+        unloaded_count = ntkrnlmp.object(
+            object_type=unloaded_count_type, offset=last_unloadedmodule_offset
+        )
+
+        unloadedmodules_array = context.object(
+            object_type=unloadedmodule_table_name
+            + constants.BANG
+            + "_UNLOADED_DRIVERS",
+            layer_name=layer_name,
+            offset=unloadedmodules,
+        )
+        unloadedmodules_array.UnloadedDrivers.count = unloaded_count
+
+        for mod in unloadedmodules_array.UnloadedDrivers:
+            yield mod
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        unloadedmodule_table_name = self.create_unloadedmodules_table(
+            self.context, kernel.symbol_table_name, self.config_path
+        )
+
+        for mod in self.list_unloadedmodules(
+            self.context,
+            kernel.layer_name,
+            kernel.symbol_table_name,
+            unloadedmodule_table_name,
+        ):
+            yield (
+                0,
+                (
+                    mod.Name.String,
+                    format_hints.Hex(mod.StartAddress),
+                    format_hints.Hex(mod.EndAddress),
+                    conversion.wintime_to_datetime(mod.CurrentTime),
+                ),
+            )
+
+    def generate_timeline(self):
+        for row in self._generator():
+            _depth, row_data = row
+            description = f"Unloaded Module: {row_data[0]}"
+            yield (description, timeliner.TimeLinerType.CHANGED, row_data[3])
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Name", str),
+                ("StartAddress", format_hints.Hex),
+                ("EndAddress", format_hints.Hex),
+                ("Time", datetime.datetime),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/symbols/windows/unloadedmodules-x64.json
+++ b/volatility3/framework/symbols/windows/unloadedmodules-x64.json
@@ -1,0 +1,109 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_UNLOADED_DRIVER": {
+            "fields": {
+                "Name": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    },
+                    "offset": 0
+                },
+                "StartAddress": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    },
+                    "offset": 16
+                },
+                "EndAddress": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    },
+                    "offset": 24
+                },
+                "CurrentTime": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    },
+                    "offset": 32
+                }
+            },
+            "kind": "struct",
+            "size": 40
+        },
+        "_UNLOADED_DRIVERS": {
+            "fields": {
+                "UnloadedDrivers": {
+                    "offset": 0,
+                    "type": {
+                        "count": 1,
+                        "kind": "array",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_UNLOADED_DRIVER"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "Dave Lassalle by hand",
+            "datetime": "2024-06-19T17:57:16.394003"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/unloadedmodules-x86.json
+++ b/volatility3/framework/symbols/windows/unloadedmodules-x86.json
@@ -1,0 +1,109 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_UNLOADED_DRIVER": {
+            "fields": {
+                "Name": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    },
+                    "offset": 0
+                },
+                "StartAddress": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 8
+                },
+                "EndAddress": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 12
+                },
+                "CurrentTime": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    },
+                    "offset": 16
+                }
+            },
+            "kind": "struct",
+            "size": 24
+        },
+        "_UNLOADED_DRIVERS": {
+            "fields": {
+                "UnloadedDrivers": {
+                    "offset": 0,
+                    "type": {
+                        "count": 1,
+                        "kind": "array",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_UNLOADED_DRIVER"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 4
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "Dave Lassalle by hand",
+            "datetime": "2024-06-19T17:57:16.394003"
+        },
+        "format": "4.0.0"
+    }
+}


### PR DESCRIPTION
This adds the missing volatility2 plugin unloadedmodules

<pre>
$ python vol.py -f data.lime windows.unloadedmodules.UnloadedModules
Name	StartAddress	EndAddress	Time

sacdrv.sys	0xfffff8057eaf0000	0xfffff8057eb0f000	2024-06-14 06:10:25.000000
hwpolicy.sys	0xfffff8057fc80000	0xfffff8057fc91000	2024-06-14 06:10:29.000000
WdBoot.sys	0xfffff8057ea10000	0xfffff8057ea1c000	2024-06-14 06:10:29.000000
KMPDC.sys	0xfffff805824f0000	0xfffff805824ff000	2024-06-14 06:10:31.000000
dam.sys	0xfffff805824d0000	0xfffff805824ec000	2024-06-14 06:10:31.000000
dump_stornvme.sys	0xfffff80580380000	0xfffff805803b7000	2024-06-14 06:10:34.000000
dump_storport.sys	0xfffff80580330000	0xfffff80580340000	2024-06-14 06:10:34.000000
WdmCompanionFilter.sys	0xfffff80582e90000	0xfffff80582e9c000	2024-06-14 06:10:40.000000
MSKSSRV.sys	0xfffff80579d10000	0xfffff80579d22000	2024-06-14 06:11:13.000000
MSKSSRV.sys	0xfffff80579da0000	0xfffff80579db2000	2024-06-14 15:57:22.000000
monitor.sys	0xfffff80579400000	0xfffff8057941c000	2024-06-14 15:57:33.000000
monitor.sys	0xfffff80579dc0000	0xfffff80579ddc000	2024-06-14 16:04:05.000000
</pre>