### PR TITLE
Windows: Fixes bad structure member in callbacks

### DIFF
--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -35,7 +35,7 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 name="netscan", component=netscan.NetScan, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="modules", component=modules.Modules, version=(1, 0, 0)
+                name="modules", component=modules.Modules, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="pdbutil", component=pdbutil.PDBUtility, version=(1, 0, 0)

--- a/volatility3/framework/symbols/windows/callbacks-x64.json
+++ b/volatility3/framework/symbols/windows/callbacks-x64.json
@@ -105,8 +105,11 @@
                 },
                 "NotificationRoutine": {
                     "type": {
-                        "kind": "base",
-                        "name": "unsigned int"
+                        "kind": "pointer",
+                        "subtype": {
+                            "kind": "base",
+                            "name": "void"
+                        }
                     },
                     "offset": 24
                 }


### PR DESCRIPTION
This fixes a bug in the x64 callbacks symbols. The `NotificationRoutine`
is currently an `unsigned int` instead of a void pointer. This prevents
the correct mapping of the notification routine to the kernel module
that contains it.

Also bumps the version number for the netstat plugin's `modules`
requirement - it didn't get updated after #1173 was merged.