### PR TITLE
Linux Page Cache and IDR

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Clean up post-test
       run: |
-        rm -rf *.lime
+        rm -rf *.bin
         rm -rf *.img
         cd volatility3/symbols
         rm -rf linux

--- a/volatility3/framework/plugins/linux/ebpf.py
+++ b/volatility3/framework/plugins/linux/ebpf.py
@@ -1,0 +1,78 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+import binascii
+import logging
+from typing import List
+
+from volatility3.framework import renderers, interfaces, exceptions
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.configuration import requirements
+
+vollog = logging.getLogger(__name__)
+
+
+class EBPF(plugins.PluginInterface):
+    """Enumerate eBPF programs"""
+
+    _required_framework_version = (2, 0, 0)
+
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Linux kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+        ]
+
+    def get_ebpf_programs(self, vmlinux) -> interfaces.objects.ObjectInterface:
+        """Enumerate eBPF programs walking its IDR.
+
+        Args:
+            vmlinux: The kernel symbols object
+
+        Yields:
+            eBPF program objects
+        """
+        if not vmlinux.has_symbol("prog_idr"):
+            raise exceptions.VolatilityException(
+                "Cannot find the eBPF prog idr. Unsupported kernel"
+            )
+
+        prog_idr_addr = vmlinux.get_symbol("prog_idr").address
+        prog_idr = vmlinux.object("idr", offset=prog_idr_addr)
+        for page_addr in prog_idr.get_page_addresses():
+            bpf_prog = vmlinux.object("bpf_prog", offset=page_addr, absolute=True)
+            yield bpf_prog
+
+    def _generator(self):
+        vmlinux = self.context.modules[self.config["kernel"]]
+        vmlinux_layer = vmlinux.context.layers[vmlinux.layer_name]
+        bpf_prog_types = vmlinux.get_enumeration("bpf_prog_type")
+        for prog in self.get_ebpf_programs(vmlinux):
+            prog_addr = prog.vol.offset
+            prog_type = bpf_prog_types.lookup(prog.type)
+            prog_tag_addr = prog.tag.vol.offset
+            prog_tag_size = prog.tag.count
+            prog_tag_bytes = vmlinux_layer.read(prog_tag_addr, prog_tag_size)
+            prog_tag = binascii.hexlify(prog_tag_bytes).decode()
+            prog_name = (
+                utility.array_to_string(prog.aux.name) or renderers.NotAvailableValue()
+            )
+            fields = (format_hints.Hex(prog_addr), prog_name, prog_tag, prog_type)
+            yield (0, fields)
+
+    def run(self):
+        headers = [
+            ("Address", format_hints.Hex),
+            ("Name", str),
+            ("Tag", str),
+            ("Type", str),
+        ]
+        return renderers.TreeGrid(headers, self._generator())

--- a/volatility3/framework/plugins/linux/ebpf.py
+++ b/volatility3/framework/plugins/linux/ebpf.py
@@ -44,7 +44,7 @@ class EBPF(plugins.PluginInterface):
             )
 
         prog_idr = vmlinux.object_from_symbol("prog_idr")
-        for page_addr in prog_idr.get_page_addresses():
+        for page_addr in prog_idr.get_entries():
             bpf_prog = vmlinux.object("bpf_prog", offset=page_addr, absolute=True)
             yield bpf_prog
 

--- a/volatility3/framework/plugins/linux/ebpf.py
+++ b/volatility3/framework/plugins/linux/ebpf.py
@@ -43,8 +43,7 @@ class EBPF(plugins.PluginInterface):
                 "Cannot find the eBPF prog idr. Unsupported kernel"
             )
 
-        prog_idr_addr = vmlinux.get_symbol("prog_idr").address
-        prog_idr = vmlinux.object("idr", offset=prog_idr_addr)
+        prog_idr = vmlinux.object_from_symbol("prog_idr")
         for page_addr in prog_idr.get_page_addresses():
             bpf_prog = vmlinux.object("bpf_prog", offset=page_addr, absolute=True)
             yield bpf_prog

