### PR TITLE
Add shell autocompletion feature for bash and fish.

### DIFF
--- a/volatility3/cli/autocompletion.py
+++ b/volatility3/cli/autocompletion.py
@@ -1,0 +1,183 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+import os
+import textwrap
+
+BASE_COMPLETION = """
+# Volatility3 {shell} completion start{script}# Volatility3 {shell} completion end
+"""
+
+COMPLETION_SCRIPTS = {
+    "bash": """
+        _vol3_completion()
+        {{
+            COMPREPLY=( $( COMP_WORDS="${{COMP_WORDS[*]}}" \\
+                           COMP_CWORD=$COMP_CWORD \\
+                           {vol3_env_var}=1 $1 2>/dev/null ) )
+        }}
+        complete -o default -o nosort -F _vol3_completion {prog}
+    """,
+    "fish": """
+        function __fish_complete_vol3
+            set -lx COMP_WORDS (commandline -o) ""
+            set -lx COMP_CWORD ( \\
+                math (contains -i -- (commandline -t) $COMP_WORDS)-1 \\
+            )
+            set -lx {vol3_env_var} 1
+            string split \\  -- (eval $COMP_WORDS[1])
+        end
+        complete -fa "(__fish_complete_vol3)" -c {prog}
+    """,
+}
+
+
+class AutoCompletion(object):
+    AUTOCOMPLETION_ACTIVATION_ENV = "VOLATILITY3_AUTOCOMPLETION"
+
+    AVAILABLE_SHELLS = sorted(COMPLETION_SCRIPTS)
+    ACTION_GROUP_OPTIONS_INDEX = 1
+    ACTION_GROUP_PLUGINS_INDEX = 2
+
+    def __init__(self, parser, skip_single_dash=True, skip_help=True):
+        if not self.is_enabled():
+            # Autocompletions wasn't requested
+            return
+
+        self._parser = parser
+        self._skip_single_dash = skip_single_dash
+        self._skip_help = skip_help
+        self._comp_words = [w for w in os.environ["COMP_WORDS"].split() if w]
+        self._comp_cword = int(os.environ["COMP_CWORD"])
+        self._main_options, self._plugins_options = self._extract_options()
+
+    @classmethod
+    def is_enabled(cls) -> None:
+        """Check if autocompletion is enabled in the shell"""
+        return (
+            cls.AUTOCOMPLETION_ACTIVATION_ENV in os.environ
+            and "COMP_WORDS" in os.environ
+            and "COMP_CWORD" in os.environ
+        )
+
+    @staticmethod
+    def get_script_template(shell_name):
+        """Return the autocompletion script template for a given shell"""
+
+        script_template = COMPLETION_SCRIPTS.get(shell_name)
+        if not script_template:
+            raise RuntimeError(f"Shell '{shell_name}' not supported for autocompletion")
+
+        activation_script = textwrap.dedent(script_template)
+        activation_script = BASE_COMPLETION.format(
+            script=activation_script, shell=shell_name
+        )
+        return activation_script
+
+    def _extract_options(self):
+        action_groups = self._parser._action_groups
+
+        # Option groups - There are n groups, one per each main option
+        main_actions = action_groups[self.ACTION_GROUP_OPTIONS_INDEX]._group_actions
+        main_options = {}
+        for main_action in main_actions:
+            for option in main_action.option_strings:
+                if self._skip_single_dash and not option.startswith("--"):
+                    continue
+                if self._skip_help and option in ("-h", "--help"):
+                    continue
+
+                main_options.setdefault(option, None)
+                if main_action.choices:
+                    main_options[option] = list(main_action.choices)
+
+        # Plugin group - There is just one group with n parsers, one per each plugin
+        plugin_groups = action_groups[self.ACTION_GROUP_PLUGINS_INDEX]._group_actions
+        plugins_parsers = plugin_groups[0]._name_parser_map
+        # Plugin options are in the same group
+        plugins_options = {}
+        for plugin_name, plugin_parser in plugins_parsers.items():
+            plugins_options.setdefault(plugin_name, {})
+            plugin_actions = plugin_parser._option_string_actions
+            for option_name, plugin_action in plugin_actions.items():
+                if (
+                    self._skip_single_dash
+                    and option_name.startswith("-")
+                    and not option_name.startswith("--")
+                ):
+                    continue
+                if self._skip_help and option_name in ("-h", "--help"):
+                    continue
+
+                plugins_options[plugin_name].setdefault(option_name, [])
+                if plugin_action.choices:
+                    plugins_options[plugin_name][option_name].extend(
+                        plugin_action.choices
+                    )
+
+        return main_options, plugins_options
+
+    def _get_current_plugin(self):
+        # The first word matching a plugin name is the current plugin name
+        for comp_word in self._comp_words[1:]:
+            if comp_word in self._plugins_options:
+                return comp_word
+
+    def _incomplete_argument(self):
+        return self._comp_cword < len(self._comp_words)
+
+    def _autocomplete_dash_option(self):
+        return self._incomplete_argument() and self._comp_words[-1].startswith("-")
+
+    def _in_dash_argument(self):
+        len_comp_words = len(self._comp_words)
+        return not self._autocomplete_dash_option() and (
+            (len_comp_words >= 2 and self._comp_words[-1].startswith("-"))
+            or (len_comp_words >= 3 and self._comp_words[-2].startswith("-"))
+        )
+
+    def _cmdline_context_words(self):
+        current_plugin = self._get_current_plugin()
+        all_options = list(self._main_options) + list(self._plugins_options)
+        if current_plugin:
+            options = self._plugins_options[current_plugin]
+        else:
+            options = self._main_options
+
+        if len(self._comp_words) == 1:
+            # Case: vol <tab>
+            sub_options = all_options
+        elif self._autocomplete_dash_option():
+            # Case: vol -<tab> or vol plugin -<tab>
+            sub_options = options
+        elif self._in_dash_argument():
+            if self._incomplete_argument():
+                # Case: vol --parallelism th<tab>
+                arg = self._comp_words[-2]
+            else:
+                # Case: vol --parallelism <tab>
+                arg = self._comp_words[-1]
+            sub_options = options[arg]
+        elif self._incomplete_argument():
+            # Case: vol linu<tab>
+            sub_options = all_options
+        else:
+            # Case: vol linux.pslist.PsList <tab>
+            sub_options = options
+
+        return list(sub_options)
+
+    def process_commandline(self):
+        """Process the current command line and print the autocompletion tokens"""
+        if not self.is_enabled():
+            return False
+
+        words = self._cmdline_context_words()
+        for word in words:
+            if self._incomplete_argument():
+                if word.startswith(self._comp_words[-1]):
+                    print(word)
+            else:
+                print(word)
+
+        return True

