### PR TITLE
Ensure the class for Modules is stored in the configruation

### DIFF
--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -191,6 +191,9 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
                 self._native_layer_name
             ].build_configuration()
 
+        # Modules are constructable, and therefore require a class configuration variable
+        config["class"] = self.__class__.__module__ + "." + self.__class__.__name__
+
         for subconfig in subconfigs:
             for req in subconfigs[subconfig]:
                 config[interfaces.configuration.path_join(subconfig, req)] = subconfigs[


### PR DESCRIPTION
This should ensure that kernel requirements are appropriately rebuilt avoiding the failure of the config file on newer plugins.

Close #1119 

Quite a minor change, if there's no complaints I'll merge this in a couple days.