--- a/volatility3/framework/plugins/linux/mountinfo.py
+++ b/volatility3/framework/plugins/linux/mountinfo.py
@@ -254,10 +254,7 @@ class MountInfo(plugins.PluginInterface):
             super_block: Kernel's struct super_block object
         """
         # No filter so that we get all the mount namespaces from all tasks
-        pid_filter = pslist.PsList.create_pid_filter()
-        tasks = pslist.PsList.list_tasks(
-            self.context, self.config["kernel"], filter_func=pid_filter
-        )
+        tasks = pslist.PsList.list_tasks(self.context, self.config["kernel"])
 
         seen_sb_ptr = set()
         for task, mnt, _mnt_ns_id in self._get_tasks_mountpoints(tasks):

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -486,7 +486,7 @@ class InodePages(plugins.PluginInterface):
             page_index = int(page_obj.index)
             page_file_offset = page_index * vmlinux_layer.page_size
             dump_safe = page_file_offset < inode_size
-            page_flags_list = page_obj.get_flags()
+            page_flags_list = page_obj.get_flags_list()
             page_flags = ",".join([x.replace("PG_", "") for x in page_flags_list])
             fields = (
                 page_vaddr,

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -131,7 +131,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
         ]
 
     @staticmethod
-    def _follow_symlink(inode, symlink_path) -> str:
+    def _follow_symlink(
+        inode: interfaces.objects.ObjectInterface,
+        symlink_path: str,
+    ) -> str:
         """Follows (fast) symlinks (kernels >= 4.2.x).
         Fast symlinks are filesystem agnostic.
 

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -1,0 +1,504 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import math
+import logging
+import datetime
+from dataclasses import dataclass, astuple
+from typing import List
+
+from volatility3.framework import renderers, interfaces
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.configuration import requirements
+from volatility3.plugins import timeliner
+from volatility3.plugins.linux import mountinfo
+
+vollog = logging.getLogger(__name__)
+
+
+@dataclass
+class InodeUser:
+    """Inode user representation, featuring augmented information and formatted fields.
+    This is the data the plugin will eventually display.
+    """
+
+    superblock_addr: int
+    mountpoint: str
+    device: str
+    inode_num: int
+    inode_addr: int
+    type: str
+    inode_pages: int
+    cached_pages: int
+    file_mode: str
+    access_time: str
+    modification_time: str
+    change_time: str
+    path: str
+
+
+@dataclass
+class InodeInternal:
+    """Inode internal representation containing only the core objects
+
+    Fields:
+        superblock: 'super_block' struct
+        mountpoint: Superblock mountpoint path
+        inode: 'inode' struct
+        path: Dentry full path
+    """
+
+    superblock: interfaces.objects.ObjectInterface
+    mountpoint: str
+    inode: interfaces.objects.ObjectInterface
+    path: str
+
+    def to_user(
+        self, kernel_layer: interfaces.layers.TranslationLayerInterface
+    ) -> InodeUser:
+        """Augment the inode information to be presented to the user
+
+        Args:
+            kernel_layer: The kernel layer to obtain the page size
+
+        Returns:
+            An InodeUser dataclass
+        """
+        # Ensure all types are atomic immutable. Otherwise, astuple() will take a long
+        # time doing a deepcopy of the Volatility objects.
+        superblock_addr = self.superblock.vol.offset
+        device = f"{self.superblock.major}:{self.superblock.minor}"
+        inode_num = int(self.inode.i_ino)
+        inode_addr = self.inode.vol.offset
+        inode_type = renderers.UnparsableValue()
+        # Round up the number of pages to fit the inode's size
+        inode_pages = int(math.ceil(self.inode.i_size / float(kernel_layer.page_size)))
+        cached_pages = int(self.inode.i_mapping.nrpages)
+        file_mode = self.inode.get_file_mode()
+        access_time_dt = self.inode.get_access_time()
+        modification_time_str = self.inode.get_modification_time()
+        change_time_str = self.inode.get_change_time()
+
+        inode_user = InodeUser(
+            superblock_addr=superblock_addr,
+            mountpoint=self.mountpoint,
+            device=device,
+            inode_num=inode_num,
+            inode_addr=inode_addr,
+            type=inode_type,
+            inode_pages=inode_pages,
+            cached_pages=cached_pages,
+            file_mode=file_mode,
+            access_time=access_time_dt,
+            modification_time=modification_time_str,
+            change_time=change_time_str,
+            path=self.path,
+        )
+        return inode_user
+
+
+class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
+    """Lists files from memory"""
+
+    _required_framework_version = (2, 0, 0)
+
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Linux kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.PluginRequirement(
+                name="mountinfo", plugin=mountinfo.MountInfo, version=(1, 1, 0)
+            ),
+            requirements.ListRequirement(
+                name="type",
+                description="List of space-separated file type filters i.e. --type REG DIR",
+                element_type=str,
+                optional=True,
+            ),
+            requirements.StringRequirement(
+                name="find",
+                description="Filename (full path) to find",
+                optional=True,
+            ),
+        ]
+
+    @staticmethod
+    def _follow_symlink(inode, symlink_path) -> str:
+        """Follows (fast) symlinks (kernels >= 4.2.x).
+        Fast symlinks are filesystem agnostic.
+
+        Args:
+            inode: The inode (or pointer) to dump
+            symlink_path: The symlink name
+
+        Returns:
+            If it can resolve the symlink, it returns a string "symlink_path -> target_path"
+            Otherwise, it returns the same symlink_path
+        """
+        # i_link (fast symlinks) were introduced in 4.2
+        if inode and inode.is_link and inode.has_member("i_link") and inode.i_link:
+            i_link_str = inode.i_link.dereference().cast(
+                "string", max_length=255, encoding="utf-8", errors="replace"
+            )
+            symlink_path = f"{symlink_path} -> {i_link_str}"
+
+        return symlink_path
+
+    @classmethod
+    def _walk_dentry(cls, seen_dentries, root_dentry, parent):
+
+        for dentry in root_dentry.get_subdirs():
+            dentry_addr = dentry.vol.offset
+
+            # corruption
+            if dentry_addr == root_dentry.vol.offset:
+                continue
+
+            if dentry_addr in seen_dentries:
+                continue
+
+            seen_dentries.add(dentry_addr)
+
+            inode = dentry.d_inode
+            if not (inode and inode.is_valid()):
+                continue
+
+            # This allows us to have consistent paths
+            if dentry.d_name.name:
+                name = dentry.d_name.name_as_str()
+                # Do NOT use os.path.join() below
+                new_file = parent + "/" + name
+            else:
+                continue
+
+            yield new_file, dentry, dentry.d_parent.vol.offset
+
+            if inode.is_dir:
+                for new_file, dentry, parent_address in cls._walk_dentry(
+                    seen_dentries, dentry, new_file
+                ):
+                    yield new_file, dentry, parent_address
+
+    @classmethod
+    def get_inodes(
+        cls,
+        context: interfaces.context.ContextInterface,
+        config_path: str,
+    ):
+        """Retrieves the inodes from the superblocks
+
+        Args:
+            context: The context that the plugin will operate within
+            config_path: The path to configuration data within the context configuration data
+
+        Yields:
+            An InodeInternal object
+        """
+
+        superblocks_iter = mountinfo.MountInfo(
+            context=context,
+            config_path=config_path,
+        ).get_superblocks()
+
+        seen_inodes = set()
+        seen_dentries = set()
+        for superblock, mountpoint in superblocks_iter:
+            parent = "" if mountpoint == "/" else mountpoint
+
+            # Superblock root dentry
+            root_dentry = superblock.s_root
+            if not root_dentry:
+                continue
+
+            # Dentry sanity check
+            if not root_dentry.is_root():
+                continue
+
+            # More dentry/inode sanity checks
+            root_inode_ptr = root_dentry.d_inode
+            if not root_inode_ptr:
+                continue
+            root_inode = root_inode_ptr.dereference()
+            if not root_inode.is_valid():
+                continue
+
+            # Inode already processed?
+            if root_inode_ptr in seen_inodes:
+                continue
+            seen_inodes.add(root_inode_ptr)
+
+            root_path = mountpoint
+
+            inode_in = InodeInternal(
+                superblock=superblock,
+                mountpoint=mountpoint,
+                inode=root_inode,
+                path=root_path,
+            )
+            yield inode_in
+
+            # Children
+            for file_path, file_dentry, _ in cls._walk_dentry(
+                seen_dentries, root_dentry, parent
+            ):
+                if not file_dentry:
+                    continue
+                # Dentry/inode sanity checks
+                file_inode_ptr = file_dentry.d_inode
+                if not file_inode_ptr:
+                    continue
+                file_inode = file_inode_ptr.dereference()
+                if not file_inode.is_valid():
+                    continue
+
+                # Inode already processed?
+                if file_inode_ptr in seen_inodes:
+                    continue
+                seen_inodes.add(file_inode_ptr)
+
+                file_path = cls._follow_symlink(file_inode_ptr, file_path)
+                inode_in = InodeInternal(
+                    superblock=superblock,
+                    mountpoint=mountpoint,
+                    inode=file_inode,
+                    path=file_path,
+                )
+                yield inode_in
+
+    def _generator(self):
+        vmlinux = self.context.modules[self.config["kernel"]]
+        vmlinux_layer = self.context.layers[vmlinux.layer_name]
+
+        inodes_iter = self.get_inodes(
+            context=self.context, config_path=self.config_path
+        )
+
+        types_filter = self.config["type"]
+        for inode_in in inodes_iter:
+            if types_filter and inode_in.inode.get_inode_type() not in types_filter:
+                continue
+
+            if self.config["find"]:
+                if inode_in.path == self.config["find"]:
+                    inode_out = inode_in.to_user(vmlinux_layer)
+                    yield (0, astuple(inode_out))
+                    break  # Only the first match
+            else:
+                inode_out = inode_in.to_user(vmlinux_layer)
+                yield (0, astuple(inode_out))
+
+    def generate_timeline(self):
+        """Generates tuples of (description, timestamp_type, timestamp)
+
+        These need not be generated in any particular order, sorting
+        will be done later
+        """
+        vmlinux = self.context.modules[self.config["kernel"]]
+        vmlinux_layer = self.context.layers[vmlinux.layer_name]
+
+        inodes_iter = self.get_inodes(
+            context=self.context, config_path=self.config_path
+        )
+        for inode_in in inodes_iter:
+            inode_out = inode_in.to_user(vmlinux_layer)
+            description = f"Cached Inode for {inode_out.path}"
+            yield description, timeliner.TimeLinerType.ACCESSED, inode_out.access_time
+            yield description, timeliner.TimeLinerType.MODIFIED, inode_out.modification_time
+            yield description, timeliner.TimeLinerType.CHANGE, inode_out.change_time
+
+    @staticmethod
+    def format_fields_with_headers(headers, generator):
+        """Uses the headers type to cast the fields obtained from the generator"""
+        for level, fields in generator:
+            formatted_fields = []
+            for header, field in zip(headers, fields):
+                header_type = header[1]
+
+                if isinstance(
+                    field, (header_type, interfaces.renderers.BaseAbsentValue)
+                ):
+                    formatted_field = field
+                else:
+                    formatted_field = header_type(field)
+
+                formatted_fields.append(formatted_field)
+            yield level, formatted_fields
+
+    def run(self):
+        headers = [
+            ("SuperblockAddr", format_hints.Hex),
+            ("MountPoint", str),
+            ("Device", str),
+            ("InodeNum", int),
+            ("InodeAddr", format_hints.Hex),
+            ("FileType", str),
+            ("InodePages", int),
+            ("CachedPages", int),
+            ("FileMode", str),
+            ("AccessTime", datetime.datetime),
+            ("ModificationTime", datetime.datetime),
+            ("ChangeTime", datetime.datetime),
+            ("FilePath", str),
+        ]
+
+        return renderers.TreeGrid(
+            headers, self.format_fields_with_headers(headers, self._generator())
+        )
+
+
+class InodePages(plugins.PluginInterface):
+    """Lists and recovers cached inode pages"""
+
+    _required_framework_version = (2, 0, 0)
+
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Linux kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.PluginRequirement(
+                name="files", plugin=Files, version=(1, 0, 0)
+            ),
+            requirements.StringRequirement(
+                name="find",
+                description="Filename (full path) to find ",
+                optional=True,
+            ),
+            requirements.IntRequirement(
+                name="inode",
+                description="Inode address",
+                optional=True,
+            ),
+            requirements.StringRequirement(
+                name="dump",
+                description="Output file path",
+                optional=True,
+            ),
+        ]
+
+    @staticmethod
+    def write_inode_content_to_file(
+        inode: interfaces.objects.ObjectInterface,
+        filename: str,
+        vmlinux_layer: interfaces.layers.TranslationLayerInterface,
+    ) -> None:
+        """Extracts the inode's contents from the page cache and saves them to a file
+
+        Args:
+            inode: The inode to dump
+            filename: Filename for writing the inode content
+            vmlinux_layer: The kernel layer to obtain the page size
+        """
+        if not inode.is_reg:
+            vollog.error("The inode is not a regular file")
+            return
+
+        # By using truncate/seek, provided the filesystem supports it, a sparse file will be
+        # created, saving both disk space and I/O time.
+        # Additionally, using the page index will guarantee that each page is written at the
+        # appropriate file position.
+        try:
+            with open(filename, "wb") as f:
+                inode_size = inode.i_size
+                f.truncate(inode_size)
+
+                for page_idx, page_content in inode.get_contents():
+                    current_fp = page_idx * vmlinux_layer.page_size
+                    max_length = inode_size - current_fp
+                    page_bytes = page_content[:max_length]
+                    if current_fp + len(page_bytes) > inode_size:
+                        vollog.error(
+                            "Page out of file bounds: inode 0x%x, inode size %d, page index %d",
+                            inode.vol.object,
+                            inode_size,
+                            page_idx,
+                        )
+                    f.seek(current_fp)
+                    f.write(page_bytes)
+
+        except IOError as e:
+            vollog.error("Unable to write to file (%s): %s", filename, e)
+
+    def _generator(self):
+        vmlinux = self.context.modules[self.config["kernel"]]
+        vmlinux_layer = self.context.layers[vmlinux.layer_name]
+
+        if self.config["inode"] and self.config["find"]:
+            vollog.error("Cannot use --inode and --find simultaneously")
+            return
+
+        if self.config["find"]:
+            inodes_iter = Files.get_inodes(
+                context=self.context, config_path=self.config_path
+            )
+            for inode_in in inodes_iter:
+                if inode_in.path == self.config["find"]:
+                    inode = inode_in.inode
+                    break  # Only the first match
+
+        elif self.config["inode"]:
+            inode = vmlinux.object("inode", self.config["inode"], absolute=True)
+        else:
+            vollog.error("You must use either --inode or --find")
+            return
+
+        if not inode.is_reg:
+            vollog.error("The inode is not a regular file")
+            return
+
+        inode_size = inode.i_size
+        if not inode.is_valid():
+            vollog.error("Invalid inode at 0x%x", self.config["inode"])
+            return
+
+        for page_obj in inode.get_pages():
+            page_vaddr = page_obj.vol.offset
+            page_paddr = page_obj.to_paddr()
+            page_mapping_addr = page_obj.mapping
+            page_index = int(page_obj.index)
+            page_file_offset = page_index * vmlinux_layer.page_size
+            dump_safe = page_file_offset < inode_size
+            page_flags_list = page_obj.get_flags()
+            page_flags = ",".join([x.replace("PG_", "") for x in page_flags_list])
+            fields = (
+                page_vaddr,
+                page_paddr,
+                page_mapping_addr,
+                page_index,
+                dump_safe,
+                page_flags,
+            )
+
+            yield 0, fields
+
+        if self.config["dump"]:
+            filename = self.config["dump"]
+            vollog.info("[*] Writing inode at 0x%x to '%s'", inode.vol.offset, filename)
+            self.write_inode_content_to_file(inode, filename, vmlinux_layer)
+
+    def run(self):
+        headers = [
+            ("PageVAddr", format_hints.Hex),
+            ("PagePAddr", format_hints.Hex),
+            ("MappingAddr", format_hints.Hex),
+            ("Index", int),
+            ("DumpSafe", bool),
+            ("Flags", str),
+        ]
+
+        return renderers.TreeGrid(
+            headers, Files.format_fields_with_headers(headers, self._generator())
+        )

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -72,7 +72,7 @@ class InodeInternal:
         device = f"{self.superblock.major}:{self.superblock.minor}"
         inode_num = int(self.inode.i_ino)
         inode_addr = self.inode.vol.offset
