### PR TITLE
Renderers time conversion fixes

### DIFF
--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -105,7 +105,9 @@ class Timeliner(interfaces.plugins.PluginInterface):
         data = item[1]
 
         def sortable(timestamp):
-            max_date = datetime.datetime(day=1, month=12, year=datetime.MAXYEAR)
+            max_date = datetime.datetime(
+                day=1, month=12, year=datetime.MAXYEAR, tzinfo=datetime.timezone.utc
+            )
             if isinstance(timestamp, interfaces.renderers.BaseAbsentValue):
                 return max_date
             return timestamp

--- a/volatility3/framework/renderers/conversion.py
+++ b/volatility3/framework/renderers/conversion.py
@@ -19,7 +19,7 @@ def wintime_to_datetime(
         return renderers.NotApplicableValue()
     unix_time = unix_time - 11644473600
     try:
-        return datetime.datetime.utcfromtimestamp(unix_time)
+        return datetime.datetime.fromtimestamp(unix_time, datetime.timezone.utc)
         # Windows sometimes throws OSErrors rather than ValueErrors when it can't convert a value
     except (ValueError, OSError):
         return renderers.UnparsableValue()
@@ -34,7 +34,7 @@ def unixtime_to_datetime(
 
     if unixtime > 0:
         with contextlib.suppress(ValueError):
-            ret = datetime.datetime.utcfromtimestamp(unixtime)
+            ret = datetime.datetime.fromtimestamp(unixtime, datetime.timezone.utc)
 
     return ret
 

--- a/volatility3/framework/renderers/conversion.py
+++ b/volatility3/framework/renderers/conversion.py
@@ -20,8 +20,8 @@ def wintime_to_datetime(
     unix_time = unix_time - 11644473600
     try:
         return datetime.datetime.fromtimestamp(unix_time, datetime.timezone.utc)
-        # Windows sometimes throws OSErrors rather than ValueErrors when it can't convert a value
-    except (ValueError, OSError):
+        # Windows sometimes throws OSErrors rather than OverflowError when it can't convert a value
+    except (OverflowError, OSError):
         return renderers.UnparsableValue()
 
 
@@ -33,7 +33,7 @@ def unixtime_to_datetime(
     )
 
     if unixtime > 0:
-        with contextlib.suppress(ValueError):
+        with contextlib.suppress(OverflowError):
             ret = datetime.datetime.fromtimestamp(unixtime, datetime.timezone.utc)
 
     return ret

--- a/volatility3/framework/renderers/conversion.py
+++ b/volatility3/framework/renderers/conversion.py
@@ -20,8 +20,10 @@ def wintime_to_datetime(
     unix_time = unix_time - 11644473600
     try:
         return datetime.datetime.fromtimestamp(unix_time, datetime.timezone.utc)
-        # Windows sometimes throws OSErrors rather than OverflowError when it can't convert a value
-    except (OverflowError, OSError):
+        # Windows sometimes throws OSErrors rather than ValueError/OverflowError when it can't convert a value
+        # Since Python 3.3, this should raise OverflowError instead of ValueError. However, it was observed
+        # that even in Python 3.7.17, ValueError is still being raised.
+    except (ValueError, OverflowError, OSError):
         return renderers.UnparsableValue()
 
 
@@ -33,7 +35,9 @@ def unixtime_to_datetime(
     )
 
     if unixtime > 0:
-        with contextlib.suppress(OverflowError):
+        # Since Python 3.3, this should raise OverflowError instead of ValueError. However, it was observed
+        # that even in Python 3.7.17, ValueError is still being raised. OSError is also raised on Linux
+        with contextlib.suppress(ValueError, OverflowError, OSError):
             ret = datetime.datetime.fromtimestamp(unixtime, datetime.timezone.utc)
 
     return ret


### PR DESCRIPTION
In the context of [volatilityfoundation/volatility3!1213](https://github.com/volatilityfoundation/volatility3/pull/1213) a few issues with time conversion in the framework were identified.

## Aware datetimes
See warning note on https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp:

> Because naive datetime objects are treated by many datetime methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing a specific timestamp in UTC is by calling datetime.fromtimestamp(timestamp, tz=timezone.utc).


Additionaly, `datetime.utcfromtimestamp()` is deprecated since 3.12

## Wrong exceptions

Since version 3.3 **utcfromtimestamp()** and **fromtimestamp()** Python **datetime** module raises `OverflowError` instead of `ValueError`. As of today, Volatility3 requires Python 3.7.3 so we should only include `OverflowError`
