### PR TITLE
Pointers smear memory protection

### DIFF
--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -445,6 +445,16 @@ class Pointer(Integer):
         layer_name = layer_name or self.vol.native_layer_name
         return self._context.layers[layer_name].is_valid(self, self.vol.subtype.size)
 
+    def __bool__(self):
+        """Enables checking if a pointer is valid in its memory layer when its evaluated
+        in a boolean context, for instance:
+            if not ptr:
+                continue
+        Without this method, the code above will only abort if 'ptr = 0', leaving the
+        code vulnerable to smear memory.
+        """
+        return self.is_readable()
+
     def __getattr__(self, attr: str) -> Any:
         """Convenience function to access unknown attributes by getting them
         from the subtype object."""


### PR DESCRIPTION
## Context
When working on [Linux Page Cache and IDR](https://github.com/volatilityfoundation/volatility3/pull/1233) I realized that Volatility3 doesn't really check if a pointer is valid when doing something like:
```python
if not ptr:
    continue
```
What that actually does is check if `ptr != 0`. 

For instance, when the pointer is zero:
```python
>>> type(inode)
<class 'volatility3.framework.objects.Pointer'>

>>> inode
0

>>> inode or True
True
```
As shown above, in those cases, it works as expected: `inode` evaluates to `False`, and `True` is returned due to the `or` statement.

However, when smear memory happens, the above code will not abort, potentially leading to a crash or incorrect behavior.
```python
>>> type(inode)
<class 'volatility3.framework.objects.Pointer'>

>>> inode
29810

>>> inode or True
29810
```
The above means that **inode** evaluated to `True` and the `or True` wasn't executed.

## Volatility3 code assesment
From analyzing the Volatility3 source code, the following three cases were identified:
1. Volatility3 pointers don't have a `is_valid()` method as in Volatility2. It does have an `is_readable()` method, however, it's used in only a few places, and it requires the developer to be aware of this method, something that doesn't seem to be the case for most of us.

1. Developers who are unaware of the `is_readable()` method are using `layer.is_valid(ptr.vol.offset, ptr.vol.size)` or simply `layer.is_valid(ptr.vol.offset)` instead to verify pointers. However, this requires first obtaining the respective layer, and since it is not used widely, it is likely unknown to most developers.

1. Finally, the remaining developers are assuming and trusting that with simply doing the following will be enough. This applies to most cases in the Volatility3 source code:
```python
if not ptr:
    continue
``` 

## Benefits of this Pull Request
This PR takes advantage of the [Python3's built-in object truth value testing](https://docs.python.org/3/reference/datamodel.html#object.__bool__) to verify a pointer has a valid address in its memory layer.
This will provide immediate benefits to those using the source code in (3) and will allow to simplify the source code in (1), (2) and future implementations. 
Refer to 305eedab10b2522d9659c6a4823fb5d7a8575db9 to see how the changes in this PR can benefit the framework.