-        inode_type = renderers.UnparsableValue()
+        inode_type = self.inode.get_inode_type() or renderers.UnparsableValue()
         # Round up the number of pages to fit the inode's size
         inode_pages = int(math.ceil(self.inode.i_size / float(kernel_layer.page_size)))
         cached_pages = int(self.inode.i_mapping.nrpages)

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -6,7 +6,7 @@ import math
 import logging
 import datetime
 from dataclasses import dataclass, astuple
-from typing import List, Set, Type
+from typing import List, Set, Type, Iterable
 
 from volatility3.framework import renderers, interfaces
 from volatility3.framework.renderers import format_hints
@@ -205,7 +205,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
         cls,
         context: interfaces.context.ContextInterface,
         config_path: str,
-    ):
+    ) -> Iterable[InodeInternal]:
         """Retrieves the inodes from the superblocks
 
         Args:

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -159,7 +159,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
         root_dentry: interfaces.objects.ObjectInterface,
         parent_dir: str,
     ):
-        """Walk dentries recursively
+        """Walks dentries recursively
 
         Args:
             seen_dentries: A set to ensure each dentry is processed only once

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -191,7 +191,7 @@ class PIDHashTable(plugins.PluginInterface):
             "numbers"
         )  # kernels >= 2.6.24
 
-        has_pid_numbers = self.vmlinux.has_type("upid") and self.vmlinux.get_type(
+        has_pid_chain = self.vmlinux.has_type("upid") and self.vmlinux.get_type(
             "upid"
         ).has_member(
             "pid_chain"
@@ -205,7 +205,7 @@ class PIDHashTable(plugins.PluginInterface):
         if pid_idr:
             # kernels >= 4.15
             return self._pid_namespace_idr
-        elif pid_hash and has_pid_numbers and has_pid_numbers:
+        elif pid_hash and has_pid_numbers and has_pid_numbers and has_pid_chain:
             # 2.6.24 <= kernels < 4.15
             return self._pid_hash_implementation
 

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -1,0 +1,249 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List
+
+from volatility3.framework import renderers, interfaces, constants
+from volatility3.framework.symbols import linux
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.configuration import requirements
+from volatility3.plugins.linux import pslist
+
+vollog = logging.getLogger(__name__)
+
+
+class PIDHashTable(plugins.PluginInterface):
+    """Enumerates processes through the PID hash table"""
+
+    _required_framework_version = (2, 0, 0)
+
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Linux kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="linuxutils", component=linux.LinuxUtilities, version=(2, 2, 0)
+            ),
+            requirements.BooleanRequirement(
+                name="decorate_comm",
+                description="Show `user threads` comm in curly brackets, and `kernel threads` comm in square brackets",
+                optional=True,
+                default=False,
+            ),
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.vmlinux = None
+        self.vmlinux_layer = None
+
+    def _is_valid_task(self, task):
+        return task and task.pid > 0 and self.vmlinux_layer.is_valid(task.parent)
+
+    def _get_pidtype_pid(self):
+        # The pid_type enumeration is present since 2.5.37, just in case
+        pid_type_enum = self.vmlinux.get_enumeration("pid_type")
+        if not pid_type_enum:
+            vollog.error("Cannot find pid_type enum. Unsupported kernel")
+            return
+
+        pidtype_pid = pid_type_enum.choices.get("PIDTYPE_PID")
+        if pidtype_pid is None:
+            vollog.error("Cannot find PIDTYPE_PID. Unsupported kernel")
+            return
+
+        # Typically PIDTYPE_PID = 0
+        return pidtype_pid
+
+    def _get_pidhash_array(self):
+        pidhash_shift = self.vmlinux.object_from_symbol("pidhash_shift")
+        pidhash_size = 1 << pidhash_shift
+
+        array_type_name = self.vmlinux.symbol_table_name + constants.BANG + "array"
+
+        pidhash_ptr = self.vmlinux.object_from_symbol("pid_hash")
+        # pidhash is an array of hlist_heads
+        pidhash = self._context.object(
+            array_type_name,
+            offset=pidhash_ptr,
+            subtype=self.vmlinux.get_type("hlist_head"),
+            count=pidhash_size,
+            layer_name=self.vmlinux.layer_name,
+        )
+
+        return pidhash
+
+    def _walk_upid(self, seen_upids, upid):
+        while upid and self.vmlinux_layer.is_valid(upid.vol.offset):
+            if upid.vol.offset in seen_upids:
+                break
+            seen_upids.add(upid.vol.offset)
+
+            pid_chain = upid.pid_chain
+            if not (pid_chain and self.vmlinux_layer.is_valid(pid_chain.vol.offset)):
+                break
+
+            upid = linux.LinuxUtilities.container_of(
+                pid_chain.next, "upid", "pid_chain", self.vmlinux
+            )
+
+    def _get_upids(self):
+        # 2.6.24 <= kernels < 4.15
+        pidhash = self._get_pidhash_array()
+
+        seen_upids = set()
+        for hlist in pidhash:
+            # each entry in the hlist is a upid which is wrapped in a pid
+            ent = hlist.first
+
+            while ent and self.vmlinux_layer.is_valid(ent.vol.offset):
+                # upid->pid_chain exists 2.6.24 <= kernel < 4.15
+                upid = linux.LinuxUtilities.container_of(
+                    ent.vol.offset, "upid", "pid_chain", self.vmlinux
+                )
+
+                if upid.vol.offset in seen_upids:
+                    break
+
+                self._walk_upid(seen_upids, upid)
+
+                ent = ent.next
+
+        return seen_upids
+
+    def _pid_hash_implementation(self):
+        # 2.6.24 <= kernels < 4.15
+        task_pids_off = self.vmlinux.get_type("task_struct").relative_child_offset(
+            "pids"
+        )
+        pidtype_pid = self._get_pidtype_pid()
+
+        for upid in self._get_upids():
+            pid = linux.LinuxUtilities.container_of(
+                upid, "pid", "numbers", self.vmlinux
+            )
+            if not pid:
+                continue
+
+            pid_tasks_0 = pid.tasks[pidtype_pid].first
+            if not pid_tasks_0:
+                continue
+
+            task = self.vmlinux.object(
+                "task_struct", offset=pid_tasks_0 - task_pids_off, absolute=True
+            )
+            if self._is_valid_task(task):
+                yield task
+
+    def _task_for_radix_pid_node(self, nodep):
+        # kernels >= 4.15
+        pid = self.vmlinux.object("pid", offset=nodep, absolute=True)
+        pidtype_pid = self._get_pidtype_pid()
+
+        pid_tasks_0 = pid.tasks[pidtype_pid].first
+        if not pid_tasks_0:
+            return
+
+        task_struct_type = self.vmlinux.get_type("task_struct")
+        if task_struct_type.has_member("pids"):
+            member = "pids"
+        elif task_struct_type.has_member("pid_links"):
+            member = "pid_links"
+        else:
+            return None
+
+        task_pids_off = task_struct_type.relative_child_offset(member)
+        task = self.vmlinux.object(
+            "task_struct", offset=pid_tasks_0 - task_pids_off, absolute=True
+        )
+        return task
+
+    def _pid_namespace_idr(self):
+        # kernels >= 4.15
+        ns_addr = self.vmlinux.get_symbol("init_pid_ns").address
+        ns = self.vmlinux.object("pid_namespace", offset=ns_addr)
+
+        for page_addr in ns.idr.get_page_addresses():
+            task = self._task_for_radix_pid_node(page_addr)
+            if self._is_valid_task(task):
+                yield task
+
+    def _determine_pid_func(self):
+        pid_hash = self.vmlinux.has_symbol("pid_hash") and self.vmlinux.has_symbol(
+            "pidhash_shift"
+        )  # 2.5.55 <= kernels < 4.15
+
+        has_pid_numbers = self.vmlinux.has_type("pid") and self.vmlinux.get_type(
+            "pid"
+        ).has_member(
+            "numbers"
+        )  # kernels >= 2.6.24
+
+        has_pid_numbers = self.vmlinux.has_type("upid") and self.vmlinux.get_type(
+            "upid"
+        ).has_member(
+            "pid_chain"
+        )  # 2.6.24 <= kernels < 4.15
+
+        # kernels >= 4.15
+        pid_idr = self.vmlinux.has_type("pid_namespace") and self.vmlinux.get_type(
+            "pid_namespace"
+        ).has_member("idr")
+
+        if pid_idr:
+            # kernels >= 4.15
+            return self._pid_namespace_idr
+        elif pid_hash and has_pid_numbers and has_pid_numbers:
+            # 2.6.24 <= kernels < 4.15
+            return self._pid_hash_implementation
+
+        return None
+
+    def get_tasks(self) -> interfaces.objects.ObjectInterface:
+        """Enumerates processes through the PID hash table
+
+        Yields:
+            task_struct objects
+        """
+        self.vmlinux = self.context.modules[self.config["kernel"]]
+        self.vmlinux_layer = self.context.layers[self.vmlinux.layer_name]
+        pid_func = self._determine_pid_func()
+        if not pid_func:
+            vollog.error("Cannot determine which PID hash table this kernel is using")
+            return
+
+        yield from sorted(pid_func(), key=lambda t: (t.tgid, t.pid))
+
+    def _generator(
+        self, decorate_comm: bool = False
+    ) -> interfaces.objects.ObjectInterface:
+        for task in self.get_tasks():
+            offset, pid, tid, ppid, name = pslist.PsList.get_task_fields(
+                task, decorate_comm
+            )
+            fields = format_hints.Hex(offset), pid, tid, ppid, name
+            yield 0, fields
+
+    def run(self):
+        decorate_comm = self.config.get("decorate_comm")
+
+        headers = [
+            ("OFFSET", format_hints.Hex),
+            ("PID", int),
+            ("TID", int),
+            ("PPID", int),
+            ("COMM", str),
+        ]
+        return renderers.TreeGrid(headers, self._generator(decorate_comm=decorate_comm))

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -49,7 +49,7 @@ class PIDHashTable(plugins.PluginInterface):
         self.vmlinux = None
         self.vmlinux_layer = None
 
-    def _is_valid_task(self, task):
+    def _is_valid_task(self, task) -> bool:
         return bool(task and task.pid > 0 and self.vmlinux_layer.is_valid(task.parent))
 
     def _get_pidtype_pid(self):

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -175,7 +175,7 @@ class PIDHashTable(plugins.PluginInterface):
         ns_addr = self.vmlinux.get_symbol("init_pid_ns").address
         ns = self.vmlinux.object("pid_namespace", offset=ns_addr)
 
-        for page_addr in ns.idr.get_page_addresses():
+        for page_addr in ns.idr.get_entries():
             task = self._task_for_radix_pid_node(page_addr)
             if self._is_valid_task(task):
                 yield task

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -50,19 +50,19 @@ class PIDHashTable(plugins.PluginInterface):
         self.vmlinux_layer = None
 
     def _is_valid_task(self, task):
-        return task and task.pid > 0 and self.vmlinux_layer.is_valid(task.parent)
+        return bool(task and task.pid > 0 and self.vmlinux_layer.is_valid(task.parent))
 
     def _get_pidtype_pid(self):
         # The pid_type enumeration is present since 2.5.37, just in case
         pid_type_enum = self.vmlinux.get_enumeration("pid_type")
         if not pid_type_enum:
             vollog.error("Cannot find pid_type enum. Unsupported kernel")
-            return
+            return None
 
         pidtype_pid = pid_type_enum.choices.get("PIDTYPE_PID")
         if pidtype_pid is None:
             vollog.error("Cannot find PIDTYPE_PID. Unsupported kernel")
-            return
+            return None
 
         # Typically PIDTYPE_PID = 0
         return pidtype_pid
@@ -154,7 +154,7 @@ class PIDHashTable(plugins.PluginInterface):
 
         pid_tasks_0 = pid.tasks[pidtype_pid].first
         if not pid_tasks_0:
-            return
+            return None
 
         task_struct_type = self.vmlinux.get_type("task_struct")
         if task_struct_type.has_member("pids"):

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -34,7 +34,7 @@ class PIDHashTable(plugins.PluginInterface):
                 name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="linuxutils", component=linux.LinuxUtilities, version=(2, 2, 0)
+                name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
             ),
             requirements.BooleanRequirement(
                 name="decorate_comm",

--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -151,17 +151,15 @@ class SockHandlers(interfaces.configuration.VersionableInterface):
 
         bpfprog = sock_filter.prog
 
-        BPF_PROG_TYPE_UNSPEC = 0  # cBPF filter
-        try:
-            bpfprog_type = bpfprog.get_type()
-            if bpfprog_type == BPF_PROG_TYPE_UNSPEC:
-                return  # cBPF filter
-        except AttributeError:
+        bpfprog_type = bpfprog.get_type()
+        if not bpfprog_type:
             # kernel < 3.18.140, it's a cBPF filter
             return None
 
-        BPF_PROG_TYPE_SOCKET_FILTER = 1  # eBPF filter
-        if bpfprog_type != BPF_PROG_TYPE_SOCKET_FILTER:
+        if bpfprog_type == "BPF_PROG_TYPE_UNSPEC":
+            return None  # cBPF filter
+
+        if bpfprog_type != "BPF_PROG_TYPE_SOCKET_FILTER":
             socket_filter["bpf_filter_type"] = f"UNK({bpfprog_type})"
             vollog.warning(f"Unexpected BPF type {bpfprog_type} for a socket")
             return None

--- a/volatility3/framework/renderers/conversion.py
+++ b/volatility3/framework/renderers/conversion.py
@@ -11,6 +11,7 @@ from typing import Union
 from volatility3.framework import interfaces, renderers
 
 
+# FIXME: Move wintime_to_datetime() and unixtime_to_datetime() out of renderers, possibly framework.objects.utility
 def wintime_to_datetime(
     wintime: int,
 ) -> Union[interfaces.renderers.BaseAbsentValue, datetime.datetime]:

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -74,7 +74,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
 class LinuxUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful linux functions."""
 
