### PR TITLE
Windows: ShimcacheMem

### DIFF
--- a/volatility3/framework/plugins/windows/shimcachemem.py
+++ b/volatility3/framework/plugins/windows/shimcachemem.py
@@ -1,0 +1,610 @@
+# This file is Copyright 2020 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+import logging
+import os
+from datetime import datetime
+from itertools import count
+from typing import Iterator, List, Optional, Tuple
+
+from volatility3.framework import constants, exceptions, interfaces, renderers, symbols
+from volatility3.framework.configuration import requirements
+from volatility3.framework.objects.utility import array_to_string
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.symbols import intermed
+from volatility3.framework.symbols.windows import versions
+from volatility3.framework.symbols.windows.extensions import pe, shimcache
+from volatility3.plugins import timeliner
+from volatility3.plugins.windows import modules, pslist, vadinfo
+
+# from volatility3.plugins.windows import pslist, vadinfo, modules
+
+vollog = logging.getLogger(__name__)
+
+
+class ShimcacheMem(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
+    """Reads Shimcache entries from the ahcache.sys AVL tree"""
+
+    _required_framework_version = (2, 0, 0)
+
+    # These checks must be completed from newest -> oldest OS version.
+    _win_version_file_map: List[Tuple[versions.OsDistinguisher, bool, str]] = [
+        (versions.is_win10, True, "shimcache-win10-x64"),
+        (versions.is_win10, False, "shimcache-win10-x86"),
+        (versions.is_windows_8_or_later, True, "shimcache-win8-x64"),
+        (versions.is_windows_8_or_later, False, "shimcache-win8-x86"),
+        (versions.is_windows_7, True, "shimcache-win7-x64"),
+        (versions.is_windows_7, False, "shimcache-win7-x86"),
+        (versions.is_vista_or_later, True, "shimcache-vista-x64"),
+        (versions.is_vista_or_later, False, "shimcache-vista-x86"),
+        (versions.is_2003, False, "shimcache-2003-x86"),
+        (versions.is_2003, True, "shimcache-2003-x64"),
+        (versions.is_windows_xp_sp3, False, "shimcache-xp-sp3-x86"),
+        (versions.is_windows_xp_sp2, False, "shimcache-xp-sp2-x86"),
+        (versions.is_xp_or_2003, True, "shimcache-xp-2003-x64"),
+        (versions.is_xp_or_2003, False, "shimcache-xp-2003-x86"),
+    ]
+
+    NT_KRNL_MODS = ["ntoskrnl.exe", "ntkrnlpa.exe", "ntkrnlmp.exe", "ntkrpamp.exe"]
+
+    def generate_timeline(
+        self,
+    ) -> Iterator[Tuple[str, timeliner.TimeLinerType, datetime]]:
+        for _, (_, last_modified, last_update, _, _, file_path) in self._generator():
+            if isinstance(last_update, datetime):
+                yield f"Shimcache: File {file_path} executed", timeliner.TimeLinerType.ACCESSED, last_update
+            if isinstance(last_modified, datetime):
+                yield f"Shimcache: File {file_path} modified", timeliner.TimeLinerType.MODIFIED, last_modified
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="vadinfo", component=vadinfo.VadInfo, version=(2, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(2, 0, 0)
+            ),
+        ]
+
+    @staticmethod
+    def create_shimcache_table(
+        context: interfaces.context.ContextInterface,
+        symbol_table: str,
+        config_path: str,
+    ) -> str:
+        """Creates a shimcache symbol table
+
+        Args:
+            context: The context to retrieve required elements (layers, symbol tables) from
+            symbol_table: The name of an existing symbol table containing the kernel symbols
+            config_path: The configuration path within the context of the symbol table to create
+
+        Returns:
+            The name of the constructed shimcache table
+        """
+        native_types = context.symbol_space[symbol_table].natives
+        is_64bit = symbols.symbol_table_is_64bit(context, symbol_table)
+        table_mapping = {"nt_symbols": symbol_table}
+
+        try:
+            symbol_filename = next(
+                filename
+                for version_check, for_64bit, filename in ShimcacheMem._win_version_file_map
+                if is_64bit == for_64bit
+                and version_check(context=context, symbol_table=symbol_table)
+            )
+        except StopIteration:
+            raise NotImplementedError("This version of Windows is not supported!")
+
+        vollog.debug(f"Using shimcache table {symbol_filename}")
+
+        return intermed.IntermediateSymbolTable.create(
+            context,
+            config_path,
+            os.path.join("windows", "shimcache"),
+            symbol_filename,
+            class_types=shimcache.class_types,
+            native_types=native_types,
+            table_mapping=table_mapping,
+        )
+
+    @classmethod
+    def find_shimcache_win_xp(
+        cls,
+        context: interfaces.context.ContextInterface,
+        layer_name: str,
+        kernel_symbol_table: str,
+        shimcache_symbol_table: str,
+    ) -> Iterator[shimcache.SHIM_CACHE_ENTRY]:
+        """Attempts to find the shimcache in a Windows XP memory image
+
+        :param context: The context to retrieve required elements (layers, symbol tables) from
+        :param layer_name: The name of the memory layer on which to operate.
+        :param kernel_symbol_table: The name of an existing symbol table containing the kernel symbols
+        :param shimcache_symbol_table: The name of a symbol table containing the hand-crafted shimcache symbols
+        """
+
+        SHIM_NUM_ENTRIES_OFFSET = 0x8
+        SHIM_MAX_ENTRIES = 0x60  # 96 max entries in XP shim cache
+        SHIM_LRU_OFFSET = 0x10
+        SHIM_HEADER_SIZE = 0x190
+        SHIM_CACHE_ENTRY_SIZE = 0x228
+
+        seen = set()
+
+        for process in pslist.PsList.list_processes(
+            context, layer_name, kernel_symbol_table
+        ):
+            pid = process.UniqueProcessId
+            vollog.debug("checking process %d" % pid)
+            for vad in vadinfo.VadInfo.list_vads(
+                process, lambda x: x.get_tag() == b"Vad " and x.Protection == 4
+            ):
+                try:
+                    proc_layer_name = process.add_process_layer()
+                    proc_layer = context.layers[proc_layer_name]
+                except exceptions.InvalidAddressException:
+                    continue
+
+                try:
+                    if proc_layer.read(vad.get_start(), 4) != b"\xEF\xBE\xAD\xDE":
+                        if pid == 624:
+                            vollog.debug("VAD magic bytes don't match DEADBEEF")
+                        continue
+                except exceptions.InvalidAddressException:
+                    continue
+
+                num_entries = context.object(
+                    shimcache_symbol_table + constants.BANG + "unsigned int",
+                    proc_layer_name,
+                    vad.get_start() + SHIM_NUM_ENTRIES_OFFSET,
+                )
+
+                if num_entries > SHIM_MAX_ENTRIES:
+                    continue
+
+                cache_idx_ptr = vad.get_start() + SHIM_LRU_OFFSET
+
+                for _ in range(num_entries):
+                    cache_idx_val = proc_layer.context.object(
+                        shimcache_symbol_table + constants.BANG + "unsigned long",
+                        proc_layer_name,
+                        cache_idx_ptr,
+                    )
+
+                    cache_idx_ptr += 4
+
+                    if cache_idx_val > SHIM_MAX_ENTRIES - 1:
+                        continue
+
+                    shim_entry_offset = (
+                        vad.get_start()
+                        + SHIM_HEADER_SIZE
+                        + (SHIM_CACHE_ENTRY_SIZE * cache_idx_val)
+                    )
+
+                    if not proc_layer.is_valid(shim_entry_offset):
+                        continue
+
+                    physical_addr = proc_layer.translate(shim_entry_offset)
+
+                    if physical_addr in seen:
+                        continue
+                    seen.add(physical_addr)
+
+                    shim_entry = proc_layer.context.object(
+                        shimcache_symbol_table + constants.BANG + "SHIM_CACHE_ENTRY",
+                        proc_layer_name,
+                        shim_entry_offset,
+                    )
+                    if not proc_layer.is_valid(shim_entry.vol.offset):
+                        continue
+                    if not shim_entry.is_valid():
+                        continue
+
+                    yield shim_entry
+
+    @classmethod
+    def find_shimcache_win_2k3_to_7(
+        cls,
+        context: interfaces.context.ContextInterface,
+        config_path: str,
+        kernel_layer_name: str,
+        nt_symbol_table: str,
+        shimcache_symbol_table: str,
+    ) -> Iterator[shimcache.SHIM_CACHE_ENTRY]:
+        """Implements the algorithm to search for the shim cache on Windows 2000
+        (x64) through Windows 7 / 2008 R2. The algorithm consists of the following:
+
+        1) Find the NT kernel module's .data and PAGE sections
+        2) Iterate over every 4/8 bytes (depending on OS bitness) in the .data
+           section and test for the following:
+           a) offset represents a valid RTL_AVL_TABLE object
+           b) RTL_AVL_TABLE is preceeded by an ERESOURCE object
+           c) RTL_AVL_TABLE is followed by the beginning of the SHIM LRU list
+
+        :param context: The context to retrieve required elements (layers, symbol tables) from
+        :param layer_name: The name of the memory layer on which to operate.
+        :param kernel_symbol_table: The name of an existing symbol table containing the kernel symbols
+        :param shimcache_symbol_table: The name of a symbol table containing the hand-crafted shimcache symbols
+        """
+
+        data_sec = cls.get_module_section_range(
+            context,
+            config_path,
+            kernel_layer_name,
+            nt_symbol_table,
+            cls.NT_KRNL_MODS,
+            ".data",
+        )
+        mod_page = cls.get_module_section_range(
+            context,
+            config_path,
+            kernel_layer_name,
+            nt_symbol_table,
+            cls.NT_KRNL_MODS,
+            "PAGE",
+        )
+
+        # We require both in order to accurately handle AVL table
+        if not (data_sec and mod_page):
+            return None
+
+        data_sec_offset, data_sec_size = data_sec
+        mod_page_offset, mod_page_size = mod_page
+
+        addr_size = 8 if symbols.symbol_table_is_64bit(context, nt_symbol_table) else 4
+
+        shim_head = None
+        for offset in range(
+            data_sec_offset, data_sec_offset + data_sec_size, addr_size
+        ):
+            shim_head = cls.try_get_shim_head_at_offset(
+                context,
+                shimcache_symbol_table,
+                nt_symbol_table,
+                kernel_layer_name,
+                mod_page_offset,
+                mod_page_offset + mod_page_size,
+                offset,
+            )
+
+            if shim_head:
+                break
+
+        if not shim_head:
+            return
+
+        for shim_entry in shim_head.ListEntry.to_list(
+            shimcache_symbol_table + constants.BANG + "SHIM_CACHE_ENTRY", "ListEntry"
+        ):
+            yield shim_entry
+
+    @classmethod
+    def try_get_shim_head_at_offset(
+        cls,
+        context: interfaces.context.ContextInterface,
+        symbol_table: str,
+        kernel_symbol_table: str,
+        layer_name: str,
+        mod_page_start: int,
+        mod_page_end: int,
+        offset: int,
+    ) -> Optional[shimcache.SHIM_CACHE_ENTRY]:
+        """Attempts to construct a SHIM_CACHE_HEAD within a layer of the given context,
+        using the provided offset within that layer, as well as the start and end offsets
+        of the kernel module's `PAGE` section start and end offsets.
+
+        If a number of validity checks are passed, this method will return the `SHIM_CACHE_HEAD`
+        object. Otherwise, `None` is returned.
+        """
+        # print("checking RTL_AVL_TABLE at offset %s" % hex(offset))
+        rtl_avl_table = context.object(
+            symbol_table + constants.BANG + "_RTL_AVL_TABLE", layer_name, offset
+        )
+        if not rtl_avl_table.is_valid(mod_page_start, mod_page_end):
+            return None
+
+        vollog.debug(f"Candidate RTL_AVL_TABLE found at offset {hex(offset)}")
+
+        ersrc_size = context.symbol_space.get_type(
+            kernel_symbol_table + constants.BANG + "_ERESOURCE"
+        ).size
+        ersrc_alignment = (
+            0x20
+            if symbols.symbol_table_is_64bit(context, kernel_symbol_table)
+            else 0x10
+            # 0x20 if context.symbol_space.get_type("pointer").size == 8 else 0x10
+        )
+        vollog.debug(
+            f"ERESOURCE size: {hex(ersrc_size)}, ERESOURCE alignment: {hex(ersrc_alignment)}"
+        )
+
+        eresource_rel_off = ersrc_size + ((offset - ersrc_size) % ersrc_alignment)
+        eresource_offset = offset - eresource_rel_off
+
+        vollog.debug("Constructing ERESOURCE at %s" % hex(eresource_offset))
+        eresource = context.object(
+            kernel_symbol_table + constants.BANG + "_ERESOURCE",
+            layer_name,
+            eresource_offset,
+        )
+        if not eresource.is_valid():
+            vollog.debug("ERESOURCE Invalid")
+            return None
+
+        shim_head_offset = offset + rtl_avl_table.vol.size
+
+        if not context.layers[layer_name].is_valid(shim_head_offset):
+            return None
+
+        shim_head = context.object(
+            symbol_table + constants.BANG + "SHIM_CACHE_ENTRY",
+            layer_name,
+            shim_head_offset,
+        )
+
+        if not shim_head.is_valid():
+            vollog.debug("shim head invalid")
+            return None
+        else:
+            vollog.debug("returning shim head")
+            return shim_head
+
+    @classmethod
+    def find_shimcache_win_8_or_later(
+        cls,
+        context: interfaces.context.ContextInterface,
+        config_path: str,
+        kernel_layer_name: str,
+        nt_symbol_table: str,
+        shimcache_symbol_table: str,
+    ) -> Iterator[shimcache.SHIM_CACHE_ENTRY]:
+        """Attempts to locate and yield shimcache entries from a Windows 8 or later memory image.
+
+        :param context: The context to retrieve required elements (layers, symbol tables) from
+        :param layer_name: The name of the memory layer on which to operate.
+        :param kernel_symbol_table: The name of an existing symbol table containing the kernel symbols
+        :param shimcache_symbol_table: The name of a symbol table containing the hand-crafted shimcache symbols
+        """
+
+        is_8_1_or_later = versions.is_windows_8_1_or_later(
+            context, nt_symbol_table
+        ) or versions.is_win10(context, nt_symbol_table)
+
+        module_names = ["ahcache.sys"] if is_8_1_or_later else cls.NT_KRNL_MODS
+        vollog.debug(f"Searching for modules {module_names}")
+
+        data_sec = cls.get_module_section_range(
+            context,
+            config_path,
+            kernel_layer_name,
+            nt_symbol_table,
+            module_names,
+            ".data",
+        )
+        mod_page = cls.get_module_section_range(
+            context,
+            config_path,
+            kernel_layer_name,
+            nt_symbol_table,
+            module_names,
+            "PAGE",
+        )
+
+        if not (data_sec and mod_page):
+            return None
+
+        mod_page_offset, mod_page_size = mod_page
+        data_sec_offset, data_sec_size = data_sec
+
+        # iterate over ahcache kernel module's .data section in search of *two* SHIM handles
+        shim_heads = []
+
+        vollog.debug(f"PAGE offset: {hex(mod_page_offset)}")
+        vollog.debug(f".data offset: {hex(data_sec_offset)}")
+
+        handle_type = context.symbol_space.get_type(
+            shimcache_symbol_table + constants.BANG + "SHIM_CACHE_HANDLE"
+        )
+        for offset in range(
+            data_sec_offset,
+            data_sec_offset + data_sec_size,
+            8 if symbols.symbol_table_is_64bit(context, nt_symbol_table) else 4,
+        ):
+            vollog.debug(f"Building shim handle pointer at {hex(offset)}")
+            shim_handle = context.object(
+                object_type=shimcache_symbol_table + constants.BANG + "pointer",
+                layer_name=kernel_layer_name,
+                subtype=handle_type,
+                offset=offset,
+            )
+
+            if shim_handle.is_valid(mod_page_offset, mod_page_offset + mod_page_size):
+                if shim_handle.head is not None:
+                    vollog.debug(
+                        f"Found valid shim handle @ {hex(shim_handle.vol.offset)}"
+                    )
+                    shim_heads.append(shim_handle.head)
+                if len(shim_heads) == 2:
+                    break
+
+        if len(shim_heads) != 2:
+            vollog.debug("Failed to identify two valid SHIM_CACHE_HANDLE structures")
+            return
+
+        # On Windows 8 x64, the frist cache contains the shim cache
+        # On Windows 8 x86, 8.1 x86/x64, and 10, the second cache contains the shim cache.
+        if (
+            not symbols.symbol_table_is_64bit(context, nt_symbol_table)
+            and not is_8_1_or_later
+        ):
+            valid_head = shim_heads[1]
+        elif not is_8_1_or_later:
+            valid_head = shim_heads[0]
+        else:
+            valid_head = shim_heads[1]
+
+        for shim_entry in valid_head.ListEntry.to_list(
+            shimcache_symbol_table + constants.BANG + "SHIM_CACHE_ENTRY", "ListEntry"
+        ):
+            if shim_entry.is_valid():
+                yield shim_entry
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+
+        shimcache_table_name = self.create_shimcache_table(
+            self.context, kernel.symbol_table_name, self.config_path
+        )
+
+        c = count()
+
+        if versions.is_windows_8_or_later(self._context, kernel.symbol_table_name):
+            vollog.info("Finding shimcache entries for Windows 8.0+")
+            entries = self.find_shimcache_win_8_or_later(
+                self.context,
+                self.config_path,
+                kernel.layer_name,
+                kernel.symbol_table_name,
+                shimcache_table_name,
+            )
+
+        elif (
+            versions.is_2003(self.context, kernel.symbol_table_name)
+            or versions.is_vista_or_later(self.context, kernel.symbol_table_name)
+            or versions.is_windows_7(self.context, kernel.symbol_table_name)
+        ):
+            vollog.info("Finding shimcache entries for Windows 2k3/Vista/7")
+            entries = self.find_shimcache_win_2k3_to_7(
+                self.context,
+                self.config_path,
+                kernel.layer_name,
+                kernel.symbol_table_name,
+                shimcache_table_name,
+            )
+
+        elif versions.is_windows_xp_sp2(
+            self._context, kernel.symbol_table_name
+        ) or versions.is_windows_xp_sp3(self.context, kernel.symbol_table_name):
+            vollog.info("Finding shimcache entries for WinXP")
+            entries = self.find_shimcache_win_xp(
+                self._context,
+                kernel.layer_name,
+                kernel.symbol_table_name,
+                shimcache_table_name,
+            )
+        else:
+            vollog.warn("Cannot parse shimcache entries for this version of Windows")
+            return
+
+        for entry in entries:
+            try:
+                vollog.debug(f"SHIM_CACHE_ENTRY type: {entry.__class__}")
+                shim_entry = (
+                    entry.last_modified,
+                    entry.last_update,
+                    entry.exec_flag,
+                    (
+                        format_hints.Hex(entry.file_size)
+                        if isinstance(entry.file_size, int)
+                        else entry.file_size
+                    ),
+                    entry.file_path,
+                )
+            except exceptions.InvalidAddressException:
+                continue
+
+            yield (
+                0,
+                (next(c), *shim_entry),
+            )
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Order", int),
+                ("Last Modified", datetime),
+                ("Last Update", datetime),
+                ("Exec Flag", bool),
+                ("File Size", format_hints.Hex),
+                ("File Path", str),
+            ],
+            self._generator(),
+        )
+
+    @classmethod
+    def get_module_section_range(
+        cls,
+        context: interfaces.context.ContextInterface,
+        config_path: str,
+        layer_name: str,
+        symbol_table: str,
+        module_list: List[str],
+        section_name: str,
+    ) -> Optional[Tuple[int, int]]:
+        """Locates the size and offset of the first found module section
+        specified by name from the list of modules.
+
+        :param context: The context to operate on
+        :param layer_name: The memory layer to read from
+        :param module_list: A list of module names to search for the given section
+        :param section_name: The name of the section to search for.
+
+        :return: The offset and size of the module, if found; Otherwise, returns `None`
+        """
+
+        try:
+            krnl_mod = next(
+                module
+                for module in modules.Modules.list_modules(
+                    context, layer_name, symbol_table
+                )
+                if module.BaseDllName.String in module_list
+            )
+        except StopIteration:
+            return None
+
+        pe_table_name = intermed.IntermediateSymbolTable.create(
+            context,
+            interfaces.configuration.path_join(config_path, "pe"),
+            "windows",
+            "pe",
+            class_types=pe.class_types,
+        )
+
+        # code taken from Win32KBase._section_chunks (win32_core.py)
+        dos_header = context.object(
+            pe_table_name + constants.BANG + "_IMAGE_DOS_HEADER",
+            layer_name,
+            offset=krnl_mod.DllBase,
+        )
+
+        if not dos_header:
+            return None
+
+        nt_header = dos_header.get_nt_header()
+
+        try:
+            section = next(
+                sec
+                for sec in nt_header.get_sections()
+                if section_name.lower() == array_to_string(sec.Name).lower()
+            )
+        except StopIteration:
+            return None
+
+        section_offset = krnl_mod.DllBase + section.VirtualAddress
+        section_size = section.Misc.VirtualSize
+
+        return section_offset, section_size

