### PR TITLE
Windows - psscan plugin fixes

### DIFF
--- a/volatility3/framework/plugins/windows/psscan.py
+++ b/volatility3/framework/plugins/windows/psscan.py
@@ -266,20 +266,28 @@ class PsScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 if proc.vol.layer_name == kernel.layer_name:
                     vproc = proc
                 else:
-                    vproc = self.virtual_process_from_physical(
-                        self.context, kernel.layer_name, kernel.symbol_table_name, proc
+                    try:
+                        vproc = self.virtual_process_from_physical(
+                            self.context,
+                            kernel.layer_name,
+                            kernel.symbol_table_name,
+                            proc,
+                        )
+                    except exceptions.PagedInvalidAddressException:
+                        vproc = None
+
+                file_output = "Error outputting file"
+                if vproc:
+                    file_handle = pslist.PsList.process_dump(
+                        self.context,
+                        kernel.symbol_table_name,
+                        pe_table_name,
+                        vproc,
+                        self.open,
                     )
 
-                file_handle = pslist.PsList.process_dump(
-                    self.context,
-                    kernel.symbol_table_name,
-                    pe_table_name,
-                    vproc,
-                    self.open,
-                )
-                file_output = "Error outputting file"
-                if file_handle:
-                    file_output = file_handle.preferred_filename
+                    if file_handle:
+                        file_output = file_handle.preferred_filename
 
             if not self.config["physical"]:
                 offset = proc.vol.offset

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -22,7 +22,7 @@ from volatility3.framework.interfaces.objects import ObjectInterface
 from volatility3.framework.layers import intel
 from volatility3.framework.renderers import conversion
 from volatility3.framework.symbols import generic
-from volatility3.framework.symbols.windows.extensions import kdbg, pe, pool
+from volatility3.framework.symbols.windows.extensions import pool
 
 vollog = logging.getLogger(__name__)
 
@@ -611,10 +611,21 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
 
                 ctime = self.get_create_time()
                 if not isinstance(ctime, datetime.datetime):
+                    # A process must have a creation time
                     return False
 
                 if not (1998 < ctime.year < 2030):
                     return False
+
+                etime = self.get_exit_time()
+                if isinstance(etime, datetime.datetime):
+                    if not (1998 < etime.year < 2030):
+                        return False
+
+                    # Exit time, if available, must be after the creation time
+                    # At this point, we are sure both are datetimes, so let's compare them
+                    if ctime > etime:
+                        return False
 
             # NT pids are divisible by 4
             if self.UniqueProcessId % 4 != 0:
@@ -633,7 +644,11 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
             if dtb & ~0xFFF == 0:
                 return False
 
-            ## TODO: we can also add the thread Flink and Blink tests if necessary
+            # Quick smear test on thread Flink and Blink
+            kernel = 0x80000000  # Yes, it's a quick test
+            list_head = self.ThreadListHead
+            if list_head.Flink < kernel or list_head.Blink < kernel:
+                return False
 
         except exceptions.InvalidAddressException:
             return False

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -614,12 +614,13 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
                     # A process must have a creation time
                     return False
 
-                if not (1998 < ctime.year < 2030):
+                current_year = datetime.datetime.now().year
+                if not (1998 < ctime.year < current_year + 10):
                     return False
 
                 etime = self.get_exit_time()
                 if isinstance(etime, datetime.datetime):
-                    if not (1998 < etime.year < 2030):
+                    if not (1998 < etime.year < current_year + 10):
                         return False
 
                     # Exit time, if available, must be after the creation time


### PR DESCRIPTION
`windows.psscan.PsScan plugin` breaks when dumping (invalid) processes.

On the one hand, this PR allows the `windows.psscan.PsScan` plugin to handle invalid page errors enabling it to continue searching and dumping processes.

On the other hand, it improves the smear memory checks in the EPROCESS class avoiding wasted time processing garbage.