-    _version = (2, 2, 0)
+    _version = (2, 1, 1)
     _required_framework_version = (2, 0, 0)
 
     framework.require_interface_version(*_required_framework_version)

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -1,6 +1,8 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
+import math
+from abc import ABC, abstractmethod
 from typing import Iterator, List, Tuple, Optional, Union
 
 from volatility3 import framework
@@ -30,6 +32,9 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("kobject", extensions.kobject)
         self.set_type_class("cred", extensions.cred)
         self.set_type_class("inode", extensions.inode)
+        self.set_type_class("idr", extensions.IDR)
+        self.set_type_class("address_space", extensions.address_space)
+        self.set_type_class("page", extensions.page)
         # Might not exist in the current symbols
         self.optional_set_type_class("module", extensions.module)
         self.optional_set_type_class("bpf_prog", extensions.bpf_prog)
@@ -67,7 +72,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
 class LinuxUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful linux functions."""
 
-    _version = (2, 1, 0)
+    _version = (2, 2, 0)
     _required_framework_version = (2, 0, 0)
 
     framework.require_interface_version(*_required_framework_version)
@@ -425,3 +430,342 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         kernel = context.modules[kernel_module_name]
 
         return kernel
+
+    @classmethod
+    def choose_kernel_tree(cls, vmlinux: interfaces.context.ModuleInterface) -> "Tree":
+        """Returns the appropriate tree data structure instance for the current kernel implementation.
+        This is used by the IDR and the PageCache to choose between the XArray and RadixTree.
+
+        Args:
+            vmlinux: The kernel module object
+
+        Returns:
+            The appropriate Tree instance for the current kernel
+        """
+        address_space_type = vmlinux.get_type("address_space")
+        address_space_has_i_pages = address_space_type.has_member("i_pages")
+        i_pages_type_name = (
+            address_space_type.child_template("i_pages").vol.type_name
+            if address_space_has_i_pages
+            else ""
+        )
+        i_pages_is_xarray = i_pages_type_name.endswith(constants.BANG + "xarray")
+        i_pages_is_radix_tree_root = i_pages_type_name.endswith(
+            constants.BANG + "radix_tree_root"
+        ) and vmlinux.get_type("radix_tree_root").has_member("xa_head")
+
+        if i_pages_is_xarray or i_pages_is_radix_tree_root:
+            return XArray(vmlinux)
+        else:
+            return RadixTree(vmlinux)
+
+
+class Tree(ABC):
+    """Abstraction to support both XArray and RadixTree"""
+
+    # Dynamic values, these will be initialized later
+    CHUNK_SHIFT = None
+    CHUNK_SIZE = None
+    CHUNK_MASK = None
+
+    def __init__(self, vmlinux: interfaces.context.ModuleInterface):
+        self.vmlinux = vmlinux
+        self.vmlinux_layer = vmlinux.context.layers[vmlinux.layer_name]
+
+        self.pointer_size = self.vmlinux.get_type("pointer").size
+        # Dynamically work out the (XA_CHUNK|RADIX_TREE_MAP)_SHIFT values based on
+        # the node.slots[] array size
+        node_type = self.vmlinux.get_type(self.node_type_name)
+        slots_array_size = node_type.child_template("slots").count
+
+        # Calculate the LSB index - 1
+        self.CHUNK_SHIFT = slots_array_size.bit_length() - 1
+        self.CHUNK_SIZE = 1 << self.CHUNK_SHIFT
+        self.CHUNK_MASK = self.CHUNK_SIZE - 1
+
+    @property
+    @abstractmethod
+    def node_type_name(self) -> str:
+        """Returns the Tree implementation node type name
+
+        Returns:
+            A string with the node type name
+        """
+        raise NotImplementedError()
+
+    @property
+    def tag_internal_value(self) -> int:
+        """Returns the internal node flag for the tree"""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def node_is_internal(self, nodep) -> bool:
+        """Checks if the node is internal"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_node_tagged(self, nodep) -> bool:
+        """Checks if the node pointer is tagged"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def untag_node(self, nodep) -> int:
+        """Untags a node pointer"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_tree_height(self, treep) -> int:
+        """Returns the tree height"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_height(self, nodep) -> int:
+        """Returns the node height"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_head_node(self, tree) -> int:
+        """Returns a pointer to the tree's head"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_valid_node(self, nodep) -> bool:
+        """Validates a node pointer"""
+        raise NotImplementedError
+
+    def nodep_to_node(self, nodep) -> interfaces.objects.ObjectInterface:
+        """Instanciates a tree node from its pointer
+
+        Args:
+            nodep: Pointer to the XArray/RadixTree node
+
+        Returns:
+            A XArray/RadixTree node instance
+        """
+        node = self.vmlinux.object(self.node_type_name, offset=nodep, absolute=True)
+        return node
+
+    def _slot_to_nodep(self, slot) -> int:
+        if self.node_is_internal(slot):
+            nodep = slot & ~self.tag_internal_value
+        else:
+            nodep = slot
+
+        return nodep
+
+    def _iter_node(self, nodep, height) -> int:
+        node = self.nodep_to_node(nodep)
+        node_slots = node.slots
+        for off in range(self.CHUNK_SIZE):
+            slot = node_slots[off]
+            if slot == 0:
+                continue
+
+            nodep = self._slot_to_nodep(slot)
+
+            if height == 1:
+                if self.is_valid_node(nodep):
+                    yield nodep
+            else:
+                for child_node in self._iter_node(nodep, height - 1):
+                    yield child_node
+
+    def get_page_addresses(self, root: interfaces.objects.ObjectInterface) -> int:
+        """Walks the tree data structure
+
+        Args:
+            root: The tree root object
+
+        Yields:
+            A tree node pointer
+        """
+        height = self.get_tree_height(root.vol.offset)
+
+        nodep = self.get_head_node(root)
+        if not nodep:
+            return
+
+        # Keep the internal flag before untagging it
+        is_internal = self.node_is_internal(nodep)
+        if self.is_node_tagged(nodep):
+            nodep = self.untag_node(nodep)
+
+        if is_internal:
+            height = self.get_node_height(nodep)
+
+        if height == 0:
+            if self.is_valid_node(nodep):
+                yield nodep
+        else:
+            for child_node in self._iter_node(nodep, height):
+                yield child_node
+
+
+class XArray(Tree):
+    XARRAY_TAG_MASK = 3
+    XARRAY_TAG_INTERNAL = 2
+
+    def get_tree_height(self, treep) -> int:
+        return 0
+
+    @property
+    def node_type_name(self) -> str:
+        return "xa_node"
+
+    @property
+    def tag_internal_value(self) -> int:
+        return self.XARRAY_TAG_INTERNAL
+
+    def get_node_height(self, nodep) -> int:
+        node = self.nodep_to_node(nodep)
+        return (node.shift / self.CHUNK_SHIFT) + 1
+
+    def get_head_node(self, tree) -> int:
+        return tree.xa_head
+
+    def node_is_internal(self, nodep) -> bool:
+        return (nodep & self.XARRAY_TAG_MASK) == self.XARRAY_TAG_INTERNAL
+
+    def is_node_tagged(self, nodep) -> bool:
+        return (nodep & self.XARRAY_TAG_MASK) != 0
+
+    def untag_node(self, nodep) -> int:
+        return nodep & (~self.XARRAY_TAG_MASK)
+
+    def is_valid_node(self, nodep) -> bool:
+        # It should have the tag mask clear
+        return not self.is_node_tagged(nodep)
+
+
+class RadixTree(Tree):
+    RADIX_TREE_INTERNAL_NODE = 1
+    RADIX_TREE_EXCEPTIONAL_ENTRY = 2
+    RADIX_TREE_ENTRY_MASK = 3
+
+    # Dynamic values. These will be initialized later
+    RADIX_TREE_INDEX_BITS = None
+    RADIX_TREE_MAX_PATH = None
+    RADIX_TREE_HEIGHT_SHIFT = None
+    RADIX_TREE_HEIGHT_MASK = None
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        char_bits = 8
+        self.RADIX_TREE_INDEX_BITS = char_bits * self.pointer_size
+        self.RADIX_TREE_MAX_PATH = int(
+            math.ceil(self.RADIX_TREE_INDEX_BITS / float(self.CHUNK_SHIFT))
+        )
+        self.RADIX_TREE_HEIGHT_SHIFT = self.RADIX_TREE_MAX_PATH + 1
+        self.RADIX_TREE_HEIGHT_MASK = (1 << self.RADIX_TREE_HEIGHT_SHIFT) - 1
+
+        if not self.vmlinux.has_type("radix_tree_root"):
+            # In kernels 4.20, RADIX_TREE_INTERNAL_NODE flag took RADIX_TREE_EXCEPTIONAL_ENTRY's
+            # value. RADIX_TREE_EXCEPTIONAL_ENTRY was removed but that's managed in is_valid_node()
+            # Note that the Radix Tree is still in use for IDR, even after kernels 4.20 when XArray
+            # mostly replace it
+            self.RADIX_TREE_INTERNAL_NODE = 2
+
+    @property
+    def node_type_name(self) -> str:
+        return "radix_tree_node"
+
+    @property
+    def tag_internal_value(self) -> int:
+        return self.RADIX_TREE_INTERNAL_NODE
+
+    def get_tree_height(self, treep) -> int:
+        try:
+            if self.vmlinux.get_type("radix_tree_root").has_member("height"):
+                # kernels < 4.7.10
+                radix_tree_root = self.vmlinux.object(
+                    "radix_tree_root", offset=treep, absolute=True
+                )
+                return radix_tree_root.height
+        except exceptions.SymbolError:
+            pass
+
+        # kernels >= 4.7.10
+        return 0
+
+    def _radix_tree_maxindex(self, node, height) -> int:
+        """Return the maximum key which can be store into a radix tree with this height."""
+
+        if not self.vmlinux.has_symbol("height_to_maxindex"):
+            # Kernels >= 4.7
+            return (self.CHUNK_SIZE << node.shift) - 1
+        else:
+            # Kernels < 4.7
+            height_to_maxindex_array = self.vmlinux.object_from_symbol(
+                "height_to_maxindex"
+            )
+            maxindex = height_to_maxindex_array[height]
+            return maxindex
+
+    def get_node_height(self, nodep) -> int:
+        node = self.nodep_to_node(nodep)
+        if hasattr(node, "shift"):
+            # 4.7 <= Kernels < 4.20
+            return (node.shift / self.CHUNK_SHIFT) + 1
+        elif hasattr(node, "path"):
+            # 3.15 <= Kernels < 4.7
+            return node.path & self.RADIX_TREE_HEIGHT_MASK
+        elif hasattr(node, "height"):
+            # Kernels < 3.15
+            return node.height
+        else:
+            raise exceptions.VolatilityException("Cannot find radix-tree node height")
+
+    def get_head_node(self, tree) -> int:
+        return tree.rnode
+
+    def node_is_internal(self, nodep) -> bool:
+        return (nodep & self.RADIX_TREE_INTERNAL_NODE) != 0
+
+    def is_node_tagged(self, nodep) -> bool:
+        return self.node_is_internal(nodep)
+
+    def untag_node(self, nodep) -> int:
+        return nodep & (~self.RADIX_TREE_ENTRY_MASK)
+
+    def is_valid_node(self, nodep) -> bool:
+        # In kernels 4.20, exceptional nodes were removed and internal entries took their bitmask
+        if self.vmlinux.has_type("radix_tree_root"):
+            return (
+                nodep & self.RADIX_TREE_ENTRY_MASK
+            ) != self.RADIX_TREE_EXCEPTIONAL_ENTRY
+
+        return True
+
+
+class PageCache(object):
+    """Linux Page Cache abstraction"""
+
+    def __init__(
+        self,
+        page_cache: interfaces.objects.ObjectInterface,
+        vmlinux: interfaces.context.ModuleInterface,
+    ):
+        """
+        Args:
+            page_cache: Page cache address space
+            vmlinux: Kernel module object
+        """
+        self.vmlinux = vmlinux
+        self._page_cache = page_cache
+        self._tree = LinuxUtilities.choose_kernel_tree(self.vmlinux)
+
+    def get_cached_pages(self) -> interfaces.objects.ObjectInterface:
+        """Returns all page cache contents
+
+        Yields:
+            Page objects
+        """
+
+        for page_addr in self._tree.get_page_addresses(self._page_cache.i_pages):
+            if not page_addr:
+                continue
+
+            page = self.vmlinux.object("page", offset=page_addr, absolute=True)
+            if page:
+                yield page

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -29,11 +29,17 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("files_struct", extensions.files_struct)
         self.set_type_class("kobject", extensions.kobject)
         self.set_type_class("cred", extensions.cred)
+        self.set_type_class("inode", extensions.inode)
         # Might not exist in the current symbols
         self.optional_set_type_class("module", extensions.module)
         self.optional_set_type_class("bpf_prog", extensions.bpf_prog)
         self.optional_set_type_class("kernel_cap_struct", extensions.kernel_cap_struct)
         self.optional_set_type_class("kernel_cap_t", extensions.kernel_cap_t)
+
+        # kernels >= 4.18
+        self.optional_set_type_class("timespec64", extensions.timespec64)
+        # kernels < 4.18. Reuses timespec64 obj extension, since both has the same members
+        self.optional_set_type_class("timespec", extensions.timespec64)
 
         # Mount
         self.set_type_class("vfsmount", extensions.vfsmount)

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -572,7 +572,7 @@ class Tree(ABC):
                 for child_node in self._iter_node(nodep, height - 1):
                     yield child_node
 
-    def get_page_addresses(self, root: interfaces.objects.ObjectInterface) -> int:
+    def get_entries(self, root: interfaces.objects.ObjectInterface) -> int:
         """Walks the tree data structure
 
         Args:
