### PR TITLE
Linux Page Cache smear memory protection improvements

### DIFF
--- a/volatility3/framework/plugins/linux/mountinfo.py
+++ b/volatility3/framework/plugins/linux/mountinfo.py
@@ -37,7 +37,7 @@ class MountInfo(plugins.PluginInterface):
 
     _required_framework_version = (2, 2, 0)
 
-    _version = (1, 2, 0)
+    _version = (1, 2, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -272,11 +272,16 @@ class MountInfo(plugins.PluginInterface):
                 continue
 
             sb_ptr = mnt.get_mnt_sb()
-            if not sb_ptr or sb_ptr in seen_sb_ptr:
+            if not (sb_ptr and sb_ptr.is_readable()):
+                continue
+
+            if sb_ptr in seen_sb_ptr:
                 continue
             seen_sb_ptr.add(sb_ptr)
 
-            yield sb_ptr.dereference(), path_root
+            superblock = sb_ptr.dereference()
+
+            yield superblock, path_root
 
     def run(self):
         pids = self.config.get("pids")

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -104,7 +104,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -186,8 +186,12 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
             seen_dentries.add(dentry_addr)
 
-            inode = dentry.d_inode
-            if not (inode and inode.is_valid()):
+            inode_ptr = dentry.d_inode
+            if not (inode_ptr and inode_ptr.is_readable()):
+                continue
+
+            inode = inode_ptr.dereference()
+            if not inode.is_valid():
                 continue
 
             # This allows us to have consistent paths
@@ -242,8 +246,9 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
             # More dentry/inode sanity checks
             root_inode_ptr = root_dentry.d_inode
-            if not root_inode_ptr:
+            if not (root_inode_ptr and root_inode_ptr.is_readable()):
                 continue
+
             root_inode = root_inode_ptr.dereference()
             if not root_inode.is_valid():
                 continue
@@ -269,10 +274,12 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             ):
                 if not file_dentry:
                     continue
+
                 # Dentry/inode sanity checks
                 file_inode_ptr = file_dentry.d_inode
-                if not file_inode_ptr:
+                if not (file_inode_ptr and file_inode_ptr.is_readable()):
                     continue
+
                 file_inode = file_inode_ptr.dereference()
                 if not file_inode.is_valid():
                     continue
@@ -382,7 +389,7 @@ class InodePages(plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -482,15 +489,15 @@ class InodePages(plugins.PluginInterface):
             vollog.error("You must use either --inode or --find")
             return
 
+        if not inode.is_valid():
+            vollog.error("Invalid inode at 0x%x", inode.vol.offset)
+            return
+
         if not inode.is_reg:
             vollog.error("The inode is not a regular file")
             return
 
         inode_size = inode.i_size
-        if not inode.is_valid():
-            vollog.error("Invalid inode at 0x%x", self.config["inode"])
-            return
-
         for page_obj in inode.get_pages():
             page_vaddr = page_obj.vol.offset
             page_paddr = page_obj.to_paddr()

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -78,8 +78,8 @@ class InodeInternal:
         cached_pages = int(self.inode.i_mapping.nrpages)
         file_mode = self.inode.get_file_mode()
         access_time_dt = self.inode.get_access_time()
-        modification_time_str = self.inode.get_modification_time()
-        change_time_str = self.inode.get_change_time()
+        modification_time_dt = self.inode.get_modification_time()
+        change_time_dt = self.inode.get_change_time()
 
         inode_user = InodeUser(
             superblock_addr=superblock_addr,
@@ -92,8 +92,8 @@ class InodeInternal:
             cached_pages=cached_pages,
             file_mode=file_mode,
             access_time=access_time_dt,
-            modification_time=modification_time_str,
-            change_time=change_time_str,
+            modification_time=modification_time_dt,
+            change_time=change_time_dt,
             path=self.path,
         )
         return inode_user

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -342,7 +342,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             description = f"Cached Inode for {inode_out.path}"
             yield description, timeliner.TimeLinerType.ACCESSED, inode_out.access_time
             yield description, timeliner.TimeLinerType.MODIFIED, inode_out.modification_time
-            yield description, timeliner.TimeLinerType.CHANGE, inode_out.change_time
+            yield description, timeliner.TimeLinerType.CHANGED, inode_out.change_time
 
     @staticmethod
     def format_fields_with_headers(headers, generator):


### PR DESCRIPTION
In the context of https://github.com/volatilityfoundation/volatility3/pull/1243 this PR improves the smear memory protection for the page cache plugins (`Files` and `InodePages`) and related function in `mountinfo`.
It also fixes a typo in the respective timeliner function.