### PR TITLE
Linux: Update malfind plugin to use symbols.symbol_table_is_64bit when determining if a 32bit OS is detected in the sample

### DIFF
--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -5,7 +5,7 @@
 from typing import List
 import logging
 from volatility3.framework import constants, interfaces
-from volatility3.framework import renderers
+from volatility3.framework import renderers, symbols
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
@@ -63,15 +63,9 @@ class Malfind(interfaces.plugins.PluginInterface):
     def _generator(self, tasks):
         # determine if we're on a 32 or 64 bit kernel
         vmlinux = self.context.modules[self.config["kernel"]]
-        if (
-            self.context.symbol_space.get_type(
-                vmlinux.symbol_table_name + constants.BANG + "pointer"
-            ).size
-            == 4
-        ):
-            is_32bit_arch = True
-        else:
-            is_32bit_arch = False
+        is_32bit_arch = not symbols.symbol_table_is_64bit(
+            self.context, vmlinux.symbol_table_name
+        )
 
         for task in tasks:
             process_name = utility.array_to_string(task.comm)


### PR DESCRIPTION
Hello :wave: 

I noticed that malfind has it's own version of 32bit OS detection and isn't using `symbol_table_is_64bit` from the framework. 

This update changes that so it uses `symbol_table_is_64bit`. It should hopefully mean that in the future any changes to `symbol_table_is_64bit` filter down to this plugin automagically.

This doesn't change the output of the plugin or how it works on my samples. 

[symbol_table_is_64bit](https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/symbols/__init__.py#L338-L348) itself actually does a very similar check on pointer sizes (just checking for 8 bytes for 64bit rather than 4 bytes for 32bit) so this should behave in the same way. 
```python
def symbol_table_is_64bit(
    context: interfaces.context.ContextInterface, symbol_table_name: str
) -> bool:
    """Returns a boolean as to whether a particular symbol table within a
    context is 64-bit or not."""
    return (
        context.symbol_space.get_type(
            symbol_table_name + constants.BANG + "pointer"
        ).size
        == 8
    )
```

Thanks!
:fox_face: 