@@ -762,7 +762,7 @@ class PageCache(object):
             Page objects
         """
 
-        for page_addr in self._tree.get_page_addresses(self._page_cache.i_pages):
+        for page_addr in self._tree.get_entries(self._page_cache.i_pages):
             if not page_addr:
                 continue
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -2,6 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import math
+import contextlib
 from abc import ABC, abstractmethod
 from typing import Iterator, List, Tuple, Optional, Union
 
@@ -676,15 +677,13 @@ class RadixTree(Tree):
         return self.RADIX_TREE_INTERNAL_NODE
 
     def get_tree_height(self, treep) -> int:
-        try:
+        with contextlib.suppress(exceptions.SymbolError):
             if self.vmlinux.get_type("radix_tree_root").has_member("height"):
                 # kernels < 4.7.10
                 radix_tree_root = self.vmlinux.object(
                     "radix_tree_root", offset=treep, absolute=True
                 )
                 return radix_tree_root.height
-        except exceptions.SymbolError:
-            pass
 
         # kernels >= 4.7.10
         return 0

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -38,6 +38,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         # Might not exist in the current symbols
         self.optional_set_type_class("module", extensions.module)
         self.optional_set_type_class("bpf_prog", extensions.bpf_prog)
+        self.optional_set_type_class("bpf_prog_aux", extensions.bpf_prog_aux)
         self.optional_set_type_class("kernel_cap_struct", extensions.kernel_cap_struct)
         self.optional_set_type_class("kernel_cap_t", extensions.kernel_cap_t)
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -419,9 +419,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         Returns:
             A kernel object (vmlinux)
         """
-        symbol_table_arr = volobj.vol.type_name.split("!", 1)
-        symbol_table = symbol_table_arr[0] if len(symbol_table_arr) == 2 else None
-
+        symbol_table = volobj.get_symbol_table_name()
         module_names = context.modules.get_modules_by_symbol_tables(symbol_table)
         module_names = list(module_names)
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1839,7 +1839,7 @@ class inode(objects.StructType):
         """Returns the inode number"""
         return int(self.i_ino)
 
-    def ___time_member_to_datetime(self, member) -> datetime:
+    def _time_member_to_datetime(self, member) -> datetime:
         if self.has_member(f"{member}_sec") and self.has_member(f"{member}_nsec"):
             # kernels >= 6.11 it's i_*_sec -> time64_t and i_*_nsec -> u32
             # Ref Linux commit 3aa63a569c64e708df547a8913c84e64a06e7853
@@ -1865,7 +1865,7 @@ class inode(objects.StructType):
         Returns:
             A datetime with the inode's last access time
         """
-        return self.___time_member_to_datetime("i_atime")
+        return self._time_member_to_datetime("i_atime")
 
     def get_modification_time(self) -> datetime:
         """Returns the inode's last modification time
@@ -1875,7 +1875,7 @@ class inode(objects.StructType):
             A datetime with the inode's last data modification time
         """
 
-        return self.___time_member_to_datetime("i_mtime")
+        return self._time_member_to_datetime("i_mtime")
 
     def get_change_time(self) -> datetime:
         """Returns the inode's last change time
