### PR TITLE
add args and kwargs to threads.py init

### DIFF
--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -18,9 +18,9 @@ class Threads(thrdscan.ThrdScan):
     _required_framework_version = (2, 4, 0)
     _version = (1, 0, 0)
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.implementation = self.list_process_threads
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:


### PR DESCRIPTION
Without args and kwargs there were an issue with timeliner plugin that tried to pass additional parameters like progress_callback raising TypeError

```Traceback (most recent call last): File "/src/volatility3/volatility3/framework/plugins/timeliner.py", line 261, in run plugin = plugins.construct_plugin( ^^^^^^^^^^^^^^^^^^^^^^^^^ File "/src/volatility3/volatility3/framework/plugins/_init.py", line 62, in construct_plugin constructed = plugin( ^^^^^^^ TypeError: Threads.init_() got an unexpected keyword argument 'progress_callback'```

After a little debug I discovered that threads was the incriminated subplugin and it was missing additional parameters in __init__