### PR TITLE
Fix changes introduced to volatility3.framework.constants in PRs #838

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -134,4 +134,5 @@ def __getattr__(name):
     ]:
         warnings.warn(f"{name} is deprecated", FutureWarning)
         return globals()[f"{deprecated_tag}{name}"]
-    return None
+
+    return getattr(__import__(__name__), name)


### PR DESCRIPTION
Trying to use the changes in #1247 I found that the following works
```python
>>> from volatility3.framework.constants.architectures import LINUX_ARCHS
>>> LINUX_ARCHS
['Intel32', 'Intel64']
```

However, the following fails:
```python
>>> from volatility3.framework.constants import architectures
>>> architectures.LINUX_ARCHS
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'LINUX_ARCHS'
```

Debugging why the import doesn't fail but instead gets a `None`, which is really weird,  I found this happens because the changes introduced to support deprecated constants in PRs #838 in [this](https://github.com/volatilityfoundation/volatility3/pull/838/files#diff-a8170e1c9c246fa23e3508eaae565d24791a0ee22d2c641d93052850ac6343feR133) line.

Completely removing the `__getattr__()` function works as expected.
```python
>>> from volatility3.framework.constants import architectures
>>> architectures.LINUX_ARCHS
['Intel32', 'Intel64']
````

The changes in this PR keep the `__getattr__()` function while still allowing the use of sub-modules of `volatility3.framework.constants`.

```python
>>> from volatility3.framework.constants import architectures
>>> architectures.LINUX_ARCHS
['Intel32', 'Intel64']
````
