### PR TITLE
yara-x support for yarascan

### DIFF
--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         host: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ more details.
 
 ## Requirements
 
-Volatility 3 requires Python 3.7.3 or later. To install the most minimal set of dependencies (some plugins will not work) use a command such as:
+Volatility 3 requires Python 3.8.0 or later. To install the most minimal set of dependencies (some plugins will not work) use a command such as:
 
 ```shell
 pip3 install -r requirements-minimal.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,7 @@ sphinx>=4.0.0,<7
 sphinx_autodoc_typehints>=1.4.0
 sphinx-rtd-theme>=0.4.3
 
+yara-python
 yara-x
 pycryptodome
 pefile

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,6 @@ sphinx>=4.0.0,<7
 sphinx_autodoc_typehints>=1.4.0
 sphinx-rtd-theme>=0.4.3
 
-yara-python
+yara-x
 pycryptodome
 pefile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Volatility Foundation", email = "volatility@volatilityfoundation.org" },
 ]
-requires-python = ">=3.7.3"
+requires-python = ">=3.8.0"
 license = { text = "VSL" }
 dynamic = ["dependencies", "optional-dependencies", "version"]
 

--- a/test/requirements-testing.txt
+++ b/test/requirements-testing.txt
@@ -5,6 +5,7 @@ pefile>=2017.8.1 #foo
 # If certain packages are not necessary, place a comment (#) at the start of the line.
 
 # This is required for the yara plugins
+yara-python>=3.8.0
 yara-x>=0.5.0
 
 pytest>=7.0.0

--- a/test/requirements-testing.txt
+++ b/test/requirements-testing.txt
@@ -5,6 +5,6 @@ pefile>=2017.8.1 #foo
 # If certain packages are not necessary, place a comment (#) at the start of the line.
 
 # This is required for the yara plugins
-yara-python>=3.8.0
+yara-x>=0.5.0
 
 pytest>=7.0.0

--- a/volatility3/framework/__init__.py
+++ b/volatility3/framework/__init__.py
@@ -7,7 +7,7 @@ import glob
 import sys
 import zipfile
 
-required_python_version = (3, 7, 3)
+required_python_version = (3, 8, 0)
 if (
     sys.version_info.major != required_python_version[0]
     or sys.version_info.minor < required_python_version[1]

--- a/volatility3/framework/plugins/linux/vmayarascan.py
+++ b/volatility3/framework/plugins/linux/vmayarascan.py
@@ -31,10 +31,10 @@ class VmaYaraScan(interfaces.plugins.PluginInterface):
                 name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
             ),
             requirements.PluginRequirement(
-                name="yarascan", plugin=yarascan.YaraScan, version=(1, 2, 0)
+                name="yarascan", plugin=yarascan.YaraScan, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="yarascanner", component=yarascan.YaraScanner, version=(2, 0, 0)
+                name="yarascanner", component=yarascan.YaraScanner, version=(2, 1, 0)
             ),
             requirements.ModuleRequirement(
                 name="kernel",

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -29,7 +29,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="yarascanner", component=yarascan.YaraScanner, version=(2, 0, 0)
+                name="yarascanner", component=yarascan.YaraScanner, version=(2, 1, 0)
             ),
         ]
 
@@ -38,7 +38,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
         # Yara Rule to scan for MFT Header Signatures
         rules = yarascan.YaraScan.process_yara_options(
-            {"yara_rules": "/FILE0|FILE\\*|BAAD/"}
+            {"yara_string": "/FILE0|FILE\\*|BAAD/"}
         )
 
         # Read in the Symbol File
@@ -197,7 +197,7 @@ class ADS(interfaces.plugins.PluginInterface):
 
         # Yara Rule to scan for MFT Header Signatures
         rules = yarascan.YaraScan.process_yara_options(
-            {"yara_rules": "/FILE0|FILE\\*|BAAD/"}
+            {"yara_string": "/FILE0|FILE\\*|BAAD/"}
         )
 
         # Read in the Symbol File

--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -73,8 +73,9 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
                     )
                     continue
 
+                data = layer.read(start, size, True)
                 if not yarascan.YaraScan._yara_x:
-                    for match in rules.match(data=layer.read(start, size, True)):
+                    for match in rules.match(data=data):
                         if yarascan.YaraScan.yara_returns_instances():
                             for match_string in match.strings:
                                 for instance in match_string.instances:
@@ -95,9 +96,7 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
                                     value,
                                 )
                 else:
-                    data = layer.read(start, size, True)
-                    results = rules.scan(data)
-                    for match in results.matching_rules:
+                    for match in rules.scan(data).matching_rules:
                         for match_string in match.patterns:
                             for instance in match_string.matches:
                                 yield 0, (

--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -171,6 +171,8 @@ class YaraScan(plugins.PluginInterface):
                 description="Yara rules (as a file)",
                 optional=True,
             ),
+            # This additional requirement is to follow suit with upstream, who feel that compiled rules could potentially be used to execute malicious code
+            # As such, there's a separate option to run compiled files, as happened with yara-3.9 and later
             requirements.URIRequirement(
                 name="yara_compiled_file",
                 description="Yara compiled rules (as a file)",

--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -204,11 +204,11 @@ class YaraScan(plugins.PluginInterface):
                 rule += " wide ascii"
             rules = YaraScanner.get_rule(rule)
         elif config.get("yara_file") is not None:
-            vollog.debug(f"Plain file: {config["yara_file"]} - yara-x: {USE_YARA_X}")
+            vollog.debug(f"Plain file: {config['yara_file']} - yara-x: {USE_YARA_X}")
             rules = YaraScanner.from_file(config["yara_file"])
         elif config.get("yara_compiled_file") is not None:
             vollog.debug(
-                f"Compiled file: {config["yara_compiled_file"]} - yara-x: {USE_YARA_X}"
+                f"Compiled file: {config['yara_compiled_file']} - yara-x: {USE_YARA_X}"
             )
             rules = YaraScanner.from_compiled_file(config["yara_compiled_file"])
         else:


### PR DESCRIPTION
This pull adds support for [yara-x ](https://virustotal.github.io/yara-x/) library.
If the library is not available it still uses yara-python library as before.

Changes:
- yara-file parameters is now yara_string
- yara_compiled_file is used also for yara-x even if in this case it's a [serialized file](https://github.com/VirusTotal/yara-x/blob/d064e427ad4f3a0f01cf4778d03d3b253727516f/py/src/lib.rs#L466) and not the old compiled 

Question:
- Not sure how to manage requirements, at the moment I've added both deps in them.
- It could be useful to have an env variable to override yara-x default?