### PR TITLE
Initial draft of complete-vad vadyarascan

### DIFF
--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -2,10 +2,11 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
+import io
 import logging
 from typing import Iterable, List, Tuple
 
-from volatility3.framework import interfaces, renderers
+from volatility3.framework import exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins import yarascan
@@ -18,7 +19,7 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
     """Scans all the Virtual Address Descriptor memory maps using yara."""
 
     _required_framework_version = (2, 4, 0)
-    _version = (1, 0, 1)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -32,11 +33,8 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
             requirements.PluginRequirement(
                 name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
             ),
-            requirements.VersionRequirement(
-                name="yarascanner", component=yarascan.YaraScanner, version=(2, 0, 0)
-            ),
             requirements.PluginRequirement(
-                name="yarascan", plugin=yarascan.YaraScan, version=(1, 2, 0)
+                name="yarascan", plugin=yarascan.YaraScan, version=(1, 3, 0)
             ),
             requirements.ListRequirement(
                 name="pid",
@@ -59,6 +57,8 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
 
         filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
 
+        sanity_check = 0x1000 * 0x1000 * 0x1000
+
         for task in pslist.PsList.list_processes(
             context=self.context,
             layer_name=kernel.layer_name,
@@ -67,18 +67,34 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
         ):
             layer_name = task.add_process_layer()
             layer = self.context.layers[layer_name]
-            for offset, rule_name, name, value in layer.scan(
-                context=self.context,
-                scanner=yarascan.YaraScanner(rules=rules),
-                sections=self.get_vad_maps(task),
-            ):
-                yield 0, (
-                    format_hints.Hex(offset),
-                    task.UniqueProcessId,
-                    rule_name,
-                    name,
-                    value,
-                )
+            for start, end in self.get_vad_maps(task):
+                size = end - start
+                if size > sanity_check:
+                    vollog.warn(
+                        f"VAD at 0x{start:x} over sanity-check size, not scanning"
+                    )
+                    continue
+
+                for match in rules.match(data=layer.read(start, end - start, True)):
+                    if yarascan.YaraScan.yara_returns_instances():
+                        for match_string in match.strings:
+                            for instance in match_string.instances:
+                                yield 0, (
+                                    format_hints.Hex(instance.offset + start),
+                                    task.UniqueProcessId,
+                                    match.rule,
+                                    match_string.identifier,
+                                    instance.matched_data,
+                                )
+                    else:
+                        for offset, name, value in match.strings:
+                            yield 0, (
+                                format_hints.Hex(offset + start),
+                                task.UniqueProcessId,
+                                match.rule,
+                                name,
+                                value,
+                            )
 
     @staticmethod
     def get_vad_maps(

--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -2,11 +2,10 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
-import io
 import logging
 from typing import Iterable, List, Tuple
 
-from volatility3.framework import exceptions, interfaces, renderers
+from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins import yarascan

--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -2,11 +2,10 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
-import io
 import logging
 from typing import Any, Dict, Iterable, List, Tuple
 
-from volatility3.framework import exceptions, interfaces, renderers
+from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.layers import resources
@@ -121,7 +120,7 @@ class YaraScan(plugins.PluginInterface):
         ]
 
     @classmethod
-    def yara_returns_instances(self) -> bool:
+    def yara_returns_instances(cls) -> bool:
         st_object = not tuple([int(x) for x in yara.__version__.split(".")]) < (
             4,
             3,


### PR DESCRIPTION
Ok, here's an initial version of a change to vadyarascan that should scan a vad in its entirety when doing yara scanning.

Essentially it ignores the scanning framework, because we've already got the process layer to make the vads contiguous so we don't need any of the rebuilding/paging that the scanning framework does.  It's a little bit duplicative in places, but not a huge amount and we use the option/rule creation code from yarascan, so this should be ok.  Please could people test it for me...

Closes #1189.
Closes #1155.