### PR TITLE
Core: Bump the version and minium python to support pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ more details.
 
 ## Requirements
 
-Volatility 3 requires Python 3.7.0 or later. To install the most minimal set of dependencies (some plugins will not work) use a command such as:
+Volatility 3 requires Python 3.7.3 or later. To install the most minimal set of dependencies (some plugins will not work) use a command such as:
 
 ```shell
 pip3 install -r requirements-minimal.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Volatility Foundation", email = "volatility@volatilityfoundation.org" },
 ]
-requires-python = ">=3.7.0"
+requires-python = ">=3.7.3"
 license = { text = "VSL" }
 dynamic = ["dependencies", "optional-dependencies", "version"]
 

--- a/volatility3/framework/__init__.py
+++ b/volatility3/framework/__init__.py
@@ -7,7 +7,7 @@ import glob
 import sys
 import zipfile
 
-required_python_version = (3, 7, 0)
+required_python_version = (3, 7, 3)
 if (
     sys.version_info.major != required_python_version[0]
     or sys.version_info.minor < required_python_version[1]

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,7 +1,7 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
 VERSION_MINOR = 7  # Number of changes that only add to the interface
-VERSION_PATCH = 1  # Number of changes that do not change the interface
+VERSION_PATCH = 2  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 # TODO: At version 2.0.0, remove the symbol_shift feature


### PR DESCRIPTION
Merging once the tests have finished, since this should have been part of the pyproject.toml pull but I didn't want to hold things up further.