### PR TITLE
Windows: remove size from filescan output as it is not the file size 

### DIFF
--- a/volatility3/framework/plugins/windows/filescan.py
+++ b/volatility3/framework/plugins/windows/filescan.py
@@ -14,6 +14,7 @@ class FileScan(interfaces.plugins.PluginInterface):
     """Scans for file objects present in a particular windows memory image."""
 
     _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls):

--- a/volatility3/framework/plugins/windows/filescan.py
+++ b/volatility3/framework/plugins/windows/filescan.py
@@ -13,7 +13,7 @@ from volatility3.plugins.windows import poolscanner
 class FileScan(interfaces.plugins.PluginInterface):
     """Scans for file objects present in a particular windows memory image."""
 
-    _required_framework_version = (2, 0, 1)
+    _required_framework_version = (2, 0, 0)
 
     @classmethod
     def get_requirements(cls):

--- a/volatility3/framework/plugins/windows/filescan.py
+++ b/volatility3/framework/plugins/windows/filescan.py
@@ -13,7 +13,7 @@ from volatility3.plugins.windows import poolscanner
 class FileScan(interfaces.plugins.PluginInterface):
     """Scans for file objects present in a particular windows memory image."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 0, 1)
 
     @classmethod
     def get_requirements(cls):
@@ -67,10 +67,10 @@ class FileScan(interfaces.plugins.PluginInterface):
             except exceptions.InvalidAddressException:
                 continue
 
-            yield (0, (format_hints.Hex(fileobj.vol.offset), file_name, fileobj.Size))
+            yield (0, (format_hints.Hex(fileobj.vol.offset), file_name))
 
     def run(self):
         return renderers.TreeGrid(
-            [("Offset", format_hints.Hex), ("Name", str), ("Size", int)],
+            [("Offset", format_hints.Hex), ("Name", str)],
             self._generator(),
         )


### PR DESCRIPTION
Hello!

This small PR removes the 'size' column from the windows filescan plugin. It's not the file size... and is always just the object size which isn't very useful. 

@atcuno commented on the issue https://github.com/volatilityfoundation/volatility3/issues/1040#issuecomment-2183518750 suggesting that it should be removed. So this PR is that. 

Thanks for looking!
