### PR TITLE
Fix misuse of all() and any() functions across the codebase

### DIFF
--- a/volatility3/cli/text_filter.py
+++ b/volatility3/cli/text_filter.py
@@ -53,7 +53,7 @@ class CLIFilter:
         """Filters the row based on each of the column_filters"""
         if not self._filters:
             return False
-        found = any([column_filter.found(row) for column_filter in self._filters])
+        found = any(column_filter.found(row) for column_filter in self._filters)
         return not found
 
 
@@ -86,7 +86,7 @@ class ColumnFilter:
         otherwise it is filtered.
         """
         if self.column_num is None:
-            found = any([self.find(x) for x in row])
+            found = any(self.find(x) for x in row)
         else:
             found = self.find(row[self.column_num])
         if self.exclude:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -529,7 +529,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                 val, interfaces.configuration.BasicTypes
             ) and not isinstance(val, list):
                 if not isinstance(val, list) or all(
-                    [isinstance(x, interfaces.configuration.BasicTypes) for x in val]
+                    isinstance(x, interfaces.configuration.BasicTypes) for x in val
                 ):
                     raise TypeError(
                         "Configurable values must be simple types (int, bool, str, bytes)"

--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -209,10 +209,8 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
             try:
                 kvp = vlayer.mapping(kvo, 0)
                 if any(
-                    [
-                        (p == kernel["mz_offset"] and layer_name == physical_layer_name)
-                        for (_, _, p, _, layer_name) in kvp
-                    ]
+                    (p == kernel["mz_offset"] and layer_name == physical_layer_name)
+                    for (_, _, p, _, layer_name) in kvp
                 ):
                     return (virtual_layer_name, kvo, kernel)
                 else:

--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -161,7 +161,7 @@ class ListRequirement(interfaces.configuration.RequirementInterface):
                 "TypeError - Too many values provided to list option.",
             )
             return {config_path: self}
-        if not all([isinstance(element, self.element_type) for element in value]):
+        if not all(isinstance(element, self.element_type) for element in value):
             vollog.log(
                 constants.LOGLEVEL_V,
                 "TypeError - At least one element in the list is not of the correct type.",
@@ -181,7 +181,7 @@ class ChoiceRequirement(interfaces.configuration.RequirementInterface):
         """
         super().__init__(*args, **kwargs)
         if not isinstance(choices, list) or any(
-            [not isinstance(choice, str) for choice in choices]
+            not isinstance(choice, str) for choice in choices
         ):
             raise TypeError("ChoiceRequirement takes a list of strings as choices")
         self.choices = choices
