### PR TITLE
[configuration.py] use default req value in config_value call

### DIFF
--- a/volatility3/framework/interfaces/configuration.py
+++ b/volatility3/framework/interfaces/configuration.py
@@ -494,8 +494,7 @@ class SimpleTypeRequirement(RequirementInterface):
         """Validates the instance requirement based upon its
         `instance_type`."""
         config_path = path_join(config_path, self.name)
-
-        value = self.config_value(context, config_path, None)
+        value = self.config_value(context, config_path, self.default)
         if not isinstance(value, self.instance_type):
             vollog.log(
                 constants.LOGLEVEL_V,
@@ -536,7 +535,7 @@ class ClassRequirement(RequirementInterface):
         """Checks to see if a class can be recovered."""
         config_path = path_join(config_path, self.name)
 
-        value = self.config_value(context, config_path, None)
+        value = self.config_value(context, config_path, self.default)
         self._cls = None
         if value is not None and isinstance(value, str):
             if "." in value:


### PR DESCRIPTION
While running Volatility with `-vvv`, I noticed the following recurring messages :


```sh
DETAIL 1 volatility3.framework.interfaces.configuration: TypeError - layer_debug requirements only accept bool type: None
DETAIL 1 volatility3.framework.interfaces.configuration: TypeError - layer_debug requirements only accept bool type: None
DETAIL 1 volatility3.framework.interfaces.configuration: TypeError - translation_debug requirements only accept bool type: None
DETAIL 1 volatility3.framework.interfaces.configuration: TypeError - translation_debug requirements only accept bool type: None
```

However, the requirement had a default value, but was never used :

```python
            requirements.BooleanRequirement(
                name="layer_debug",
                optional=True,
                description="Specify if debugging informations about the layer should be printed to user.",
                default=False,
            ),
```

This PR fixes the issue, as `self.default` wasn't used anywhere, and is still `None` by default.