--- a/volatility3/cli/autocompletion.py
+++ b/volatility3/cli/autocompletion.py
@@ -3,7 +3,7 @@
 #
 import os
 import textwrap
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 BASE_COMPLETION = """
 # Volatility3 {shell} completion start{script}# Volatility3 {shell} completion end
@@ -132,11 +132,13 @@ class AutoCompletion(object):
 
         return main_options, plugins_options
 
-    def _get_current_plugin(self) -> str:
+    def _get_current_plugin(self) -> Union[None, str]:
         # The first word matching a plugin name is the current plugin name
         for comp_word in self._comp_words[1:]:
             if comp_word in self._plugins_options:
                 return comp_word
+
+        return None
 
     def _incomplete_argument(self) -> bool:
         return self._comp_cword < len(self._comp_words)


### PR DESCRIPTION
This PR adds command-line autocompletion for both **Bash** and **Fish** shells.

The shell activation scripts are based on the Python PIP scripts [here](https://github.com/pypa/pip/blob/main/src/pip/_internal/commands/completion.py#L14). They did an excellent job unifying the way the various shell scripts call the Python script.

The shell activation scripts require Volatility3 to be installed in a virtual environment or system-wide as it's shown in the examples below. They do not support in-tree or in-place executions, such as running ```./vol.py <tab>``` or ```python ./vol.py <tab>``` directly from the source directory.

# Bash
To enable vol3 autocompletion in the current shell:
```shell
$ eval "$(vol --autocompletion bash)"
```
To make this available in all shell sessions, add the script to the respective user rc scripts:
```shell
$ vol --autocompletion bash >> ~/.bashrc
```
Example:
![bash](https://github.com/user-attachments/assets/c2c91952-e9e0-4876-8e58-d169d255d65f)

# Fish
To enable vol3 autocompletion in the current shell:
```shell
$ eval "$(vol --autocompletion fish)"
```
To make this available in all shell sessions, add the script to the respective user rc scripts:
```shell
$ vol --autocompletion fish >> ~/.config/fish/config.fish
````
It will be even better if you add the script inside the  interactive check `if`.
```shell
if status is-interactive
    # Commands to run in interactive sessions can go here
end
```
Example:
![fish](https://github.com/user-attachments/assets/92be0994-a9b0-40bf-933c-05622775e3a9)

# Other implementation details
### Arguments not included in autocompletion
The help arguments `--help` and the single letter arguments such as `-f` , `-c`, etc are not taken into account as it doesn't make sense to autocomplete them and duplicate the number of options making it less usable. Anyway, these settings are parametrized in the Autocompletion class [here](https://github.com/volatilityfoundation/volatility3/compare/develop...gcmoreira:volatility3:shell_autocompletion?expand=1#diff-99295f86b4b5d7881ea22f7adc38b595b69c7e6e8ad69a729e009d007ee0bd92R42). We can easily change this behavior if required.

### Other shells
It might also be possible to get this Python code working without any modification, just adding the PIP **zsh** and **powershell** activation scripts. However, based on my tests, those scripts weren't working as expected, so those were removed from this effort. I will leave this to someone more familiar with those shells to include the working activation scripts in a future PR.