--- a/volatility3/framework/symbols/windows/__init__.py
+++ b/volatility3/framework/symbols/windows/__init__.py
@@ -17,6 +17,7 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("_KTHREAD", extensions.KTHREAD)
         self.set_type_class("_LIST_ENTRY", extensions.LIST_ENTRY)
         self.set_type_class("_EPROCESS", extensions.EPROCESS)
+        self.set_type_class("_ERESOURCE", extensions.ERESOURCE)
         self.set_type_class("_UNICODE_STRING", extensions.UNICODE_STRING)
         self.set_type_class("_EX_FAST_REF", extensions.EX_FAST_REF)
         self.set_type_class("_TOKEN", extensions.TOKEN)

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -306,16 +306,19 @@ class MMVAD_SHORT(objects.StructType):
 
         raise AttributeError("Unable to find the private memory member")
 
+    @property
+    def Protection(self):
+        if self.has_member("u"):
+            return self.u.VadFlags.Protection
+        elif self.has_member("Core"):
+            return self.Core.u.VadFlags.Protection
+        else:
+            return None
+
     def get_protection(self, protect_values, winnt_protections):
         """Get the VAD's protection constants as a string."""
 
-        protect = None
-
-        if self.has_member("u"):
-            protect = self.u.VadFlags.Protection
-
-        elif self.has_member("Core"):
-            protect = self.Core.u.VadFlags.Protection
+        protect = self.Protection
 
         try:
             value = protect_values[protect]
