### PR TITLE
Linux pidhashtable plugin pointer verification improvements

### DIFF
--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -20,7 +20,7 @@ class PIDHashTable(plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -45,9 +45,7 @@ class PIDHashTable(plugins.PluginInterface):
         ]
 
     def _is_valid_task(self, task) -> bool:
-        vmlinux = self.context.modules[self.config["kernel"]]
-        vmlinux_layer = self.context.layers[vmlinux.layer_name]
-        return bool(task and task.pid > 0 and vmlinux_layer.is_valid(task.parent))
+        return bool(task and task.pid > 0 and task.parent.is_readable())
 
     def _get_pidtype_pid(self):
         vmlinux = self.context.modules[self.config["kernel"]]
@@ -96,7 +94,7 @@ class PIDHashTable(plugins.PluginInterface):
             seen_upids.add(upid.vol.offset)
 
             pid_chain = upid.pid_chain
-            if not (pid_chain and vmlinux_layer.is_valid(pid_chain.vol.offset)):
+            if not (pid_chain.next and pid_chain.next.is_readable()):
                 break
 
             upid = linux.LinuxUtilities.container_of(
@@ -105,7 +103,6 @@ class PIDHashTable(plugins.PluginInterface):
 
     def _get_upids(self):
         vmlinux = self.context.modules[self.config["kernel"]]
-        vmlinux_layer = self.context.layers[vmlinux.layer_name]
 
         # 2.6.24 <= kernels < 4.15
         pidhash = self._get_pidhash_array()
@@ -115,7 +112,7 @@ class PIDHashTable(plugins.PluginInterface):
             # each entry in the hlist is a upid which is wrapped in a pid
             ent = hlist.first
 
-            while ent and vmlinux_layer.is_valid(ent.vol.offset):
+            while ent and ent.is_readable():
                 # upid->pid_chain exists 2.6.24 <= kernel < 4.15
                 upid = linux.LinuxUtilities.container_of(
                     ent.vol.offset, "upid", "pid_chain", vmlinux
@@ -143,7 +140,7 @@ class PIDHashTable(plugins.PluginInterface):
                 continue
 
             pid_tasks_0 = pid.tasks[pidtype_pid].first
-            if not pid_tasks_0:
+            if not (pid_tasks_0 and pid_tasks_0.is_readable()):
                 continue
 
             task = vmlinux.object(
@@ -160,7 +157,7 @@ class PIDHashTable(plugins.PluginInterface):
         pidtype_pid = self._get_pidtype_pid()
 
         pid_tasks_0 = pid.tasks[pidtype_pid].first
-        if not pid_tasks_0:
+        if not (pid_tasks_0 and pid_tasks_0.is_readable()):
             return None
 
         task_struct_type = vmlinux.get_type("task_struct")


### PR DESCRIPTION
In the context of https://github.com/volatilityfoundation/volatility3/pull/1243 this PR improves the smear memory protection for the `pidhashtable` plugin.