### PR TITLE
[core, constants] : add OS and framework supported architectures

### DIFF
--- a/volatility3/framework/constants/architectures.py
+++ b/volatility3/framework/constants/architectures.py
@@ -1,0 +1,21 @@
+from volatility3.framework.layers import intel
+
+WIN_ARCHS = ["Intel32", "Intel64"]
+"""Windows supported architectures"""
+WIN_ARCHS_LAYERS = [intel.Intel]
+"""Windows supported architectures layers"""
+
+LINUX_ARCHS = ["Intel32", "Intel64"]
+"""Linux supported architectures"""
+LINUX_ARCHS_LAYERS = [intel.Intel]
+"""Linux supported architectures layers"""
+
+MAC_ARCHS = ["Intel32", "Intel64"]
+"""Mac supported architectures"""
+MAC_ARCHS_LAYERS = [intel.Intel]
+"""Mac supported architectures layers"""
+
+FRAMEWORK_ARCHS = ["Intel32", "Intel64"]
+"""Framework supported architectures"""
+FRAMEWORK_ARCHS_LAYERS = [intel.Intel]
+"""Framework supported architectures layers"""


### PR DESCRIPTION
Hi, 

To increase general scalability, in the multi-architectures handling task, I would like to propose a way to unify and remove "string hardcoded" values all around the framework. Indeed, if a new architecture is added, most of the plugins will need to be updated to support this new layer. If there are a few cases where a plugin would work on Intel but not an AArch64 (although I do not see right now any reason), the plugin could still use a custom set of supported architectures.

With this PR, the plugins could later be updated from :

https://github.com/volatilityfoundation/volatility3/blob/517f46e833648d1232b410436e53e07da429d6f5/volatility3/framework/plugins/windows/pslist.py#L33

to : 

```python
architectures=WINDOWS_ARCHS,
```

When a new (CPU) architecture is implemented, this should allow to reduce the amount of small changes in each plugin, and unify everything.

---

This is also a starting point to resolve the hardcoded `intel.Intel` checks, which are in fact `CPU layers` checks.

Going from : https://github.com/volatilityfoundation/volatility3/blob/517f46e833648d1232b410436e53e07da429d6f5/volatility3/framework/automagic/linux.py#L44-L47 to :

```python
# This "check" can also be put in an global utility
if any([isinstance(layer, l) for l in LINUX_ARCHS_LAYERS]): 
   return None 
```
or equivalent. This can be applied easily inside plugins checks.

ps : For this automagic bit, it can be a bit trickier when virtual CPU layers stacking occurs, as discussed here : https://github.com/volatilityfoundation/volatility3/pull/1088#discussion_r1471104621. 

---

I created a new file, as inserting the code in `constants.py` resulted in circular imports. 

Thanks by advance for the reviews :)