### PR TITLE
Linux: Sockstat - fix incorrect version bump

### DIFF
--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -438,7 +438,7 @@ class Sockstat(plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 0)
+    _version = (2, 0, 0)
 
     @classmethod
     def get_requirements(cls):
@@ -449,7 +449,7 @@ class Sockstat(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="SockHandlers", component=SockHandlers, version=(1, 0, 0)
+                name="SockHandlers", component=SockHandlers, version=(2, 0, 0)
             ),
             requirements.PluginRequirement(
                 name="lsof", plugin=lsof.Lsof, version=(1, 1, 0)


### PR DESCRIPTION
I erred when I bumped the version as a part of #1277 - The `SockHandlers` class got the major version bump, not `Sockstat`. This reverts the `SockHandlers` version bump and applies it to `Sockstat` instead.