### PR TITLE
Linux: Add support for the mount namespace in kernels 6.8+

### DIFF
--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -425,3 +425,36 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         kernel = context.modules[kernel_module_name]
 
         return kernel
+
+
+class RBTree(object):
+    """Simple Red-Black tree abstraction"""
+
+    def __init__(self, root):
+        self.root = root
+
+    def _walk_nodes(self, root_node) -> Iterator[int]:
+        """Traverses the Red-Black tree from the root node and yields a pointer to each
+        node in this tree.
+
+        Args:
+            root_node: A Red-Black tree node from which to start descending
+
+        Yields:
+            A pointer to every node descending from the specified root node
+        """
+        if not root_node:
+            return
+
+        yield root_node
+        yield from self._walk_nodes(root_node.rb_left)
+        yield from self._walk_nodes(root_node.rb_right)
+
+    def get_nodes(self) -> Iterator[int]:
+        """Yields a pointer to each node in the Red-Black tree
+
+        Yields:
+            A pointer to every node in the Red-Black tree
+        """
+
+        yield from self._walk_nodes(root_node=self.root.rb_node)

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -46,6 +46,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         # Might not exist in older kernels or the current symbols
         self.optional_set_type_class("mount", extensions.mount)
         self.optional_set_type_class("mnt_namespace", extensions.mnt_namespace)
+        self.optional_set_type_class("rb_root", extensions.rb_root)
 
         # Network
         self.set_type_class("net", extensions.net)
@@ -425,36 +426,3 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         kernel = context.modules[kernel_module_name]
 
         return kernel
-
-
-class RBTree(object):
-    """Simple Red-Black tree abstraction"""
-
-    def __init__(self, root):
-        self.root = root
-
-    def _walk_nodes(self, root_node) -> Iterator[int]:
-        """Traverses the Red-Black tree from the root node and yields a pointer to each
-        node in this tree.
-
-        Args:
-            root_node: A Red-Black tree node from which to start descending
-
-        Yields:
-            A pointer to every node descending from the specified root node
-        """
-        if not root_node:
-            return
-
-        yield root_node
-        yield from self._walk_nodes(root_node.rb_left)
-        yield from self._walk_nodes(root_node.rb_right)
-
-    def get_nodes(self) -> Iterator[int]:
-        """Yields a pointer to each node in the Red-Black tree
-
-        Yields:
-            A pointer to every node in the Red-Black tree
-        """
-
-        yield from self._walk_nodes(root_node=self.root.rb_node)

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1326,7 +1326,7 @@ class mnt_namespace(objects.StructType):
             vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(
                 self._context, self
             )
-            for node in linux.RBTree(self.mounts).get_nodes():
+            for node in self.mounts.get_nodes():
                 mnt = linux.LinuxUtilities.container_of(
                     node, "mount", "mnt_list", vmlinux
                 )
@@ -1925,3 +1925,31 @@ class inode(objects.StructType):
             The inode's file mode string
         """
         return stat.filemode(self.i_mode)
+
+
+class rb_root(objects.StructType):
+    def _walk_nodes(self, root_node) -> Iterator[int]:
+        """Traverses the Red-Black tree from the root node and yields a pointer to each
+        node in this tree.
+
+        Args:
+            root_node: A Red-Black tree node from which to start descending
+
+        Yields:
+            A pointer to every node descending from the specified root node
+        """
+        if not root_node:
+            return
+
+        yield root_node
+        yield from self._walk_nodes(root_node.rb_left)
+        yield from self._walk_nodes(root_node.rb_right)
+
+    def get_nodes(self) -> Iterator[int]:
+        """Yields a pointer to each node in the Red-Black tree
+
+        Yields:
+            A pointer to every node in the Red-Black tree
+        """
+
+        yield from self._walk_nodes(root_node=self.rb_node)


### PR DESCRIPTION
In the context of volatilityfoundation/volatility3#1187, this PR adds support for the mount namespace in kernels 6.8+. A basic Red-Black tree abstraction was also introduced to enable reuse in other parts of the framework if necessary.

```shell
./vol.py -f ./ubuntu_2410_x86-64_6.8.0-31.core linux.mountinfo.MountInfo 
Volatility 3 Framework 2.8.0
Progress:  100.00               Stacking attempts finished                  
MNT_NS_ID       MOUNT ID        PARENT_ID       MAJOR:MINOR     ROOT    MOUNT_POINT     MOUNT_OPTIONS   FIELDS  FSTYPE  MOUNT_SRC       SB_OPTIONS

4026531841      55      25      0:7     /       /sys/kernel/debug       rw,nosuid,nodev,noexec,relatime shared:15       debugfs debugfs rw
4026531841      31      25      0:6     /       /sys/kernel/security    rw,nosuid,nodev,noexec,relatime shared:7        securityfs      securityfs  rw
4026531841      27      30      0:5     /       /dev    rw,nosuid,relatime      shared:2        devtmpfs        udev    rw
4026531841      25      30      0:23    /       /sys    rw,nosuid,nodev,noexec,relatime shared:6        sysfs   sysfs   rw
4026531841      1       1       0:2     /       /       rw              rootfs  rootfs  rw
...
```