@@ -591,6 +594,38 @@ class UNICODE_STRING(objects.StructType):
         )
 
     String = property(get_string)
+
+
+class ERESOURCE(objects.StructType):
+    def is_valid(self) -> bool:
+        vollog.debug(f"Checking ERESOURCE Validity: {hex(self.vol.offset)}")
+
+        if not self._context.layers[self.vol.layer_name].is_valid(self.vol.offset):
+            return False
+
+        sym_table = self.get_symbol_table_name()
+
+        waiters_valid = self.SharedWaiters == 0 or self._context.layers[
+            self.vol.layer_name
+        ].is_valid(
+            self.SharedWaiters.vol.offset,
+            self._context.symbol_space.get_type(
+                sym_table + constants.BANG + "_KSEMAPHORE"
+            ).size,
+        )
+
+        try:
+            return (
+                waiters_valid
+                and self.SystemResourcesList.Flink is not None
+                and self.SystemResourcesList.Blink is not None
+                and self.SystemResourcesList.Flink != self.SystemResourcesList.Blink
+                and self.SystemResourcesList.Flink.Blink == self.vol.offset
+                and self.SystemResourcesList.Blink.Flink == self.vol.offset
+                and self.NumberOfSharedWaiters == 0
+            )
+        except exceptions.InvalidAddressException:
+            return False
 
 
 class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):

