### PR TITLE
Fix hexdump text render. Set default to 16 bytes width

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -25,7 +25,7 @@ except ImportError:
     vollog.debug("Disassembly library capstone not found")
 
 
-def hex_bytes_as_text(value: bytes) -> str:
+def hex_bytes_as_text(value: bytes, width: int = 16) -> str:
     """Renders HexBytes as text.
 
     Args:
@@ -36,19 +36,24 @@ def hex_bytes_as_text(value: bytes) -> str:
     """
     if not isinstance(value, bytes):
         raise TypeError(f"hex_bytes_as_text takes bytes not: {type(value)}")
-    ascii = []
-    hex = []
-    count = 0
-    output = ""
-    for byte in value:
-        hex.append(f"{byte:02x}")
-        ascii.append(chr(byte) if 0x20 < byte <= 0x7E else ".")
-        if (count % 8) == 7:
-            output += "\n"
-            output += " ".join(hex[count - 7 : count + 1])
-            output += "\t"
-            output += "".join(ascii[count - 7 : count + 1])
-        count += 1
+
+    printables = ""
+    output = "\n"
+    for count, byte in enumerate(value):
+        output += f"{byte:02x} "
+        char = chr(byte)
+        printables += char if 0x20 <= byte <= 0x7E else "."
+        if count % width == width - 1:
+            output += printables
+            if count < len(value) - 1:
+                output += "\n"
+            printables = ""
+
+    # Handle leftovers when the lenght is not mutiple of width
+    if printables:
+        output += "   " * (width - len(printables))
+        output += printables
+
     return output
 
 


### PR DESCRIPTION
## Missing bytes
On the one hand, this PR fixes an issue with the hexdump text render function `hex_bytes_as_text`.
The previous implementation failed to handle buffer lengths that are not multiples of 8 bytes, resulting in missing bytes in its output.

For instance, using the text `abcd`, the previous implementation didn't dump anything.
```shell
[*] Text is: abcd
old_hex_bytes_as_text
---------------------

```

On the contrary, the new implementation correctly handles this case.
```shell
[*] Text is: abcd
new_hex_bytes_as_text
---------------------

61 62 63 64                                     abcd
```
Using a 22 bytes buffer `abcdefghijklmnopqrstuv`, the old implementation misses the last `qrstuv` bytes:
```shell
[*] Text is: abcdefghijklmnopqrstuv

old_hex_bytes_as_text
---------------------

61 62 63 64 65 66 67 68 abcdefgh
69 6a 6b 6c 6d 6e 6f 70 ijklmnop
```

While the new implementation handles this case too.
```shell
[*] Text is: abcdefghijklmnopqrstuv

new_hex_bytes_as_text
---------------------

61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 abcdefghijklmnop
71 72 73 74 75 76                               qrstuv
```




## 16 bytes width
On the other hand, this PR increases the hexdump width from 8 bytes to 16 bytes per row for better visualization and to match other hex dump tools/utilities.

Before:
```shell
$ python3 ./vol.py -f sample.lime windows.malfind.Malfind 
Volatility 3 Framework 2.7.1
Progress:  100.00               PDB scanning finished                        
PID     Process Start VPN       End VPN Tag     Protection      CommitCharge    PrivateMemory   File output     Notes   Hexdump Disasm

1436    WaAppAgent.exe  0xaf0000        0xb6ffff        VadS    PAGE_EXECUTE_READWRITE  2       1       Disabled        N/A
00 00 00 00 00 00 00 00 ........
72 7c b4 85 c6 8f 00 01 r|......
ee ff ee ff 00 00 00 00 ........
28 01 af 00 00 00 00 00 (.......
28 01 af 00 00 00 00 00 (.......
00 00 af 00 00 00 00 00 ........
00 00 af 00 00 00 00 00 ........
80 00 00 00 00 00 00 00 ........        00 00 00 00 00 00 00 00 72 7c b4 85 c6 8f 00 01 ee ff ee ff 00 00 00 00 28 01 af 00 00 00 00 00 28 01 af 00 00 00 00 00 00 00 af 00 00 00 00 00 00 00 af 00 00 00 00 00 80 00 00 00 00 00 00 00
...
```

After:
```shell
$ python3 ./vol.py -f sample.lime windows.malfind.Malfind
Volatility 3 Framework 2.7.1
Progress:  100.00               PDB scanning finished                                                                                             
PID     Process Start VPN       End VPN Tag     Protection      CommitCharge    PrivateMemory   File output     Notes   Hexdump Disasm

1436    WaAppAgent.exe  0xaf0000        0xb6ffff        VadS    PAGE_EXECUTE_READWRITE  2       1       Disabled        N/A
00 00 00 00 00 00 00 00 72 7c b4 85 c6 8f 00 01 ........r|......
ee ff ee ff 00 00 00 00 28 01 af 00 00 00 00 00 ........(.......
28 01 af 00 00 00 00 00 00 00 af 00 00 00 00 00 (...............
00 00 af 00 00 00 00 00 80 00 00 00 00 00 00 00 ................        00 00 00 00 00 00 00 00 72 7c b4 85 c6 8f 00 01 ee ff ee ff 00 00 00 00 28 01 af 00 00 00 00 00 28 01 af 00 00 00 00 00 00 00 af 00 00 00 00 00 00 00 af 00 00 00 00 00 80 00 00 00 00 00 00 00
...
```

## Lost in Space
Lastly, the new implementation includes the space character (0x20) in the list of printable characters which, for some reason, was omitted in the original version.