### PR TITLE
Windows: update handles plugin sar warnings to use DEFAULT_SAR_VALUE var

### DIFF
--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -177,7 +177,7 @@ class Handles(interfaces.plugins.PluginInterface):
                 )
             except exceptions.InvalidAddressException:
                 vollog.warning(
-                    f"Failed to read {hex(num_bytes_to_read)} bytes at symbol {hex(func_addr_to_read)}. Unable to decode SAR value. Failing back to a common value of {hex(DEFAULT_SAR_VALUE)}}"
+                    f"Failed to read {hex(num_bytes_to_read)} bytes at symbol {hex(func_addr_to_read)}. Unable to decode SAR value. Failing back to a common value of {hex(DEFAULT_SAR_VALUE)}"
                 )
                 self._sar_value = DEFAULT_SAR_VALUE
                 return self._sar_value

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -177,7 +177,7 @@ class Handles(interfaces.plugins.PluginInterface):
                 )
             except exceptions.InvalidAddressException:
                 vollog.warning(
-                    f"Failed to read {hex(num_bytes_to_read)} bytes at symbol {hex(func_addr_to_read)}. Unable to decode SAR value. Failing back to a common value of 0x10"
+                    f"Failed to read {hex(num_bytes_to_read)} bytes at symbol {hex(func_addr_to_read)}. Unable to decode SAR value. Failing back to a common value of {hex(DEFAULT_SAR_VALUE)}}"
                 )
                 self._sar_value = DEFAULT_SAR_VALUE
                 return self._sar_value
@@ -201,7 +201,7 @@ class Handles(interfaces.plugins.PluginInterface):
 
             if self._sar_value is None:
                 vollog.warning(
-                    f"Failed to to locate SAR value having parsed {instruction_count} instructions, failing back to a common value of 0x10"
+                    f"Failed to to locate SAR value having parsed {instruction_count} instructions, failing back to a common value of {hex(DEFAULT_SAR_VALUE)}"
                 )
                 self._sar_value = DEFAULT_SAR_VALUE
 


### PR DESCRIPTION
Hello 👋 

I'm very sorry but I missed something from the previous PR https://github.com/volatilityfoundation/volatility3/pull/1214

The warnings don't use the variable DEFAULT_SAR_VALUE when they should. If it's changed in the future the warnings would become out of sync and this could cause some confusion. 

🦊 