### PR TITLE
Windows: Netscan - fix missing TCP connections

### DIFF
--- a/volatility3/framework/plugins/windows/netscan.py
+++ b/volatility3/framework/plugins/windows/netscan.py
@@ -76,7 +76,7 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
         # ~ vollog.debug("Using pool size constraints: TcpL {}, TcpE {}, UdpA {}".format(tcpl_size, tcpe_size, udpa_size))
 
-        return [
+        constraints = [
             # TCP listener
             poolscanner.PoolConstraint(
                 b"TcpL",
@@ -99,6 +99,19 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 page_type=poolscanner.PoolType.NONPAGED | poolscanner.PoolType.FREE,
             ),
         ]
+
+        if symbol_table.startswith("netscan-win10-20348"):
+            vollog.debug("Adding additional pool constraint for `TTcb` tags")
+            constraints.append(
+                poolscanner.PoolConstraint(
+                    b"TTcb",
+                    type_name=symbol_table + constants.BANG + "_TCP_ENDPOINT",
+                    size=(tcpe_size, None),
+                    page_type=poolscanner.PoolType.NONPAGED | poolscanner.PoolType.FREE,
+                )
+            )
+
+        return constraints
 
     @classmethod
     def determine_tcpip_version(


### PR DESCRIPTION
This fixes some missing TCP connections in Windows 10 20348 by adding a scan constraint for `TTcb` pool tags when using the `netscan-win10-20348` layer.