### PR TITLE
[Core, plugin] : Virtual mappings dumping and caching

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -19,6 +19,8 @@ import os
 import sys
 import tempfile
 import traceback
+import hashlib
+import lzma
 from typing import Any, Dict, List, Tuple, Type, Union
 from urllib import parse, request
 
@@ -45,6 +47,7 @@ from volatility3.framework import (
 )
 from volatility3.framework.automagic import stacker
 from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces.configuration import path_join
 
 # Make sure we log everything
 
@@ -247,7 +250,12 @@ class CommandLine:
             default=[],
             action="append",
         )
-
+        parser.add_argument(
+            "--virtmap-cache-path",
+            help="Path to the virtmap cache file, typically produced by the virtmapscanner plugin.",
+            default=None,
+            type=str,
+        )
         parser.set_defaults(**default_config)
 
         # We have to filter out help, otherwise parse_known_args will trigger the help message before having
@@ -398,6 +406,47 @@ class CommandLine:
                     plugin_config_path,
                     interfaces.configuration.HierarchicalDict(json_val),
                 )
+        if args.virtmap_cache_path:
+            with open(args.virtmap_cache_path, "rb") as f:
+                virtmap_cache_content = f.read()
+
+            virtmap_metadata_filename = os.path.join(
+                constants.CACHE_PATH,
+                "data_" + hashlib.sha512(virtmap_cache_content).hexdigest() + ".cache",
+            )
+            if os.path.exists(virtmap_metadata_filename):
+                with open(virtmap_metadata_filename, "r") as f:
+                    map_metadata = json.loads(f.read())
+                layers_classes = map_metadata["layers_classes"]
+                sections_per_layer = map_metadata["sections_per_layer"]
+            else:
+                vollog.debug("Saving virtmap cache file metadata to Volatility3 cache")
+                raw_json = lzma.decompress(virtmap_cache_content)
+                json_val: dict = json.loads(raw_json)
+                layers_classes = list(json_val.keys())
+
+                sections_per_layer = {}
+                for layer_class, sections in json_val.items():
+                    sections_per_layer[layer_class] = list(sections.keys())
+
+                # Save metadata in the Vol3 cache, to avoid the costly
+                # decompression and deserialization process on each run.
+                with open(virtmap_metadata_filename, "w+") as f:
+                    json.dump(
+                        {
+                            "layers_classes": list(json_val.keys()),
+                            "sections_per_layer": sections_per_layer,
+                        },
+                        f,
+                    )
+
+            ctx.config[path_join("virtmap_cache", "filepath")] = args.virtmap_cache_path
+            ctx.config[path_join("virtmap_cache", "layers_classes")] = layers_classes
+            ctx.config.splice(
+                path_join("virtmap_cache", "sections_per_layer"),
+                interfaces.configuration.HierarchicalDict(sections_per_layer),
+            )
+            vollog.log(constants.LOGLEVEL_VV, "Successfully loaded virtmap cache file")
 
         # It should be up to the UI to determine which automagics to run, so this is before BACK TO THE FRAMEWORK
         automagics = automagic.choose_automagic(automagics, plugin)
@@ -451,7 +500,7 @@ class CommandLine:
                 )
                 args.save_config = "config.json"
             if args.save_config:
