### PR TITLE
Bump the modules version number

### DIFF
--- a/volatility3/framework/plugins/windows/ssdt.py
+++ b/volatility3/framework/plugins/windows/ssdt.py
@@ -30,7 +30,7 @@ class SSDT(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="modules", plugin=modules.Modules, version=(1, 0, 0)
+                name="modules", plugin=modules.Modules, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/verinfo.py
+++ b/volatility3/framework/plugins/windows/verinfo.py
@@ -46,7 +46,7 @@ class VerInfo(interfaces.plugins.PluginInterface):
                 name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
             ),
             requirements.PluginRequirement(
-                name="modules", plugin=modules.Modules, version=(1, 0, 0)
+                name="modules", plugin=modules.Modules, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="dlllist", component=dlllist.DllList, version=(2, 0, 0)


### PR DESCRIPTION
Pull-request #1173 bumped the version of the modules plugin (even though this only needed to be a MINOR version bump, see [here](https://github.com/volatilityfoundation/volatility3/pull/1173#discussion_r1649614761) ), but failed to verify that other plugins which relied on it were also updated to make use of the new plugin.  This was the version system working as intended, but highlighted a review failure that the neither the author, nor the reviewers, verified that the rest of the framework (specifically other plugins which relied on modules) worked correctly with the new code (which this kind of error is designed to fix).

Fixes #1244.