### PR TITLE
Add timeliner support to userassist

### DIFF
--- a/volatility3/framework/plugins/windows/registry/userassist.py
+++ b/volatility3/framework/plugins/windows/registry/userassist.py
@@ -336,7 +336,6 @@ class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfac
             )
             yield result
 
-
     def generate_timeline(self):
         self._reg_table_name = intermed.IntermediateSymbolTable.create(
             self.context, self._config_path, "windows", "registry"
@@ -345,7 +344,9 @@ class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfac
         for row in self._generator():
             _depth, row_data = row
             # check the name and the timestamp to not be empty
-            if isinstance(row_data[5], str) and not isinstance(row_data[10], renderers.NotApplicableValue):
+            if isinstance(row_data[5], str) and not isinstance(
+                row_data[10], renderers.NotApplicableValue
+            ):
                 description = f"UserAssist: {row_data[5]} {row_data[2]} ({row_data[7]})"
                 yield (description, timeliner.TimeLinerType.MODIFIED, row_data[10])
 

--- a/volatility3/framework/plugins/windows/registry/userassist.py
+++ b/volatility3/framework/plugins/windows/registry/userassist.py
@@ -17,11 +17,12 @@ from volatility3.framework.layers.registry import RegistryHive
 from volatility3.framework.renderers import conversion, format_hints
 from volatility3.framework.symbols import intermed
 from volatility3.plugins.windows.registry import hivelist
+from volatility3.plugins import timeliner
 
 vollog = logging.getLogger(__name__)
 
 
-class UserAssist(interfaces.plugins.PluginInterface):
+class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Print userassist registry keys and information."""
 
     _required_framework_version = (2, 0, 0)
@@ -334,6 +335,19 @@ class UserAssist(interfaces.plugins.PluginInterface):
                 ),
             )
             yield result
+
+
+    def generate_timeline(self):
+        self._reg_table_name = intermed.IntermediateSymbolTable.create(
+            self.context, self._config_path, "windows", "registry"
+        )
+
+        for row in self._generator():
+            _depth, row_data = row
+            # check the name and the timestamp to not be empty
+            if isinstance(row_data[5], str) and not isinstance(row_data[10], renderers.NotApplicableValue):
+                description = f"UserAssist: {row_data[5]} {row_data[2]} ({row_data[7]})"
+                yield (description, timeliner.TimeLinerType.MODIFIED, row_data[10])
 
     def run(self):
         self._reg_table_name = intermed.IntermediateSymbolTable.create(

--- a/volatility3/framework/plugins/windows/registry/userassist.py
+++ b/volatility3/framework/plugins/windows/registry/userassist.py
@@ -286,6 +286,10 @@ class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfac
             hive_offsets = [self.config.get("offset", None)]
         kernel = self.context.modules[self.config["kernel"]]
 
+        self._reg_table_name = intermed.IntermediateSymbolTable.create(
+            self.context, self._config_path, "windows", "registry"
+        )
+
         # get all the user hive offsets or use the one specified
         for hive in hivelist.HiveList.list_hives(
             context=self.context,
@@ -337,10 +341,6 @@ class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfac
             yield result
 
     def generate_timeline(self):
-        self._reg_table_name = intermed.IntermediateSymbolTable.create(
-            self.context, self._config_path, "windows", "registry"
-        )
-
         for row in self._generator():
             _depth, row_data = row
             # check the name and the timestamp to not be empty
@@ -351,10 +351,6 @@ class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfac
                 yield (description, timeliner.TimeLinerType.MODIFIED, row_data[10])
 
     def run(self):
-        self._reg_table_name = intermed.IntermediateSymbolTable.create(
-            self.context, self._config_path, "windows", "registry"
-        )
-
         return renderers.TreeGrid(
             [
                 ("Hive Offset", renderers.format_hints.Hex),


### PR DESCRIPTION
These records hold the time programs last executed along with their path, number of times ran, and other details depending on the OS version. We should include these in the timeliner interface.