@@ -410,11 +410,9 @@ class TranslationLayerRequirement(
         args = {"context": context, "config_path": config_path, "name": name}
 
         if any(
-            [
-                subreq.unsatisfied(context, config_path)
-                for subreq in self.requirements.values()
-                if not subreq.optional
-            ]
+            subreq.unsatisfied(context, config_path)
+            for subreq in self.requirements.values()
+            if not subreq.optional
         ):
             return None
 
@@ -485,11 +483,9 @@ class SymbolTableRequirement(
         args = {"context": context, "config_path": config_path, "name": name}
 
         if any(
-            [
-                subreq.unsatisfied(context, config_path)
-                for subreq in self.requirements.values()
-                if not subreq.optional
-            ]
+            subreq.unsatisfied(context, config_path)
+            for subreq in self.requirements.values()
+            if not subreq.optional
         ):
             return None
 
@@ -710,11 +706,9 @@ class ModuleRequirement(
         args = {"context": context, "config_path": config_path, "name": name}
 
         if any(
-            [
-                subreq.unsatisfied(context, config_path)
-                for subreq in self.requirements.values()
-                if not subreq.optional
-            ]
+            subreq.unsatisfied(context, config_path)
+            for subreq in self.requirements.values()
+            if not subreq.optional
         ):
             return None
 

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -216,7 +216,7 @@ class ObjectInterface(metaclass=abc.ABCMeta):
         Args:
             member_names: List of names to test as to members with those names validity
         """
-        return all([self.has_valid_member(member_name) for member_name in member_names])
+        return all(self.has_valid_member(member_name) for member_name in member_names)
 
     class VolTemplateProxy(metaclass=abc.ABCMeta):
         """A container for proxied methods that the ObjectTemplate of this

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -270,10 +270,8 @@ class Intel(linear.LinearlyMappedLayer):
         try:
             # TODO: Consider reimplementing this, since calls to mapping can call is_valid
             return all(
-                [
-                    self._context.layers[layer].is_valid(mapped_offset)
-                    for _, _, mapped_offset, _, layer in self.mapping(offset, length)
-                ]
+                self._context.layers[layer].is_valid(mapped_offset)
+                for _, _, mapped_offset, _, layer in self.mapping(offset, length)
             )
         except exceptions.InvalidAddressException:
             return False

--- a/volatility3/framework/layers/registry.py
+++ b/volatility3/framework/layers/registry.py
@@ -318,10 +318,8 @@ class RegistryHive(linear.LinearlyMappedLayer):
         with contextlib.suppress(exceptions.InvalidAddressException):
             # Pass this to the lower layers for now
             return all(
-                [
-                    self.context.layers[layer].is_valid(offset, length)
-                    for (_, _, offset, length, layer) in self.mapping(offset, length)
-                ]
+                self.context.layers[layer].is_valid(offset, length)
+                for (_, _, offset, length, layer) in self.mapping(offset, length)
             )
         return False
 

--- a/volatility3/framework/layers/segmented.py
+++ b/volatility3/framework/layers/segmented.py
@@ -51,10 +51,8 @@ class NonLinearlySegmentedLayer(
         try:
             base_layer = self._context.layers[self._base_layer]
             return all(
-                [
-                    base_layer.is_valid(mapped_offset)
-                    for _i, _i, mapped_offset, _i, _s in self.mapping(offset, length)
-                ]
+                base_layer.is_valid(mapped_offset)
+                for _i, _i, mapped_offset, _i, _s in self.mapping(offset, length)
             )
         except exceptions.InvalidAddressException:
             return False

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -928,10 +928,8 @@ class AggregateType(interfaces.objects.ObjectInterface):
             members, collections.abc.Mapping
         ), f"{agg_name} members parameter must be a mapping: {type(members)}"
         assert all(
-            [
-                (isinstance(member, tuple) and len(member) == 2)
-                for member in members.values()
-            ]
+            (isinstance(member, tuple) and len(member) == 2)
+            for member in members.values()
         ), f"{agg_name} members must be a tuple of relative_offsets and templates"
 
     def member(self, attr: str = "member") -> object:

--- a/volatility3/framework/plugins/linux/check_afinfo.py
+++ b/volatility3/framework/plugins/linux/check_afinfo.py
@@ -53,9 +53,7 @@ class Check_afinfo(plugins.PluginInterface):
     def _check_afinfo(self, var_name, var, op_members, seq_members):
         # check if object has a least one of the members used for analysis by this function
         required_members = ["seq_fops", "seq_ops", "seq_show"]
-        has_required_member = any(
-            [var.has_member(member) for member in required_members]
-        )
+        has_required_member = any(var.has_member(member) for member in required_members)
         if not has_required_member:
             vollog.debug(
                 f"{var_name} object at {hex(var.vol.offset)} had none of the required members: {', '.join([member for member in required_members])}"

--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -66,7 +66,7 @@ class Timeliner(interfaces.plugins.PluginInterface):
         if selected_list:
 
             def filter_plugins(name: str, selected: List[str]) -> bool:
-                return any([s in name for s in selected])
+                return any(s in name for s in selected)
 
             filter_func = filter_plugins
         else:
@@ -252,10 +252,8 @@ class Timeliner(interfaces.plugins.PluginInterface):
                 continue
 
             if filter_list and not any(
-                [
-                    filter in plugin_class.__module__ + "." + plugin_class.__name__
-                    for filter in filter_list
-                ]
+                filter in plugin_class.__module__ + "." + plugin_class.__name__
+                for filter in filter_list
             ):
                 continue
 

--- a/volatility3/framework/symbols/metadata.py
+++ b/volatility3/framework/symbols/metadata.py
@@ -24,8 +24,8 @@ class ProducerMetadata(interfaces.symbols.MetadataInterface):
         version = self._json_data.get("version", None)
         if not version:
             return None
-        if all([x in "0123456789." for x in version]):
-            return tuple([int(x) for x in version.split(".")])
+        if all(x in "0123456789." for x in version):
+            return tuple(int(x) for x in version.split("."))
         vollog.log(
             constants.LOGLEVEL_VVVV,
             f"Metadata version contains unexpected characters: '{version}'",


### PR DESCRIPTION
We are misusing the `all()` and `any()` Python's built-in functions. Wrapping the iterable in [] converts it into a list before the function is called, which unnecessarily increases the runtime to the worst-case which is O(n) in every case.

## What we are currently doing:
```python
>>> import timeit
>>> timeit.timeit('any([n > 0 for n in range(10000)])', number=10000)
4.729606243010494
```

## How it should be:
```python
>>> import timeit
>>> timeit.timeit('any(n > 0 for n in range(10000))', number=10000)
0.019788431003689766
```