@@ -1884,7 +1884,7 @@ class inode(objects.StructType):
         Returns:
             A datetime with the inode's last change time
         """
-        return self.___time_member_to_datetime("i_ctime")
+        return self._time_member_to_datetime("i_ctime")
 
     def get_file_mode(self) -> str:
         """Returns the inode's file mode as string of the form '-rwxrwxrwx'.

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1780,34 +1780,42 @@ class inode(objects.StructType):
         # pointer, will easily cause an integer overflow here.
         return self.i_ino > 0 and self.i_count.counter >= 0
 
+    @property
     def is_dir(self) -> bool:
         """Returns True if the inode is a directory"""
         return stat.S_ISDIR(self.i_mode) != 0
 
+    @property
     def is_reg(self) -> bool:
         """Returns True if the inode is a regular file"""
         return stat.S_ISREG(self.i_mode) != 0
 
+    @property
     def is_link(self) -> bool:
         """Returns True if the inode is a symlink"""
         return stat.S_ISLNK(self.i_mode) != 0
 
+    @property
     def is_fifo(self) -> bool:
         """Returns True if the inode is a FIFO"""
         return stat.S_ISFIFO(self.i_mode) != 0
 
+    @property
     def is_sock(self) -> bool:
         """Returns True if the inode is a socket"""
         return stat.S_ISSOCK(self.i_mode) != 0
 
+    @property
     def is_block(self) -> bool:
         """Returns True if the inode is a block device"""
         return stat.S_ISBLK(self.i_mode) != 0
 
+    @property
     def is_char(self) -> bool:
         """Returns True if the inode is a char device"""
         return stat.S_ISCHR(self.i_mode) != 0
 
+    @property
     def is_sticky(self) -> bool:
         """Returns True if the sticky bit is set"""
         return (self.i_mode & stat.S_ISVTX) != 0
@@ -1818,19 +1826,19 @@ class inode(objects.StructType):
         Returns:
             The inode type name
         """
-        if self.is_dir():
+        if self.is_dir:
             return "DIR"
-        elif self.is_reg():
+        elif self.is_reg:
             return "REG"
-        elif self.is_link():
+        elif self.is_link:
             return "LNK"
-        elif self.is_fifo():
+        elif self.is_fifo:
             return "FIFO"
-        elif self.is_sock():
+        elif self.is_sock:
             return "SOCK"
-        elif self.is_char():
+        elif self.is_char:
             return "CHR"
-        elif self.is_block():
+        elif self.is_block:
             return "BLK"
         else:
             return None

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2168,11 +2168,12 @@ class IDR(objects.StructType):
 
     def _old_kernel_get_entries(self) -> int:
         # Kernels < 4.11
+        cur = self.cur
         total = next_id = 0
-        while total < in_use:
-            page_addr = self.idr_find(next_id)
-            if page_addr:
-                yield page_addr
+        while next_id < cur:
+            entry = self.idr_find(next_id)
+            if entry:
+                yield entry
                 total += 1
 
             next_id += 1

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2134,7 +2134,7 @@ class IDR(objects.StructType):
         """Finds an ID within the IDR data structure.
         Based on idr_find_slowpath(), 3.9 <= Kernel < 4.11
         Args:
-            idr_id: The IDR element ID
+            idr_id: The IDR lookup ID
 
         Returns:
             A pointer to the given ID element
@@ -2144,28 +2144,28 @@ class IDR(objects.StructType):
             vollog.info(
                 "Unsupported IDR implementation, it should be a very very old kernel, probabably < 2.6"
             )
-            return
+            return None
 
         if idr_id < 0:
-            return
+            return None
 
-        cur_layer = self.top
-        if not cur_layer:
-            return
+        idr_layer = self.top
+        if not idr_layer:
+            return None
 
-        n = (cur_layer.layer + 1) * self.IDR_BITS
+        n = (idr_layer.layer + 1) * self.IDR_BITS
 
-        if idr_id > self.idr_max(cur_layer.layer + 1):
-            return
+        if idr_id > self.idr_max(idr_layer.layer + 1):
+            return None
 
         assert n != 0
 
-        while n > 0 and cur_layer:
+        while n > 0 and idr_layer:
             n -= self.IDR_BITS
-            assert n == cur_layer.layer * self.IDR_BITS
-            cur_layer = cur_layer.ary[(idr_id >> n) & self.IDR_MASK]
+            assert n == idr_layer.layer * self.IDR_BITS
+            idr_layer = idr_layer.ary[(idr_id >> n) & self.IDR_MASK]
 
-        return cur_layer.v()
+        return idr_layer
 
     def _old_kernel_get_page_addresses(self, in_use) -> int:
         # Kernels < 4.11

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -4,10 +4,13 @@
 
 import collections.abc
 import logging
+import stat
+from datetime import datetime
 import socket as socket_module
 from typing import Generator, Iterable, Iterator, Optional, Tuple, List
 
 from volatility3.framework import constants, exceptions, objects, interfaces, symbols
+from volatility3.framework import renderers
 from volatility3.framework.constants.linux import SOCK_TYPES, SOCK_FAMILY
 from volatility3.framework.constants.linux import IP_PROTOCOLS, IPV6_PROTOCOLS
 from volatility3.framework.constants.linux import TCP_STATES, NETLINK_PROTOCOLS
@@ -1761,3 +1764,132 @@ class kernel_cap_t(kernel_cap_struct):
             )
 
         return cap_value & self.get_kernel_cap_full()
+
+
+class timespec64(objects.StructType):
+    def to_datetime(self) -> datetime:
+        """Returns the respective aware datetime"""
+
+        dt = renderers.conversion.unixtime_to_datetime(self.tv_sec + self.tv_nsec / 1e9)
+        return dt
+
+
+class inode(objects.StructType):
+    def is_valid(self) -> bool:
+        # i_count is a 'signed' counter (atomic_t). Smear, or essentially a wrong inode
+        # pointer, will easily cause an integer overflow here.
+        return self.i_ino > 0 and self.i_count.counter >= 0
+
+    def is_dir(self) -> bool:
+        """Returns True if the inode is a directory"""
+        return stat.S_ISDIR(self.i_mode) != 0
+
+    def is_reg(self) -> bool:
+        """Returns True if the inode is a regular file"""
+        return stat.S_ISREG(self.i_mode) != 0
+
+    def is_link(self) -> bool:
+        """Returns True if the inode is a symlink"""
+        return stat.S_ISLNK(self.i_mode) != 0
+
+    def is_fifo(self) -> bool:
+        """Returns True if the inode is a FIFO"""
+        return stat.S_ISFIFO(self.i_mode) != 0
+
+    def is_sock(self) -> bool:
+        """Returns True if the inode is a socket"""
+        return stat.S_ISSOCK(self.i_mode) != 0
+
+    def is_block(self) -> bool:
+        """Returns True if the inode is a block device"""
+        return stat.S_ISBLK(self.i_mode) != 0
+
+    def is_char(self) -> bool:
+        """Returns True if the inode is a char device"""
+        return stat.S_ISCHR(self.i_mode) != 0
+
+    def is_sticky(self) -> bool:
+        """Returns True if the sticky bit is set"""
+        return (self.i_mode & stat.S_ISVTX) != 0
+
+    def get_inode_type(self) -> str:
+        """Returns inode type name
+
+        Returns:
+            The inode type name
+        """
+        if self.is_dir():
+            return "DIR"
+        elif self.is_reg():
+            return "REG"
+        elif self.is_link():
+            return "LNK"
+        elif self.is_fifo():
+            return "FIFO"
+        elif self.is_sock():
+            return "SOCK"
+        elif self.is_char():
+            return "CHR"
+        elif self.is_block():
+            return "BLK"
+        else:
+            return renderers.UnparsableValue()
+
+    def get_inode_number(self) -> int:
+        """Returns the inode number"""
+        return int(self.i_ino)
+
+    def ___time_member_to_datetime(self, member) -> datetime:
+        if self.has_member(f"{member}_sec") and self.has_member(f"{member}_nsec"):
+            # kernels >= 6.11 it's i_*_sec -> time64_t and i_*_nsec -> u32
+            # Ref Linux commit 3aa63a569c64e708df547a8913c84e64a06e7853
+            return renderers.conversion.unixtime_to_datetime(
+                self.member(f"{member}_sec") + self.has_member(f"{member}_nsec") / 1e9
+            )
+        elif self.has_member(f"__{member}"):
+            # 6.6 <= kernels < 6.11 it's a timespec64
+            # Ref Linux commit 13bc24457850583a2e7203ded05b7209ab4bc5ef / 12cd44023651666bd44baa36a5c999698890debb
+            return self.member(f"__{member}").to_datetime()
+        elif self.has_member(member):
+            # In kernels < 6.6 it's a timespec64 or timespec
+            return self.member(member).to_datetime()
+        else:
+            raise exceptions.VolatilityException(
+                "Unsupported kernel inode type implementation"
+            )
+
+    def get_access_time(self) -> datetime:
+        """Returns the inode's last access time
+        This is updated when inode contents are read
+
+        Returns:
+            A datetime with the inode's last access time
+        """
+        return self.___time_member_to_datetime("i_atime")
+
+    def get_modification_time(self) -> datetime:
+        """Returns the inode's last modification time
+        This is updated when the inode contents change
+
+        Returns:
+            A datetime with the inode's last data modification time
+        """
+
+        return self.___time_member_to_datetime("i_mtime")
+
+    def get_change_time(self) -> datetime:
+        """Returns the inode's last change time
+        This is updated when the inode metadata changes
+
+        Returns:
+            A datetime with the inode's last change time
+        """
+        return self.___time_member_to_datetime("i_ctime")
+
+    def get_file_mode(self) -> str:
+        """Returns the inode's file mode as string of the form '-rwxrwxrwx'.
+
+        Returns:
+            The inode's file mode string
+        """
+        return stat.filemode(self.i_mode)

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1965,7 +1965,7 @@ class address_space(objects.StructType):
 
 class page(objects.StructType):
     @property