--- a/volatility3/framework/symbols/windows/extensions/shimcache.py
+++ b/volatility3/framework/symbols/windows/extensions/shimcache.py
@@ -1,0 +1,278 @@
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import struct
+from datetime import datetime
+from typing import Dict, Optional, Tuple, Union
+
+from volatility3.framework import constants, exceptions, interfaces, objects, renderers
+from volatility3.framework.symbols.windows.extensions import conversion
+
+vollog = logging.getLogger(__name__)
+
+
+class SHIM_CACHE_ENTRY(objects.StructType):
+    """Class for abstracting variations in the shimcache LRU list entry structure"""
+
+    def __init__(
+        self,
+        context: interfaces.context.ContextInterface,
+        type_name: str,
+        object_info: interfaces.objects.ObjectInformation,
+        size: int,
+        members: Dict[str, Tuple[int, interfaces.objects.Template]],
+    ) -> None:
+        super().__init__(context, type_name, object_info, size, members)
+        self._exec_flag = None
+        self._file_path = None
+        self._file_size = None
+        self._last_modified = None
+        self._last_updated = None
+
+    @property
+    def exec_flag(self) -> Union[bool, interfaces.renderers.BaseAbsentValue]:
+        """Checks if InsertFlags fields has been bitwise OR'd with a value of 2.
+        This behavior was observed when processes are created by CSRSS."""
+        if self._exec_flag is not None:
+            return self._exec_flag
+
+        if hasattr(self, "ListEntryDetail") and hasattr(
+            self.ListEntryDetail, "InsertFlags"
+        ):
+            self._exec_flag = self.ListEntryDetail.InsertFlags & 0x2 == 2
+
+        elif hasattr(self, "InsertFlags"):
+            self._exec_flag = self.InsertFlags & 0x2 == 2
+
+        elif hasattr(self, "ListEntryDetail") and hasattr(
+            self.ListEntryDetail, "BlobBuffer"
+        ):
+            blob_offset = self.ListEntryDetail.BlobBuffer
+            blob_size = self.ListEntryDetail.BlobSize
+
+            if not self._context.layers[self.vol.native_layer_name].is_valid(
+                blob_offset, blob_size
+            ):
+                self._exec_flag = renderers.UnparsableValue()
+
+            raw_flag = self._context.layers[self.vol.native_layer_name].read(
+                blob_offset, blob_size
+            )
+            if not raw_flag:
+                self._exec_flag = renderers.UnparsableValue()
+
+            try:
+                self._exec_flag = bool(struct.unpack("<I", raw_flag)[0])
+            except struct.error:
+                self._exec_flag = renderers.UnparsableValue()
+
+        else:
+            # Always set to true for XP/2K3
+            self._exec_flag = renderers.NotApplicableValue()
+        return self._exec_flag
+
+    @property
+    def file_size(self) -> Union[int, interfaces.renderers.BaseAbsentValue]:
+        if self._file_size is not None:
+            return self._file_size
+        try:
+            self._file_size = self.FileSize
+            if self._file_size < 0:
+                self._file_size = 0
+
+        except AttributeError:
+            self._file_size = renderers.NotApplicableValue()
+        except exceptions.InvalidAddressException:
+            self._file_size = renderers.UnreadableValue()
+
+        return self._file_size
+
+    @property
+    def last_modified(self) -> Union[datetime, interfaces.renderers.BaseAbsentValue]:
+        if self._last_modified is not None:
+            return self._last_modified
+        try:
+            self._last_modified = conversion.wintime_to_datetime(
+                self.ListEntryDetail.LastModified.QuadPart
+            )
+        except AttributeError:
+            self._last_modified = conversion.wintime_to_datetime(
+                self.LastModified.QuadPart
+            )
+        except exceptions.InvalidAddressException:
+            self._last_modified = renderers.UnreadableValue()
+
+        return self._last_modified
+
+    @property
+    def last_update(self) -> Union[datetime, interfaces.renderers.BaseAbsentValue]:
+        if self._last_updated is not None:
+            return self._last_updated
+
+        try:
+            self._last_updated = conversion.wintime_to_datetime(
+                self.LastUpdate.QuadPart
+            )
+        except AttributeError:
+            self._last_updated = renderers.NotApplicableValue()
+
+        return self._last_updated
+
+    @property
+    def file_path(self) -> Union[str, interfaces.renderers.BaseAbsentValue]:
+        if self._file_path is not None:
+            return self._file_path
+
+        if not hasattr(self.Path, "Buffer"):
+            return self.Path.cast(
+                "string", max_length=self.Path.vol.count, encoding="utf-16le"
+            )
+
+        try:
+            file_path_raw = (
+                self._context.layers[self.vol.native_layer_name].read(
+                    self.Path.Buffer, self.Path.Length
+                )
+                or b""
+            )
+            self._file_path = file_path_raw.decode("utf-16", errors="replace")
+        except exceptions.InvalidAddressException:
+            self._file_path = renderers.UnreadableValue()
+
+        return self._file_path
+
+    def is_valid(self) -> bool:
+        """Shim cache validation is limited to ensuring that a subset of the
+        pointers in the LIST_ENTRY field are valid (similar to validation of
+        ERESOURCE)"""
+
+        # shim entries on Windows XP do not have list entry attributes; in this case,
+        # perform a different set of validations
+        try:
+            if not hasattr(self, "ListEntry"):
+                return bool(self.last_modified and self.last_update and self.file_size)
+
+            # on some platforms ListEntry.Blink is null, so this cannot be validated
+            if (
+                self.ListEntry.Flink != 0
+                and (
+                    self.ListEntry.Blink.dereference()
+                    != self.ListEntry.Flink.dereference()
+                )
+                and (
+                    self.ListEntry.Flink.Blink
+                    == self.ListEntry.Flink.Blink.dereference().vol.offset
+                )
+            ):
+
+                return True
+            else:
+                return False
+        except exceptions.InvalidAddressException:
+            return False
+
+
+class SHIM_CACHE_HANDLE(objects.StructType):
+    def __init__(
+        self,
+        context: interfaces.context.ContextInterface,
+        type_name: str,
+        object_info: interfaces.objects.ObjectInformation,
+        size: int,
+        members: Dict[str, Tuple[int, interfaces.objects.Template]],
+    ) -> None:
+        super().__init__(context, type_name, object_info, size, members)
+
+    @property
+    def head(self) -> Optional[SHIM_CACHE_ENTRY]:
+        try:
+            if not self.eresource.is_valid():
+                return None
+        except exceptions.InvalidAddressException:
+            return None
+
+        rtl_avl_table = self._context.object(
+            self.get_symbol_table_name() + constants.BANG + "_RTL_AVL_TABLE",
+            self.vol.layer_name,
+            self.rtl_avl_table,
+            self.vol.native_layer_name,
+        )
+
+        if not self._context.layers[self.vol.layer_name].is_valid(
+            self.rtl_avl_table.vol.offset
+        ):
+            return None
+
+        offset_head = rtl_avl_table.vol.offset + rtl_avl_table.vol.size
+
+        head = self._context.object(
+            self.get_symbol_table_name() + constants.BANG + "SHIM_CACHE_ENTRY",
+            self.vol.layer_name,
+            offset_head,
+        )
+
+        if not head.is_valid():
+            return None
+
+        return head
+
+    def is_valid(self, avl_section_start: int, avl_section_end: int) -> bool:
+        if self.vol.offset == 0:
+            return False
+
+        vollog.debug(f"Checking SHIM_CACHE_HANDLE validity @ {hex(self.vol.offset)}")
+
+        if not (
+            self._context.layers[self.vol.layer_name].is_valid(self.vol.offset)
+            and self.eresource.is_valid()
+            and self.rtl_avl_table.is_valid(avl_section_start, avl_section_end)
+            and self.head
+        ):
+            return False
+
+        return self.head.is_valid()
+
+
+class RTL_AVL_TABLE(objects.StructType):
+    def is_valid(self, page_start: int, page_end: int) -> bool:
+        try:
+            if self.BalancedRoot.Parent != self.BalancedRoot.vol.offset:
+                vollog.debug(
+                    f"RTL_AVL_TABLE @ {self.vol.offset} Invalid: Failed BalancedRoot parent equality check"
+                )
+                return False
+
+            elif self.AllocateRoutine < page_start or self.AllocateRoutine > page_end:
+                vollog.debug(
+                    f"RTL_AVL_TABLE @ {self.vol.offset} Invalid: Failed AllocateRoutine range check"
+                )
+                return False
+
+            elif self.CompareRoutine < page_start or self.CompareRoutine > page_end:
+                vollog.debug(
+                    f"RTL_AVL_TABLE @ {self.vol.offset} Invalid: Failed CompareRoutine range check"
+                )
+                return False
+
+            elif (
+                (self.AllocateRoutine.vol.offset == self.CompareRoutine.vol.offset)
+                or (self.AllocateRoutine.vol.offset == self.FreeRoutine.vol.offset)
+                or (self.CompareRoutine.vol.offset == self.FreeRoutine.vol.offset)
+            ):
+                vollog.debug(
+                    f"RTL_AVL_TABLE @ {self.vol.offset} Invalid: Failed (Compare|Allocate|Free)Routine uniqueness check"
+                )
+                return False
+
+            return True
+        except exceptions.InvalidAddressException:
+            return False
+
+
+class_types = {
+    "SHIM_CACHE_HANDLE": SHIM_CACHE_HANDLE,
+    "SHIM_CACHE_ENTRY": SHIM_CACHE_ENTRY,
+    "_RTL_AVL_TABLE": RTL_AVL_TABLE,
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-2003-x64.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-2003-x64.json
@@ -1,0 +1,327 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 16
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 24
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 25
+                }
+            },
+            "kind": "struct",
+            "size": 32
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 32
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 40
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 44
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 48
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 56
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 64
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 72
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 80
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 88
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 96
+                }
+            },
+            "kind": "struct",
+            "size": 104
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "Path": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "LastModified": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "FileSize": {
+                    "offset": 40,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 48
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-2003-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-2003-x86.json
@@ -1,0 +1,334 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 4
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 12
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 16
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 20
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 24
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 28
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 32
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 36
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 40
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 44
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 48
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 52
+                }
+            },
+            "kind": "struct",
+            "size": 56
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "Path": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "LastModified": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "FileSize": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "Padding": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 36
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-vista-x64.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-vista-x64.json
@@ -1,0 +1,334 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 16
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 24
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 25
+                }
+            },
+            "kind": "struct",
+            "size": 32
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 32
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 40
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 44
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 48
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 56
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 64
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 72
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 80
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 88
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 96
+                }
+            },
+            "kind": "struct",
+            "size": 104
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "Path": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "LastModified": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "InsertFlags": {
+                    "offset": 40,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "ShimFlags": {
+                    "offset": 44,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 48
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-vista-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-vista-x86.json
@@ -1,0 +1,334 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 4
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 12
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 16
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 20
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 24
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 28
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 32
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 36
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 40
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 44
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 48
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 52
+                }
+            },
+            "kind": "struct",
+            "size": 56
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "Path": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "LastModified": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "InsertFlags": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "ShimFlags": {
+                    "offset": 28,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 36
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-win10-x64.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-win10-x64.json
@@ -1,0 +1,371 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 16
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 24
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 25
+                }
+            },
+            "kind": "struct",
+            "size": 32
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 32
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 40
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 44
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 48
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 56
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 64
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 72
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 80
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 88
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 96
+                }
+            },
+            "kind": "struct",
+            "size": 104
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "u1": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "Path": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "ListEntryDetail": {
+                    "offset": 40,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "SHIM_CACHE_ENTRY_DETAIL"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 48
+        },
+        "SHIM_CACHE_ENTRY_DETAIL": {
+            "fields": {
+                "u1": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "LastModified": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "BlobSize": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "u2": {
+                    "offset": 20,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "BlobBuffer": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 32
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-win10-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-win10-x86.json
@@ -1,0 +1,371 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 4
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 4
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 12
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 16
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 20
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 24
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 28
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 32
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 36
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 40
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 44
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 48
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 52
+                }
+            },
+            "kind": "struct",
+            "size": 56
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "u1": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "Path": {
+                    "offset": 12,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "ListEntryDetail": {
+                    "offset": 20,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "SHIM_CACHE_ENTRY_DETAIL"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 24
+        },
+        "SHIM_CACHE_ENTRY_DETAIL": {
+            "fields": {
+                "u1": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "InsertFlags": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "LastModified": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "BlobSize": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "BlobBuffer": {
+                    "offset": 20,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 24
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-win7-x64.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-win7-x64.json
@@ -1,0 +1,348 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 16
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 24
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 25
+                }
+            },
+            "kind": "struct",
+            "size": 32
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 32
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 40
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 44
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 48
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 56
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 64
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 72
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 80
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 88
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 96
+                }
+            },
+            "kind": "struct",
+            "size": 104
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "Path": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "LastModified": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "InsertFlags": {
+                    "offset": 40,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "ShimFlags": {
+                    "offset": 44,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "BlobSize": {
+                    "offset": 48,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "BlobBuffer": {
+                    "offset": 56,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 64
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-win7-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-win7-x86.json
@@ -1,0 +1,348 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 4
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 12
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 16
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 20
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 24
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 28
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 32
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 36
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 40
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 44
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 48
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 52
+                }
+            },
+            "kind": "struct",
+            "size": 56
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 4
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "Path": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "LastModified": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "InsertFlags": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "ShimFlags": {
+                    "offset": 28,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "BlobSize": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "BlobBuffer": {
+                    "offset": 36,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 40
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-win8-x64.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-win8-x64.json
@@ -1,0 +1,392 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 16
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 24
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 25
+                }
+            },
+            "kind": "struct",
+            "size": 32
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 32
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 40
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 44
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 48
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 56
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 64
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 72
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 80
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 88
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 96
+                }
+            },
+            "kind": "struct",
+            "size": 104
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 8
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "u1": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "Path": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "u2": {
+                    "offset": 40,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "u3": {
+                    "offset": 48,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "ListEntryDetail": {
+                    "offset": 56,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "SHIM_CACHE_ENTRY_DETAIL"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 64
+        },
+        "SHIM_CACHE_ENTRY_DETAIL": {
+            "fields": {
+                "LastModified": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "InsertFlags": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "ShimFlags": {
+                    "offset": 12,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "BlobSize": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "Padding": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "BlobBuffer": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 40
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-win8-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-win8-x86.json
@@ -1,0 +1,386 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 4
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 12
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 16
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 20
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 24
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 28
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 32
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 36
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 40
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 44
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 48
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 52
+                }
+            },
+            "kind": "struct",
+            "size": 56
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 4
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "ListEntry": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_LIST_ENTRY"
+                    }
+                },
+                "u1": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "u2": {
+                    "offset": 12,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "Path": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_UNICODE_STRING"
+                    }
+                },
+                "u3": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long long"
+                    }
+                },
+                "ListEntryDetail": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "SHIM_CACHE_ENTRY_DETAIL"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 36
+        },
+        "SHIM_CACHE_ENTRY_DETAIL": {
+            "fields": {
+                "LastModified": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "_LARGE_INTEGER"
+                    }
+                },
+                "InsertFlags": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    }
+                },
+                "ShimFlags": {
+                    "offset": 12,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "BlobSize": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "BlobBuffer": {
+                    "offset": 20,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 24
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}
+

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-xp-sp2-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-xp-sp2-x86.json
@@ -1,0 +1,485 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 4
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 12
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 16
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 20
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 24
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 28
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 32
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 36
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 40
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 44
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 48
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 52
+                }
+            },
+            "kind": "struct",
+            "size": 56
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 4
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "SHIM_CACHE_HEADER": {
+            "fields": {
+                "Magic": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 0
+                },
+                "u1": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 4
+                },
+                "NumEntries": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 8
+                },
+                "u2": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 400
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "Path": {
+                    "type": {
+                        "count": 520,
+                        "kind": "array",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LastModified": {
+                    "type": {
+                        "kind": "union",
+                        "name": "LARGE_INTEGER"
+                    },
+                    "offset": 4
+                },
+                "FileSize": {
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    },
+                    "offset": 8
+                },
+                "LastUpdate": {
+                    "type": {
+                        "kind": "union",
+                        "name": "LARGE_INTEGER"
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 552
+        },
+        "_SEGMENT": {
+            "fields": {
+                "ControlArea": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_CONTROL_AREA"
+                        }
+                    }
+                },
+                "TotalNumberOfPtes": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "NonExtendedPtes": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "WritableUserReferences": {
+                    "offset": 12,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "SizeOfSegment": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "SegmentPteTemplate": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_MMPTE"
+                    }
+                },
+                "NumberOfCommittedPages": {
+                    "offset": 28,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "ExtendInfo": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_MMEXTEND_INFO"
+                        }
+                    }
+                },
+                "SystemImageBase": {
+                    "offset": 36,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    }
+                },
+                "BasedAddress": {
+                    "offset": 40,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "u1": {
+                    "offset": 44,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "u2": {
+                    "offset": 48,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "PrototypePte": {
+                    "offset": 52,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_MMPTE"
+                        }
+                    }
+                },
+                "ThePtes": {
+                    "offset": 60,
+                    "type": {
+                        "kind": "array",
+                        "count": 1,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "nt_symbols!_MMPTE"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 64
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-xp-sp3-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-xp-sp3-x86.json
@@ -1,0 +1,485 @@
+{
+    "symbols": {},
+    "enums": {},
+    "base_types": {
+        "unsigned long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned long long": {
+            "kind": "int",
+            "size": 8,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned char": {
+            "kind": "char",
+            "size": 1,
+            "signed": false,
+            "endian": "little"
+        },
+        "pointer": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned int": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        },
+        "unsigned short": {
+            "kind": "int",
+            "size": 2,
+            "signed": false,
+            "endian": "little"
+        },
+        "long": {
+            "kind": "int",
+            "size": 4,
+            "signed": false,
+            "endian": "little"
+        }
+    },
+    "user_types": {
+        "_LARGE_INTEGER": {
+            "fields": {
+                "HighPart": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "LowPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "QuadPart": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    }
+                },
+                "u": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "struct",
+                        "name": "__unnamed_2"
+                    }
+                }
+            },
+            "kind": "union",
+            "size": 8
+        },
+        "__unnamed_2": {
+          "fields": {
+            "HighPart": {
+              "offset": 4,
+              "type": {
+                "kind": "base",
+                "name": "long"
+              }
+            },
+            "LowPart": {
+              "offset": 0,
+              "type": {
+                "kind": "base",
+                "name": "unsigned long"
+              }
+            }
+          },
+          "kind": "struct",
+          "size": 8
+        },
+        "_RTL_BALANCED_LINKS": {
+            "fields": {
+                "Parent": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LeftChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 4
+                },
+                "RightChild": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 8
+                },
+                "Balance": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned char"
+                    },
+                    "offset": 12
+                },
+                "Reserved": {
+                    "type": {
+                        "kind": "array",
+                        "count": 3,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 16
+        },
+        "_RTL_AVL_TABLE": {
+            "fields": {
+                "BalancedRoot": {
+                    "type": {
+                        "kind": "struct",
+                        "name": "_RTL_BALANCED_LINKS"
+                    },
+                    "offset": 0
+                },
+                "OrderedPointer": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 16
+                },
+                "WhichOrderedElement": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 20
+                },
+                "NumberGenericTableElements": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 24
+                },
+                "DepthOfTree": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 28
+                },
+                "RestartKey": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_BALANCED_LINKS"
+                        }
+                    },
+                    "offset": 32
+                },
+                "DeleteCount": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    },
+                    "offset": 36
+                },
+                "CompareRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 40
+                },
+                "AllocateRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 44
+                },
+                "FreeRoutine": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 48
+                },
+                "TableContext": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    },
+                    "offset": 52
+                }
+            },
+            "kind": "struct",
+            "size": 56
+        },
+        "SHIM_CACHE_HEADER": {
+            "fields": {
+                "Magic": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 0
+                },
+                "u1": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 4
+                },
+                "NumEntries": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 8
+                },
+                "u2": {
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned int"
+                    },
+                    "offset": 12
+                }
+            },
+            "kind": "struct",
+            "size": 400
+        },
+        "SHIM_CACHE_ENTRY": {
+            "fields": {
+                "Path": {
+                    "type": {
+                        "count": 520,
+                        "kind": "array",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "unsigned char"
+                        }
+                    },
+                    "offset": 0
+                },
+                "LastModified": {
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    },
+                    "offset": 528
+                },
+                "FileSize": {
+                    "type": {
+                        "kind": "base",
+                        "name": "long long"
+                    },
+                    "offset": 536
+                },
+                "LastUpdate": {
+                    "type": {
+                        "kind": "union",
+                        "name": "_LARGE_INTEGER"
+                    },
+                    "offset": 544
+                }
+            },
+            "kind": "struct",
+            "size": 552
+        },
+        "SHIM_CACHE_HANDLE": {
+            "fields": {
+                "eresource": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!ERESOURCE"
+                        }
+                    },
+                    "offset": 0
+                },
+                "rtl_avl_table": {
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "_RTL_AVL_TABLE"
+                        }
+                    },
+                    "offset": 4
+                }
+            },
+            "kind": "struct",
+            "size": 8
+        },
+        "_SEGMENT": {
+            "fields": {
+                "ControlArea": {
+                    "offset": 0,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_CONTROL_AREA"
+                        }
+                    }
+                },
+                "TotalNumberOfPtes": {
+                    "offset": 4,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "NonExtendedPtes": {
+                    "offset": 8,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "WritableUserReferences": {
+                    "offset": 12,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "SizeOfSegment": {
+                    "offset": 16,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "SegmentPteTemplate": {
+                    "offset": 24,
+                    "type": {
+                        "kind": "struct",
+                        "name": "nt_symbols!_MMPTE"
+                    }
+                },
+                "NumberOfCommittedPages": {
+                    "offset": 32,
+                    "type": {
+                        "kind": "base",
+                        "name": "unsigned long"
+                    }
+                },
+                "ExtendInfo": {
+                    "offset": 36,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_MMEXTEND_INFO"
+                        }
+                    }
+                },
+                "SystemImageBase": {
+                    "offset": 40,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
+                    }
+                },
+                "BasedAddress": {
+                    "offset": 44,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "u1": {
+                    "offset": 48,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "u2": {
+                    "offset": 52,
+                    "type": {
+                        "kind": "base",
+                        "name": "long"
+                    }
+                },
+                "PrototypePte": {
+                    "offset": 56,
+                    "type": {
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "struct",
+                            "name": "nt_symbols!_MMPTE"
+                        }
+                    }
+                },
+                "ThePtes": {
+                    "offset": 64,
+                    "type": {
+                        "kind": "array",
+                        "count": 1,
+                        "subtype": {
+                            "kind": "base",
+                            "name": "nt_symbols!_MMPTE"
+                        }
+                    }
+                }
+            },
+            "kind": "struct",
+            "size": 72
+        }
+    },
+    "metadata": {
+        "producer": {
+            "version": "0.0.1",
+            "name": "dgmcdona by hand",
+            "datetime": "2024-07-05T18:28:00.000000+00:00"
+        },
+        "format": "4.0.0"
+    }
+}

