### PR TITLE
Implement the fix that was reverted as part of #1162.

### DIFF
--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -180,7 +180,9 @@ class Intel(linear.LinearlyMappedLayer):
         position = self._initial_position
         entry = self._initial_entry
 
-        if self.minimum_address > offset > self.maximum_address:
+        if not (
+            self.minimum_address <= (offset & self.address_mask) <= self.maximum_address
+        ):
             raise exceptions.PagedInvalidAddressException(
                 self.name,
                 offset,


### PR DESCRIPTION
This should properly widen the test by a single byte, hopefully solving the previous issue being encountered (where the check wasn't conducted at all).

Hopefully this can be tested in #1162 before it goes live, since it touches a crucial part of the codebase.