-    @functools.cache
+    @functools.lru_cache()
     def pageflags_enum(self) -> Dict:
         """Returns 'pageflags' enumeration key/values
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2063,10 +2063,9 @@ class page(objects.StructType):
                     vmemmap_start = vmemmap_base_l4
                 else:
                     # 5-Level paging -> VMEMMAP_START = __VMEMMAP_BASE_L5
-                    vmemmap_base_l5 = 0xFFD4000000000000
-                    vmemmap_start = vmemmap_base_l5
-
-                    # FIXME: Remove this exception once 5-level paging is supported.
+                    # FIXME: Once 5-level paging is supported, uncomment the following lines and remove the exception
+                    # vmemmap_base_l5 = 0xFFD4000000000000
+                    # vmemmap_start = vmemmap_base_l5
                     raise exceptions.VolatilityException(
                         "5-level paging is not yet supported"
                     )

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1972,8 +1972,11 @@ class inode(objects.StructType):
         elif not (self.i_mapping and self.i_mapping.nrpages > 0):
             return
 
-        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
-        page_cache = linux.PageCache(self.i_mapping.dereference(), vmlinux)
+        page_cache = linux.PageCache(
+            context=self._context,
+            kernel_module_name="kernel",
+            page_cache=self.i_mapping.dereference(),
+        )
         yield from page_cache.get_cached_pages()
 
     def get_contents(self):
@@ -2180,9 +2183,10 @@ class IDR(objects.StructType):
 
     def _new_kernel_get_entries(self) -> int:
         # Kernels >= 4.11
-        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
-        tree = linux.LinuxUtilities.choose_kernel_tree(vmlinux)
-        for page_addr in tree.get_entries(root=self.idr_rt):
+        id_storage = linux.IDStorage.choose_id_storage(
+            self._context, kernel_module_name="kernel"
+        )
+        for page_addr in id_storage.get_entries(root=self.idr_rt):
             yield page_addr
 
     def get_entries(self) -> int:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -13,6 +13,7 @@ from typing import Generator, Iterable, Iterator, Optional, Tuple, List, Union, 
 
 from volatility3.framework import constants, exceptions, objects, interfaces, symbols
 from volatility3.framework.renderers import conversion
+from volatility3.framework.configuration import requirements
 from volatility3.framework.constants.linux import SOCK_TYPES, SOCK_FAMILY
 from volatility3.framework.constants.linux import IP_PROTOCOLS, IPV6_PROTOCOLS
 from volatility3.framework.constants.linux import TCP_STATES, NETLINK_PROTOCOLS
@@ -1608,6 +1609,19 @@ class xdp_sock(objects.StructType):
 
 
 class bpf_prog(objects.StructType):
+    def _get_vmlinux(self):
+        linuxutils_required_version = (2, 1, 1)
+        linuxutils_current_version = linux.LinuxUtilities._version
+        if not requirements.VersionRequirement.matches_required(
+            linuxutils_required_version, linuxutils_current_version
+        ):
+            raise exceptions.PluginRequirementException(
+                f"linux.LinuxUtilities version not suitable: required {linuxutils_required_version} found {linuxutils_current_version}"
+            )
+
+        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+        return vmlinux
+
     def get_type(self) -> Union[str, None]:
         """Returns a string with the eBPF program type"""
 
@@ -1631,7 +1645,7 @@ class bpf_prog(objects.StructType):
         if not self.has_member("tag"):
             return None
 
-        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+        vmlinux = self._get_vmlinux()
         vmlinux_layer = vmlinux.context.layers[vmlinux.layer_name]
 
         prog_tag_addr = self.tag.vol.offset
@@ -2043,13 +2057,26 @@ class page(objects.StructType):
 
         return flags
 
+    def _get_vmlinux(self):
+        linuxutils_required_version = (2, 1, 1)
+        linuxutils_current_version = linux.LinuxUtilities._version
+        if not requirements.VersionRequirement.matches_required(
+            linuxutils_required_version, linuxutils_current_version
+        ):
+            raise exceptions.PluginRequirementException(
+                f"linux.LinuxUtilities version not suitable: required {linuxutils_required_version} found {linuxutils_current_version}"
+            )
+
+        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+        return vmlinux
+
     def to_paddr(self) -> int:
         """Converts a page's virtual address to its physical address using the current physical memory model.
 
         Returns:
             int: page physical address
         """
-        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+        vmlinux = self._get_vmlinux()
         vmlinux_layer = vmlinux.context.layers[vmlinux.layer_name]
 
         vmemmap_start = None
@@ -2100,7 +2127,7 @@ class page(objects.StructType):
         Returns:
             The page content
         """
-        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+        vmlinux = self._get_vmlinux()
         vmlinux_layer = vmlinux.context.layers[vmlinux.layer_name]
         physical_layer = vmlinux.context.layers["memory_layer"]
         page_paddr = self.to_paddr()
@@ -2117,6 +2144,19 @@ class IDR(objects.StructType):
     INT_SIZE = 4
     MAX_IDR_SHIFT = INT_SIZE * 8 - 1
     MAX_IDR_BIT = 1 << MAX_IDR_SHIFT
+
+    def _get_vmlinux(self):
+        linuxutils_required_version = (2, 1, 1)
+        linuxutils_current_version = linux.LinuxUtilities._version
+        if not requirements.VersionRequirement.matches_required(
+            linuxutils_required_version, linuxutils_current_version
+        ):
+            raise exceptions.PluginRequirementException(
+                f"linux.LinuxUtilities version not suitable: required {linuxutils_required_version} found {linuxutils_current_version}"
+            )
+
+        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+        return vmlinux
 
     def idr_max(self, num_layers: int) -> int:
         """Returns the maximum ID which can be allocated given idr::layers
@@ -2141,7 +2181,7 @@ class IDR(objects.StructType):
         Returns:
             A pointer to the given ID element
         """
-        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+        vmlinux = self._get_vmlinux()
         if not vmlinux.get_type("idr_layer").has_member("layer"):
             vollog.info(
                 "Unsupported IDR implementation, it should be a very very old kernel, probabably < 2.6"

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -47,7 +47,7 @@ class module(generic.GenericIntelProcess):
                 ).choices
             except exceptions.SymbolError:
                 vollog.debug(
-                    f"Unable to find mod_mem_type enum. This message can be ignored for kernels < 6.4"
+                    "Unable to find mod_mem_type enum. This message can be ignored for kernels < 6.4"
                 )
                 # set to empty dict to show that the enum was not found, and so shouldn't be searched for again
                 self._mod_mem_type = {}
@@ -936,7 +936,8 @@ class mount(objects.StructType):
         MNT_RELATIME: "relatime",
     }
 
-    def get_mnt_sb(self):
+    def get_mnt_sb(self) -> int:
+        """Returns a pointer to the super_block"""
         if self.has_member("mnt"):
             return self.mnt.mnt_sb
         elif self.has_member("mnt_sb"):
@@ -1251,6 +1252,7 @@ class vfsmount(objects.StructType):
             return self._get_real_mnt().has_parent()
 
     def get_mnt_sb(self):
+        """Returns a pointer to the super_block"""
         return self.mnt_sb
 
     def get_flags_access(self) -> str:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1843,10 +1843,6 @@ class inode(objects.StructType):
         else:
             return None
 
-    def get_inode_number(self) -> int:
-        """Returns the inode number"""
-        return int(self.i_ino)
-
     def _time_member_to_datetime(self, member) -> datetime:
         if self.has_member(f"{member}_sec") and self.has_member(f"{member}_nsec"):
             # kernels >= 6.11 it's i_*_sec -> time64_t and i_*_nsec -> u32

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -7,10 +7,10 @@ import logging
 import stat
 from datetime import datetime
 import socket as socket_module
-from typing import Generator, Iterable, Iterator, Optional, Tuple, List
+from typing import Generator, Iterable, Iterator, Optional, Tuple, List, Union
 
 from volatility3.framework import constants, exceptions, objects, interfaces, symbols
-from volatility3.framework import renderers
+from volatility3.framework.renderers import conversion
 from volatility3.framework.constants.linux import SOCK_TYPES, SOCK_FAMILY
 from volatility3.framework.constants.linux import IP_PROTOCOLS, IPV6_PROTOCOLS
 from volatility3.framework.constants.linux import TCP_STATES, NETLINK_PROTOCOLS
@@ -1770,7 +1770,7 @@ class timespec64(objects.StructType):
     def to_datetime(self) -> datetime:
         """Returns the respective aware datetime"""
 
-        dt = renderers.conversion.unixtime_to_datetime(self.tv_sec + self.tv_nsec / 1e9)
+        dt = conversion.unixtime_to_datetime(self.tv_sec + self.tv_nsec / 1e9)
         return dt
 
 
@@ -1812,7 +1812,7 @@ class inode(objects.StructType):
         """Returns True if the sticky bit is set"""
         return (self.i_mode & stat.S_ISVTX) != 0
 
-    def get_inode_type(self) -> str:
+    def get_inode_type(self) -> Union[str, None]:
         """Returns inode type name
 
         Returns:
@@ -1833,7 +1833,7 @@ class inode(objects.StructType):
         elif self.is_block():
             return "BLK"
         else:
-            return renderers.UnparsableValue()
+            return None
 
     def get_inode_number(self) -> int:
         """Returns the inode number"""
@@ -1843,7 +1843,7 @@ class inode(objects.StructType):
         if self.has_member(f"{member}_sec") and self.has_member(f"{member}_nsec"):
             # kernels >= 6.11 it's i_*_sec -> time64_t and i_*_nsec -> u32
             # Ref Linux commit 3aa63a569c64e708df547a8913c84e64a06e7853
-            return renderers.conversion.unixtime_to_datetime(
+            return conversion.unixtime_to_datetime(
                 self.member(f"{member}_sec") + self.has_member(f"{member}_nsec") / 1e9
             )
         elif self.has_member(f"__{member}"):

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2027,7 +2027,7 @@ class page(objects.StructType):
 
         return pageflags_enum
 
-    def flags_list(self) -> List[str]:
+    def get_flags_list(self) -> List[str]:
         """Returns a list of page flags
 
         Returns:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2102,7 +2102,7 @@ class page(objects.StructType):
         physical_layer = vmlinux.context.layers["memory_layer"]
         page_paddr = self.to_paddr()
         if not page_paddr:
-            return
+            return None
 
         page_data = physical_layer.read(page_paddr, vmlinux_layer.page_size)
         return page_data


### PR DESCRIPTION
This PR includes abstractions for RadixTree, XArray, Page Cache and IDR to ensure support with both older and the newest kernel versions. The RadixTree and XArray enable the implementation of other subsystems like the Page Cache and IDR.