-                vollog.debug("Writing out configuration data to {args.save_config}")
+                vollog.debug(f"Writing out configuration data to {args.save_config}")
                 if os.path.exists(os.path.abspath(args.save_config)):
                     parser.error(
                         f"Cannot write configuration: file {args.save_config} already exists"

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -417,31 +417,33 @@ class CommandLine:
             if os.path.exists(virtmap_metadata_filename):
                 with open(virtmap_metadata_filename, "r") as f:
                     map_metadata = json.loads(f.read())
-                layers_classes = map_metadata["layers_classes"]
+                layers_identifiers = map_metadata["layers_identifiers"]
                 sections_per_layer = map_metadata["sections_per_layer"]
             else:
                 vollog.debug("Saving virtmap cache file metadata to Volatility3 cache")
                 raw_json = lzma.decompress(virtmap_cache_content)
                 json_val: dict = json.loads(raw_json)
-                layers_classes = list(json_val.keys())
+                layers_identifiers = list(json_val.keys())
 
                 sections_per_layer = {}
-                for layer_class, sections in json_val.items():
-                    sections_per_layer[layer_class] = list(sections.keys())
+                for layer_identifier, sections in json_val.items():
+                    sections_per_layer[layer_identifier] = list(sections.keys())
 
                 # Save metadata in the Vol3 cache, to avoid the costly
                 # decompression and deserialization process on each run.
                 with open(virtmap_metadata_filename, "w+") as f:
                     json.dump(
                         {
-                            "layers_classes": list(json_val.keys()),
+                            "layers_identifiers": list(json_val.keys()),
                             "sections_per_layer": sections_per_layer,
                         },
                         f,
                     )
 
             ctx.config[path_join("virtmap_cache", "filepath")] = args.virtmap_cache_path
-            ctx.config[path_join("virtmap_cache", "layers_classes")] = layers_classes
+            ctx.config[path_join("virtmap_cache", "layers_identifiers")] = (
+                layers_identifiers
+            )
             ctx.config.splice(
                 path_join("virtmap_cache", "sections_per_layer"),
                 interfaces.configuration.HierarchicalDict(sections_per_layer),

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -482,23 +482,21 @@ class TranslationLayerInterface(DataLayerInterface, metaclass=ABCMeta):
             A list containing mappings for a specific section of this layer"""
 
         # Check if layer is fully constructed first
-        if self.config.get("class") and self.context.config.get(
+        if self.context.config.get(
             path_join("virtmap_cache", "filepath")
-        ):
+        ) and self.config.get("class"):
             filepath = self.context.config[path_join("virtmap_cache", "filepath")]
-            layers_classes = self.context.config[
-                path_join("virtmap_cache", "layers_classes")
+            layer_identifier = path_join(self.config["class"], self.name)
+            layers_identifiers = self.context.config[
+                path_join("virtmap_cache", "layers_identifiers")
             ]
-
-            # Exact match only, even if a requested section would *fit*
+            # Exact section match only, even if a requested section would *fit*
             # inside one available in the cache.
             if (
-                self.config["class"] in layers_classes
+                layer_identifier in layers_identifiers
                 and str(section)
                 in self.context.config[
-                    path_join(
-                        "virtmap_cache", "sections_per_layer", self.config["class"]
-                    )
+                    path_join("virtmap_cache", "sections_per_layer", layer_identifier)
                 ]
             ):
                 # Avoid decompressing and deserializing the file
@@ -511,9 +509,9 @@ class TranslationLayerInterface(DataLayerInterface, metaclass=ABCMeta):
 
                 vollog.log(
                     constants.LOGLEVEL_VVV,
-                    f"Applying virtmap cache to section {section} of layer {self.config['class']}",
+                    f'Applying virtmap cache to section "{section}" of layer "{layer_identifier}"',
                 )
-                return self._virtmap_cache_dict[self.config["class"]][str(section)]
+                return self._virtmap_cache_dict[layer_identifier][str(section)]
         return None
 
     @functools.lru_cache(maxsize=512)

--- a/volatility3/framework/plugins/windows/virtmapscanner.py
+++ b/volatility3/framework/plugins/windows/virtmapscanner.py
@@ -6,18 +6,20 @@ import logging
 import functools
 import json
 import lzma
+import traceback
 
-from typing import Iterable, Type, Tuple
-from volatility3.framework import renderers, interfaces
+from typing import Iterable, Type, Tuple, Dict
+from volatility3.framework import renderers, interfaces, constants, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.layers.scanners import BytesScanner
-
+from volatility3.framework.interfaces.configuration import path_join
+from volatility3.plugins.windows import pslist
 
 vollog = logging.getLogger(__name__)
 
 
 class VirtMapScanner(interfaces.plugins.PluginInterface):
-    """Scans the entire kernel virtual memory space, and dumps its content to the disk. Allows to speed-up mapping operations afterwards, by specifying the output file as an argument to --virtmap-cache-path."""
+    """Scans by default the entire kernel virtual memory space, and dumps its content to the disk. Allows to speed-up mapping operations afterwards, by specifying the output file as an argument to --virtmap-cache-path."""
 
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)
@@ -30,30 +32,24 @@ class VirtMapScanner(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.BooleanRequirement(
+                name="scan-processes",
+                description="Scan each process address space",
+                default=False,
+                optional=True,
+            ),
         ]
 
     @classmethod
     def virtmap_cache_file_producer(
         cls,
-        sections: Iterable[Tuple[int, int]],
-        layer: interfaces.layers.DataLayerInterface,
+        results: dict,
         open_method: Type[interfaces.plugins.FileHandlerInterface],
+        filename: str = "virtmapcache.json.xz",
     ):
-        results = {}
-        for section in sections:
-            scan_iterator = functools.partial(
-                layer._scan_iterator, BytesScanner(""), [section]
-            )
-            scan_values = list(scan_iterator())
-            results[str(section)] = scan_values
-
-        results = {layer.config["class"]: results}
-
-        # Prefer a simpler filename for convenience when passing as an argument
-        # Leave the task of distinguishing between multiple virtmapcache files to the user
-        # formatted_sections = "_".join([f"{hex(s[0])}-{hex(s[0] + s[1])}" for s in sections])
-        # filename = f"virtmapcache_{layer.name}_{formatted_sections}.json.xz"
-        filename = "virtmapcache.json.xz"
         file_handle = open_method(filename)
         json_data = json.dumps(results).encode()
         xz_data = lzma.compress(json_data)
@@ -62,29 +58,114 @@ class VirtMapScanner(interfaces.plugins.PluginInterface):
 
         return file_handle.preferred_filename
 
+    @classmethod
+    def virtmap_cache_scanner(
+        cls,
+        layer: interfaces.layers.DataLayerInterface,
+        sections: Iterable[Tuple[int, int]],
+        progress_callback: constants.ProgressCallback = None,
+    ):
+        layer_results = {}
+        scanner = BytesScanner("")
+        for section in sections:
+            scan_iterator = functools.partial(layer._scan_iterator, scanner, [section])
+            scan_metric = layer._scan_metric(scanner, [section])
+            scan_values = []
+            try:
+                for value in scan_iterator():
+                    scan_values.append(value)
+                    if progress_callback:
+                        progress_callback(
+                            scan_metric(value[1]),
+                            f"Scanning {layer.name} using {scanner.__class__.__name__}",
+                        )
+            except Exception as e:
+                vollog.debug(f"Scan Failure: {str(e)}")
+                vollog.log(
+                    constants.LOGLEVEL_VVV,
+                    "\n".join(
+                        traceback.TracebackException.from_exception(e).format(
+                            chain=True
+                        )
+                    ),
+                )
+
+            layer_results[str(section)] = scan_values
+
+        return layer_results
+
+    @classmethod
+    def virtmap_cache_producer(
+        cls,
+        layers_sections: Dict[
+            interfaces.layers.DataLayerInterface, Iterable[Tuple[int, int]]
+        ],
+        progress_callback: constants.ProgressCallback = None,
+    ):
+        layers_results = {}
+
+        for layer, sections in layers_sections.items():
+            layer_results = cls.virtmap_cache_scanner(
+                layer, sections, progress_callback
+            )
+            # Clearly identify this layer, by concatenating the layer class and the layer name
+            layer_identifier = path_join(layer.config["class"], layer.name)
+            layers_results[layer_identifier] = layer_results
+
+        return layers_results
+
     def _generator(self):
         kernel = self.context.modules[self.config["kernel"]]
         kernel_layer = self.context.layers[kernel.layer_name]
-        sections = [
+        layers_sections = {}
+        layers_sections[kernel_layer] = [
             (
                 kernel_layer.minimum_address,
                 kernel_layer.maximum_address - kernel_layer.minimum_address,
             )
         ]
+        if self.config["scan-processes"]:
+            for proc in pslist.PsList.list_processes(
+                context=self.context,
+                layer_name=kernel.layer_name,
+                symbol_table=kernel.symbol_table_name,
+            ):
+                proc_id = "Unknown"
+                try:
+                    proc_id = proc.UniqueProcessId
+                    proc_layer_name = proc.add_process_layer()
+                except exceptions.InvalidAddressException as excp:
+                    vollog.debug(
+                        "Process {}: invalid address {} in layer {}".format(
+                            proc_id, excp.invalid_address, excp.layer_name
+                        )
+                    )
+                    continue
+
+                proc_layer = self.context.layers[proc_layer_name]
+                layers_sections[proc_layer] = [
+                    (
+                        proc_layer.minimum_address,
+                        proc_layer.maximum_address - proc_layer.minimum_address,
+                    )
+                ]
+
+        layers_results = self.virtmap_cache_producer(
+            layers_sections, self._progress_callback
+        )
+        virtmapcache_filename = self.virtmap_cache_file_producer(
+            layers_results, self.open
+        )
 
         res = (
             0,
-            (
-                str(sections),
-                self.virtmap_cache_file_producer(sections, kernel_layer, self.open),
-            ),
+            (virtmapcache_filename,),
         )
         yield res
 
     def run(self):
         return renderers.TreeGrid(
             [
-                ("Sections", str),
                 ("Virtual mappings cache file output", str),
             ],
             self._generator(),

--- a/volatility3/framework/plugins/windows/virtmapscanner.py
+++ b/volatility3/framework/plugins/windows/virtmapscanner.py
@@ -1,0 +1,91 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import functools
+import json
+import lzma
+
+from typing import Iterable, Type, Tuple
+from volatility3.framework import renderers, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.layers.scanners import BytesScanner
+
+
+vollog = logging.getLogger(__name__)
+
+
+class VirtMapScanner(interfaces.plugins.PluginInterface):
+    """Scans the entire kernel virtual memory space, and dumps its content to the disk. Allows to speed-up mapping operations afterwards, by specifying the output file as an argument to --virtmap-cache-path."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+        ]
+
+    @classmethod
+    def virtmap_cache_file_producer(
+        cls,
+        sections: Iterable[Tuple[int, int]],
+        layer: interfaces.layers.DataLayerInterface,
+        open_method: Type[interfaces.plugins.FileHandlerInterface],
+    ):
+        results = {}
+        for section in sections:
+            scan_iterator = functools.partial(
+                layer._scan_iterator, BytesScanner(""), [section]
+            )
+            scan_values = list(scan_iterator())
+            results[str(section)] = scan_values
+
+        results = {layer.config["class"]: results}
+
+        # Prefer a simpler filename for convenience when passing as an argument
+        # Leave the task of distinguishing between multiple virtmapcache files to the user
+        # formatted_sections = "_".join([f"{hex(s[0])}-{hex(s[0] + s[1])}" for s in sections])
+        # filename = f"virtmapcache_{layer.name}_{formatted_sections}.json.xz"
+        filename = "virtmapcache.json.xz"
+        file_handle = open_method(filename)
+        json_data = json.dumps(results).encode()
+        xz_data = lzma.compress(json_data)
+        file_handle.write(xz_data)
+        file_handle.close()
+
+        return file_handle.preferred_filename
+
+    def _generator(self):
+        kernel = self.context.modules[self.config["kernel"]]
+        kernel_layer = self.context.layers[kernel.layer_name]
+        sections = [
+            (
+                kernel_layer.minimum_address,
+                kernel_layer.maximum_address - kernel_layer.minimum_address,
+            )
+        ]
+
+        res = (
+            0,
+            (
+                str(sections),
+                self.virtmap_cache_file_producer(sections, kernel_layer, self.open),
+            ),
+        )
+        yield res
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Sections", str),
+                ("Virtual mappings cache file output", str),
+            ],
+            self._generator(),
+        )


