### PR TITLE
Windows: change warnings around large memory maps to debug level as per issue #1256

### DIFF
--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -18,7 +18,7 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
     """Scans all the Virtual Address Descriptor memory maps using yara."""
 
     _required_framework_version = (2, 4, 0)
-    _version = (1, 1, 0)
+    _version = (1, 1, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -68,7 +68,7 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
             layer = self.context.layers[layer_name]
             for start, size in self.get_vad_maps(task):
                 if size > sanity_check:
-                    vollog.warn(
+                    vollog.debug(
                         f"VAD at 0x{start:x} over sanity-check size, not scanning"
                     )
                     continue


### PR DESCRIPTION
Hello :wave: 

In issue https://github.com/volatilityfoundation/volatility3/issues/1256 @atcuno wanted to see the warnings in vadyarascan lowered to a debug message. This PR makes just that minor change. 

Note that issue https://github.com/volatilityfoundation/volatility3/issues/1256 also talks about overlapping vads. I'm worried that if this is merged it'll auto close the issue - which shouldn't happen as the other part of the issue is not yet resolved. 

Thanks as always
:fox_face: 