This is the final iteration of other PRs which are part of this feature. 
- https://github.com/volatilityfoundation/volatility3/pull/1222
- https://github.com/volatilityfoundation/volatility3/pull/1230


Besides the Page Cache plugins, we added two more plugins to this PR to be able to test the whole code with different kernel versions.

# Inode Page Cache
## linux.pagecache.Files plugin 
This plugin can list all inodes, filter by type and find filenames. Basically, it shows superblock, dentry and inode info.
It also supports the Timeliner plugin.

For instance, to list all inodes:
```shell
$ ./vol.py -f ./ubuntu-4.9.0-19-32bit.core linux.pagecache.Files 
Volatility 3 Framework 2.7.1
Progress:  100.00               Stacking attempts finished                  
SuperblockAddr  MountPoint      Device  InodeNum        InodeAddr       FileType        InodePages      CachedPages     FileMode        AccessTime      ModificationTime        ChangeTime      FilePath

0xf7094800      /       0:1     1       0xf4801e60      DIR     0       0       drwxr-xr-x      2024-07-29 13:44:58.916000 UTC  2024-07-29 13:44:58.916000 UTC  2024-07-29 13:44:58.916000 UTC  /
0xf7094800      /       0:1     7626    0xf4b2a5c0      DIR     0       0       drwx------      2022-06-30 18:26:10.000000 UTC  2022-06-30 18:26:10.000000 UTC  2024-07-29 13:44:58.228996 UTC  /root
0xf7154800      /sys    0:16    1       0xf4b492e0      DIR     0       0       dr-xr-xr-x      2024-07-29 13:44:58.500000 UTC  2024-07-29 13:44:58.500000 UTC  2024-07-29 13:44:58.500000 UTC  /sys
...
```
Filtering by file type. For instance, list the top Regular files with more pages in cache:
```shell
$ ./vol.py -f ./ubuntu-4.9.0-19-32bit.core linux.pagecache.Files --type REG | sort -k8 -n -r | head -10
0xf6845800      /run    0:18    9964    0xf6fd30b0      REG     647     647     -rw-r-----      2024-07-29 13:45:01.348000 UTC  2024-07-29 13:45:02.044000 UTC  2024-07-29 13:45:02.044000 UTC  /run/log/journal/791e6a5cbadf47da9808b2fdd26a7bf0/system.journal
0xf6f7b800      /       254:3   5506492 0xf46d5780      REG     549     474     -rwxr-xr-x      2024-07-29 13:00:30.392000 UTC  2020-06-20 17:33:46.000000 UTC  2024-01-07 10:46:57.080673 UTC  /usr/bin/perl
0xf6f7b800      /       254:3   2359824 0xf4536a08      REG     517     440     -rw-r--r--      2024-07-29 13:00:29.524000 UTC  2022-06-29 12:41:17.000000 UTC  2024-01-07 10:56:29.475108 UTC  /lib/systemd/libsystemd-shared-232.so
...
```

Find a specific file name:
```shell
$ ./vol.py -f ./ubuntu-4.9.0-19-32bit.core linux.pagecache.Files  --find /etc/shadow
Volatility 3 Framework 2.7.1
Progress:  100.00               Stacking attempts finished                  
SuperblockAddr  MountPoint      Device  InodeNum        InodeAddr       FileType        InodePages      CachedPages     FileMode        AccessTime      ModificationTime        ChangeTime      FilePath

0xf6f7b800      /       254:3   7078755 0xf46c83f8      REG     1       1       -rw-r-----      2024-07-29 13:00:30.552000 UTC  2024-01-07 11:19:42.597348 UTC  2024-01-07 11:19:42.597348 UTC  /etc/shadow

```
## linux.pagecache.InodePages plugin 

This plugin requires either an inode address (--inode) or a filename (--find) to search for the inode, and optionally, you can use (--dump) to dump the inode's page cache contents which is the primary and greatest goal of this effort.

Example 1, via inode address:
```shell
$ ./vol.py -f ./ubuntu-4.9.0-19-32bit.core linux.pagecache.InodePages --inode 0xf6fd30b0 --dump system.journal
Volatility 3 Framework 2.7.1
PageVAddr       PagePAddr       MappingAddr     Index   DumpSafe        Flags
 
0xf5e9be90      0x7bf84000      0xf6fd31a8      0       True    active,dirty,lru,referenced,savepinned,swapbacked,uptodate
0xf5e9beb4      0x7bf85000      0xf6fd31a8      1       True    active,dirty,lru,referenced,savepinned,swapbacked,uptodate
0xf5e9bed8      0x7bf86000      0xf6fd31a8      2       True    active,dirty,lru,referenced,savepinned,swapbacked,uptodate
...
0xf5e8f944      0x7ba09000      0xf6fd31a8      646     True    dirty,lru,savepinned,swapbacked
```

Same inode but finding it via its filename:
```shell
$ ./vol.py -f ./ubuntu-4.9.0-19-32bit.core linux.pagecache.InodePages --find /run/log/journal/791e6a5cbadf47da9808b2fdd26a7bf0/system.journal --dump system.journal
Volatility 3 Framework 2.7.1
PageVAddr       PagePAddr       MappingAddr     Index   DumpSafe        Flags
 
0xf5e9be90      0x7bf84000      0xf6fd31a8      0       True    active,dirty,lru,referenced,savepinned,swapbacked,uptodate
0xf5e9beb4      0x7bf85000      0xf6fd31a8      1       True    active,dirty,lru,referenced,savepinned,swapbacked,uptodate
0xf5e9bed8      0x7bf86000      0xf6fd31a8      2       True    active,dirty,lru,referenced,savepinned,swapbacked,uptodate
...
0xf5e8f944      0x7ba09000      0xf6fd31a8      646     True    dirty,lru,savepinned,swapbacked
```
Checking the results:
```shell
$ file system.journal 
system.journal: Journal file, Mon Jul 29 13:44:59 2024, online, compressed lz4, header size 0xf0, entries 0x23f

$ journalctl --file=system.journal --list-boots
IDX BOOT ID                          FIRST ENTRY                  LAST ENTRY                  
  0 4f2a7426dab64f4dafa29343d13c1483 Mon 2024-07-29 23:44:59 AEST Mon 2024-07-29 23:45:01 AEST

$ journalctl --file=system.journal 
Jul 29 23:44:59 debian9.localdomain kernel: Linux version 4.9.0-19-686 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.320-2 (2022-06-30)
Jul 29 23:44:59 debian9.localdomain kernel: x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
Jul 29 23:44:59 debian9.localdomain kernel: x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
Jul 29 23:44:59 debian9.localdomain kernel: x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
...
```
Example 2:
```shell
$ ./vol.py ./ubuntu-4.9.0-19-686.core linux.pagecache.Files --find /etc/passwd
Volatility 3 Framework 2.7.1        
SuperblockAddr  MountPoint      Device  InodeNum        InodeAddr       FileType        InodePages      CachedPages     FileMode        AccessTime      ModificationTime        ChangeTime      FilePath

0xf6f7b800      /       254:3   7078938 0xf45116c0      REG     1       1       -rw-r--r--      2024-07-29 13:00:30.368000 UTC  2024-01-07 11:07:28.924695 UTC  2024-01-07 11:07:28.924695 UTC  /etc/passwd
```
Dump the inode:
```shell
$ ./vol.py -f ./ubuntu-4.9.0-19-686.core linux.pagecache.InodePages --find /etc/passwd --dump passwd
Volatility 3 Framework 2.7.1
PageVAddr       PagePAddr       MappingAddr     Index   DumpSafe        Flags

0xf5e87b68      0x7b68a000      0xf45117b8      0       True    active,lru,mappedtodisk,referenced,uptodate
```

Check the file:
```shell
$ cat passwd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologi
...
```

# IDR
## linux.ebpf.EBPF
A basic plugin to enumerate eBPF programs using the prog IDR. Tip for devs: Other contributions using the maps, links, etc. IDRs and even extending this plugin are welcome ;)

Test the plugin on a Cilium installation.
```shell
$ ./vol.py -f ./ram-5.8.0-53-ubuntu20.04-64bit.lime_cilium linux.ebpf.EBPF 
Volatility 3 Framework 2.8.0
Progress:  100.00               Stacking attempts finished                 
Address Name    Tag     Type

0xc9000002f000  -       3b185187f1855c4c        BPF_PROG_TYPE_XDP
0xc90000031000  BEGIN   f4b3d30cab782162        BPF_PROG_TYPE_KPROBE
0xc90000067000  sys_enter_execv e4476dee689a817e        BPF_PROG_TYPE_TRACEPOINT
0xc90000063000  -       3b185187f1855c4c        BPF_PROG_TYPE_XDP
0xc900005d5000  xdp_prog_simple 3b185187f1855c4c        BPF_PROG_TYPE_XDP
0xc90000141000  -       59904229c5a1f55d        BPF_PROG_TYPE_SCHED_CLS
0xc90000559000  -       6deef7357e7b4530        BPF_PROG_TYPE_CGROUP_SKB
0xc90000409000  -       6deef7357e7b4530        BPF_PROG_TYPE_CGROUP_SKB
0xc9000079d000  -       6deef7357e7b4530        BPF_PROG_TYPE_CGROUP_SKB
0xc9000079b000  -       6deef7357e7b4530        BPF_PROG_TYPE_CGROUP_SKB
...
```
## linux.pidhashtable.PIDHashTable
This is based on the vol2 plugin, removing ancient kernel support, curating code and enhancing comments, while using the new IDR abstraction included also in this effort.

```shell
$ ./vol.py -f ./ram-5.8.0-53-ubuntu20.04-64bit.lime_cilium linux.pidhashtable.PIDHashTable --decorate-comm 
Volatility 3 Framework 2.8.0
Progress:  100.00               Stacking attempts finished                 
OFFSET  PID     TID     PPID    COMM

0x8881396117c0  1       1       0       systemd
0x888139615f00  2       2       0       [kthreadd]
0x888139614740  3       3       2       [rcu_gp]
0x888139610000  4       4       2       [rcu_par_gp]
0x8881396317c0  6       6       2       [kworker/0:0H]
0x888139630000  9       9       2       [mm_percpu_wq]
0x888139632f80  10      10      2       [ksoftirqd/0]
0x8881396397c0  11      11      2       [rcu_sched]
...
```