### PR TITLE
Core: Verify plugin requirements of plugins

### DIFF
--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -585,6 +585,24 @@ class PluginRequirement(VersionRequirement):
             version=version,
         )
 
+    def unsatisfied(
+        self, context: interfaces.context.ContextInterface, config_path: str
+    ) -> Dict[str, interfaces.configuration.RequirementInterface]:
+        result = super().unsatisfied(context, config_path)
+        if not result:
+            component: Type[interfaces.plugins.PluginInterface] = self._component
+            for requirement in component.get_requirements():
+                if isinstance(requirement, PluginRequirement):
+                    result.update(
+                        requirement.unsatisfied(
+                            context,
+                            interfaces.configuration.path_join(config_path, self.name),
+                        )
+                    )
+        if result:
+            result[config_path] = self
+        return result
+
 
 class ModuleRequirement(
     interfaces.configuration.ConstructableRequirementInterface,

--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -558,16 +558,20 @@ class VersionRequirement(interfaces.configuration.RequirementInterface):
         if not self.matches_required(self._version, self._component.version):
             return {config_path: self}
 
+        recurse = True
         if accumulator is None:
             accumulator = set([self._component])
         else:
             if self._component in accumulator:
-                return {config_path: self}
+                recurse = False
             else:
                 accumulator.add(self._component)
 
         # Check for child requirements
-        if issubclass(self._component, interfaces.configuration.ConfigurableInterface):
+        if (
+            issubclass(self._component, interfaces.configuration.ConfigurableInterface)
+            and recurse
+        ):
             result = {}
             for requirement in self._component.get_requirements():
                 if not requirement.optional and isinstance(

--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -534,7 +534,7 @@ class VersionRequirement(interfaces.configuration.RequirementInterface):
         version: Optional[Tuple[int, ...]] = None,
     ) -> None:
         if description is None:
-            description = f"Version {".".join([str(x) for x in version])} dependency on {component.__module__}.{component.__name__} unmet"
+            description = f"Version {'.'.join([str(x) for x in version])} dependency on {component.__module__}.{component.__name__} unmet"
         super().__init__(
             name=name, description=description, default=default, optional=optional
         )


### PR DESCRIPTION
Make all VersionRequirements verify any sub-version requirements the versioned components may depend on.

Should be minimal impact other than improving errors that may happen down the line.  Likely to merge in a couple of days unless anyone shouts.