### PR TITLE
Windows: Callbacks - fixes bad callback validity check

### DIFF
--- a/volatility3/framework/plugins/windows/callbacks.py
+++ b/volatility3/framework/plugins/windows/callbacks.py
@@ -248,8 +248,12 @@ class Callbacks(interfaces.plugins.PluginInterface):
             context, layer_name, nt_symbol_table, constraints
         ):
             try:
-                if hasattr(mem_object, "is_valid") and not mem_object.is_valid():
-                    continue
+                if isinstance(mem_object, callbacks._SHUTDOWN_PACKET):
+                    if not mem_object.is_parseable(type_map):
+                        continue
+                elif hasattr(mem_object, "is_valid"):
+                    if not mem_object.is_valid():
+                        continue
 
                 yield cls._process_scanned_callback(mem_object, type_map)
             except exceptions.InvalidAddressException:


### PR DESCRIPTION
This fixes a bug in the callbacks plugin which causes it to miss `IoRegisterShutdownNotification` callbacks on x86 samples. The `header.NameInfo.Name` field was being incorrectly treated as the device type. This fixes the issue by updating the `is_valid` method on the `_SHUTDOWN_PACKET` extension class to take a `type_map` parameter, and updates the method to correctly validate the object type.

LMK if we need to do a version bump on the callbacks plugin, and if so, what kind. I was unsure because the change to `is_valid`'s method signature is in the callbacks extensions module and not the plugin itself.