### PR TITLE
Windows: fixes scanner bug for versions < win10

### DIFF
--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -256,12 +256,13 @@ class Module(interfaces.context.ModuleInterface):
         if not absolute:
             offset += self._offset
 
-        # Ensure we don't use a layer_name other than the module's, why would anyone do that?
-        if "layer_name" in kwargs:
-            del kwargs["layer_name"]
+        # We have to allow using an alternative layer name due to pool scanners switching
+        # to the memory layer for scanning samples prior to Windows 10.
+        layer_name = kwargs.pop("layer_name", self._layer_name)
+
         return self._context.object(
             object_type=object_type,
-            layer_name=self._layer_name,
+            layer_name=layer_name,
             offset=offset,
             native_layer_name=native_layer_name or self._native_layer_name,
             **kwargs,


### PR DESCRIPTION
This commit fixes a bug where the `layer_name` gets discarded when constructing objects. Previously, it was assumed that we would not want to construct an object for a module with a layer_name different from that of the module. However, because we switch to scanning the memory layer on samples where the version is < 10, but still construct kernel executive objects based on the result of the memory layer scan, we actually do sometimes need to specify a different layer.

The effects of this were most noticeable when scanning for symlinks in a Windows 7 sample. It was returning no results due to an `InvalidAddressException` on all attempts to access the `_OBJECT_HEADER.NameInfo.Name` - the original `_OBJECT_HEADER` has a `layer_name` of `memory_layer` and a `native_layer_name` of `kernel.layer_name`, but the `Name` member, which is a `_UNICODE_STRING`, ends up with both the `layer_name` and `native_layer_name` values being set to `kernel.layer_name`. Therefore, when attempting to read the `Buffer` and `Length` members of the string, we get the `InvalidAddressException`.

This fix corrects the output of `windows.symlinkscan.SymlinkScan`, which is now equivalent to the output produced by the original vol2 plugin, and the output of Win10+ samples remains the same. It will likely also impact https://github.com/volatilityfoundation/volatility3/pull/1110, as well as any other existing plugins that access `OBJECT_SYMBOLIC_LINK`, `KMUTANT`, `DRIVER_OBJECT` or `DEVICE_OBJECT` names.