### PR DESCRIPTION
Hi 👋,

Following an observation made while investigating WIndowsAArch64 (https://github.com/volatilityfoundation/volatility3/issues/161#issuecomment-2284556649), I noticed that multiple plugins were scanning and physically mapping the entire virtual address space : 

https://github.com/volatilityfoundation/volatility3/blob/6b739f6f6cff04021004ef16d21b522eae7a9d07/volatility3/framework/interfaces/layers.py#L235-L238

to later do bytes searching on the virtual (kernel) layer directly. However, on large memory samples, or heavily populated address spaces, this process takes quite some time, and needs to be reproduced on each plugin run. 

As the input (the section to scan) and output (the virtual->physical mappings) are constant **for a unique memory sample**, there is no need to reproduce the calculations.

---

This PR introduces a new plugin `windows.virtmapscanner` and a new framework argument `--virtmap-cache-path`. Here is a demo : 

- Classical `windows.filescan` run : 

```
time vol3.py -f memory_layer.raw -c conf.json windows.filescan > /dev/null 
Formatting...0.00               PDB scanning finished                  
0,02s user 0,04s system 0% cpu 4:52,12 total
```

- Generate the virtual mappings cache with `windows.virtmapscanner`, and save it to a file : 

```
# This command can be run once when first analyzing a memory sample
time vol3.py -f memory_layer.raw --save-config conf.json -o virtmapcache_dir/ windows.virtmapscanner
Formatting...0.00               PDB scanning finished                        
Volatility 3 Framework 2.8.0
  |                                 Sections | Virtual mappings cache file output
* | [(18446673704965373952, 70368744177663)] |             virtmapcache.json.xz
0,00s user 0,05s system 0% cpu 5:17,29 total
```


- Run the `windows.filescan` plugin, providing the framework with the virtual mappings cache filepath : 

```
time vol3.py -f memory_layer.raw -c conf.json --virtmap-cache-path virtmapcache_dir/virtmapcache.json.xz windows.filescan > /dev/null
Formatting...0.00               PDB scanning finished                  
0,00s user 0,03s system 0% cpu 1:54,60 total
```

The time spent running `windows.virtmap` is already profitable ! This does not only applies to the `windows.filescan` plugins, but any that does an entire virtual layer scanning (`windows.netscan`, `windows.threads` ...). 

I'll be glad to hear your thoughts, and improvements, about this idea ! 

---

Notes : 

- The `volshell` integration hasn't been done yet
- This applies to Linux too, the Linux plugin code should be 99% the same