--- a/volatility3/framework/symbols/windows/versions.py
+++ b/volatility3/framework/symbols/windows/versions.py
@@ -114,11 +114,38 @@ is_windows_xp = OsDistinguisher(
     ],
 )
 
+is_windows_xp_sp2 = OsDistinguisher(
+    version_check=lambda x: (5, 1) <= x < (5, 2),
+    fallback_checks=[
+        ("KdCopyDataBlock", None, False),
+        ("_MMFREE_POOL_ENTRY", None, False),
+        ("_HANDLE_TABLE", "HandleCount", True),
+    ],
+)
+
+is_windows_xp_sp3 = OsDistinguisher(
+    version_check=lambda x: (5, 1) <= x < (5, 2),
+    fallback_checks=[
+        ("KdCopyDataBlock", None, False),
+        ("_MMFREE_POOL_ENTRY", None, True),
+        ("_HANDLE_TABLE", "HandleCount", True),
+    ],
+)
+
 is_xp_or_2003 = OsDistinguisher(
     version_check=lambda x: (5, 1) <= x < (6, 0),
     fallback_checks=[
         ("KdCopyDataBlock", None, False),
         ("_HANDLE_TABLE", "HandleCount", True),
+    ],
+)
+
+is_2003 = OsDistinguisher(
+    version_check=lambda x: (5, 2) <= x < (5, 3),
+    fallback_checks=[
+        ("KdCopyDataBlock", None, False),
+        ("_HANDLE_TABLE", "HandleCount", True),
+        ("_MM_AVL_TABLE", None, True),
     ],
 )
 


### PR DESCRIPTION
This PR adds a port of the ShimcacheMem Windows plugin from the original volatility framework.

It has been tested against a large collection of both 32-bit and 64-bit samples for each of the relevant Windows versions to confirm parity between the results of the original plugin and this new version.