### PR TITLE
CLI: Filter on rendered values

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -180,8 +180,7 @@ class QuickTextRenderer(CLIRenderer):
 
         def visitor(node: interfaces.renderers.TreeNode, accumulator):
             line = []
-            for column_index in range(len(grid.columns)):
-                column = grid.columns[column_index]
+            for column_index, column in enumerate(grid.columns):
                 renderer = self._type_renderers.get(
                     column.type, self._type_renderers["default"]
                 )
@@ -261,8 +260,7 @@ class CSVRenderer(CLIRenderer):
             # Nodes always have a path value, giving them a path_depth of at least 1, we use max just in case
             row = {"TreeDepth": str(max(0, node.path_depth - 1))}
             line = []
-            for column_index in range(len(grid.columns)):
-                column = grid.columns[column_index]
+            for column_index, column in enumerate(grid.columns):
                 renderer = self._type_renderers.get(
                     column.type, self._type_renderers["default"]
                 )
@@ -326,8 +324,7 @@ class PrettyTextRenderer(CLIRenderer):
 
             line = {}
             rendered_line = []
-            for column_index in range(len(grid.columns)):
-                column = grid.columns[column_index]
+            for column_index, column in enumerate(grid.columns):
                 renderer = self._type_renderers.get(
                     column.type, self._type_renderers["default"]
                 )
@@ -357,8 +354,7 @@ class PrettyTextRenderer(CLIRenderer):
         format_string_list = [
             "{0:<" + str(max_column_widths.get(tree_indent_column, 0)) + "s}"
         ]
-        for column_index in range(len(grid.columns)):
-            column = grid.columns[column_index]
+        for column_index, column in enumerate(grid.columns):
             format_string_list.append(
                 "{"
                 + str(column_index + 1)
@@ -448,8 +444,7 @@ class JsonRenderer(CLIRenderer):
             acc_map, final_tree = accumulator
             node_dict: Dict[str, Any] = {"__children": []}
             line = []
-            for column_index in range(len(grid.columns)):
-                column = grid.columns[column_index]
+            for column_index, column in enumerate(grid.columns):
                 renderer = self._type_renderers.get(
                     column.type, self._type_renderers["default"]
                 )

--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -179,7 +179,15 @@ class QuickTextRenderer(CLIRenderer):
         outfd.write("\n{}\n".format("\t".join(line)))
 
         def visitor(node: interfaces.renderers.TreeNode, accumulator):
-            if self.filter and self.filter.filter(node.values):
+            line = []
+            for column_index in range(len(grid.columns)):
+                column = grid.columns[column_index]
+                renderer = self._type_renderers.get(
+                    column.type, self._type_renderers["default"]
+                )
+                line.append(renderer(node.values[column_index]))
+
+            if self.filter and self.filter.filter(line):
                 return accumulator
 
             accumulator.write("\n")
@@ -188,13 +196,6 @@ class QuickTextRenderer(CLIRenderer):
                 "*" * max(0, node.path_depth - 1)
                 + ("" if (node.path_depth <= 1) else " ")
             )
-            line = []
-            for column_index in range(len(grid.columns)):
-                column = grid.columns[column_index]
-                renderer = self._type_renderers.get(
-                    column.type, self._type_renderers["default"]
-                )
-                line.append(renderer(node.values[column_index]))
             accumulator.write("{}".format("\t".join(line)))
             accumulator.flush()
             return accumulator
@@ -259,12 +260,18 @@ class CSVRenderer(CLIRenderer):
         def visitor(node: interfaces.renderers.TreeNode, accumulator):
             # Nodes always have a path value, giving them a path_depth of at least 1, we use max just in case
             row = {"TreeDepth": str(max(0, node.path_depth - 1))}
+            line = []
             for column_index in range(len(grid.columns)):
                 column = grid.columns[column_index]
                 renderer = self._type_renderers.get(
                     column.type, self._type_renderers["default"]
                 )
                 row[f"{column.name}"] = renderer(node.values[column_index])
+                line.append(row[f"{column.name}"])
+
+            if self.filter and self.filter.filter(line):
+                return accumulator
+
             accumulator.writerow(row)
             return accumulator
 
@@ -317,10 +324,8 @@ class PrettyTextRenderer(CLIRenderer):
                 max_column_widths.get(tree_indent_column, 0), node.path_depth
             )
 
-            if self.filter and self.filter.filter(node.values):
-                return accumulator
-
             line = {}
+            rendered_line = []
             for column_index in range(len(grid.columns)):
                 column = grid.columns[column_index]
                 renderer = self._type_renderers.get(
@@ -334,6 +339,11 @@ class PrettyTextRenderer(CLIRenderer):
                     max_column_widths.get(column.name, len(column.name)), field_width
                 )
                 line[column] = data.split("\n")
+                rendered_line.append(data)
+
+            if self.filter and self.filter.filter(rendered_line):
+                return accumulator
+
             accumulator.append((node.path_depth, line))
             return accumulator
 
@@ -437,6 +447,7 @@ class JsonRenderer(CLIRenderer):
             # Nodes always have a path value, giving them a path_depth of at least 1, we use max just in case
             acc_map, final_tree = accumulator
             node_dict: Dict[str, Any] = {"__children": []}
+            line = []
             for column_index in range(len(grid.columns)):
                 column = grid.columns[column_index]
                 renderer = self._type_renderers.get(
@@ -446,6 +457,11 @@ class JsonRenderer(CLIRenderer):
                 if isinstance(data, interfaces.renderers.BaseAbsentValue):
                     data = None
                 node_dict[column.name] = data
+                line.append(data)
+
+            if self.filter and self.filter.filter(line):
+                return accumulator
+
             if node.parent:
                 acc_map[node.parent.path]["__children"].append(node_dict)
             else:

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 9  # Number of changes that only add to the interface
+VERSION_MINOR = 10  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 


### PR DESCRIPTION
This now filters JSON, JSONL and CSV as well as quick and pretty rendering.  The filtering is now carried out on the rendered values, this will allow a rudimentary filtering on AbsentValues but will require knowing how the specific absent values will be rendered into text.  It will also *no longer* allow filtering of values that are displayed as hex by using the integer value.

This also kinda needs us to bump a version number so we can tell if people are using a different version with filtering or not.  It could probably have been a patch version, but I think people would better understand the CLI changing syntax/behaviour with a MINOR bump at least.

Fixes #1252 