### PR TITLE
Timeliner plugin `plugin-filter` improvements

### DIFF
--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -199,9 +199,10 @@ class Timeliner(interfaces.plugins.PluginInterface):
                                     ),
                                 )
                             )
-            except Exception:
+            except Exception as e:
                 vollog.log(
-                    logging.INFO, f"Exception occurred running plugin: {plugin_name}"
+                    logging.INFO,
+                    f"Exception occurred running plugin: {plugin_name}: {e}",
                 )
                 vollog.log(logging.DEBUG, traceback.format_exc())
 

--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -248,6 +248,7 @@ class Timeliner(interfaces.plugins.PluginInterface):
         # Identify plugins that we can run which output datetimes
         for plugin_class in self.usable_plugins:
             if not issubclass(plugin_class, TimeLinerInterface):
+                # get_usable_plugins() should filter this, but adding a safeguard just in case
                 continue
 
             if filter_list and not any(


### PR DESCRIPTION
The current `Timeliner` plugin implementation, for every class inheriting from `TimeLinerInterface` will do the steps below. Note that it will happen even if the plugin isn't intended for the operating system being analyzed. 
- Evaluates the requirements
- Runs automagic
- Constructs and instantiates the plugin

...before finally checking if that plugin name matches the `plugin-filter` argument.  This is a waste of time when the user just want to execute just one or two plugins.

This PR optimizes the main loop by filtering plugin classes at an earlier stage, significantly reducing execution time.
