### PR TITLE
Add --remote-isf-url argument to be able to use a remote ISF server from the command-line arguments

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -243,7 +243,9 @@ class CommandLine:
             action="store_true",
         )
         isf_group.add_argument(
+            "-u",
             "--remote-isf-url",
+            metavar="URL",
             help="Search online for ISF json files",
             default=constants.REMOTE_ISF_URL,
             type=str,

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -235,11 +235,18 @@ class CommandLine:
             default=constants.CACHE_PATH,
             type=str,
         )
-        parser.add_argument(
+        isf_group = parser.add_mutually_exclusive_group()
+        isf_group.add_argument(
             "--offline",
             help="Do not search online for additional JSON files",
             default=False,
             action="store_true",
+        )
+        isf_group.add_argument(
+            "--remote-isf-url",
+            help="Search online for ISF json files",
+            default=constants.REMOTE_ISF_URL,
+            type=str,
         )
         parser.add_argument(
             "--filters",
@@ -313,6 +320,8 @@ class CommandLine:
 
         if partial_args.offline:
             constants.OFFLINE = partial_args.offline
+        elif partial_args.remote_isf_url:
+            constants.REMOTE_ISF_URL = partial_args.remote_isf_url
 
         # Do the initialization
         ctx = contexts.Context()  # Construct a blank context

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -167,7 +167,9 @@ class VolShell(cli.CommandLine):
             action="store_true",
         )
         isf_group.add_argument(
+            "-u",
             "--remote-isf-url",
+            metavar="URL",
             help="Search online for ISF json files",
             default=constants.REMOTE_ISF_URL,
             type=str,

--- a/volatility3/cli/volshell/__init__.py
+++ b/volatility3/cli/volshell/__init__.py
@@ -159,11 +159,18 @@ class VolShell(cli.CommandLine):
             default=constants.CACHE_PATH,
             type=str,
         )
-        parser.add_argument(
+        isf_group = parser.add_mutually_exclusive_group()
+        isf_group.add_argument(
             "--offline",
             help="Do not search online for additional JSON files",
             default=False,
             action="store_true",
+        )
+        isf_group.add_argument(
+            "--remote-isf-url",
+            help="Search online for ISF json files",
+            default=constants.REMOTE_ISF_URL,
+            type=str,
         )
 
         # Volshell specific flags
@@ -236,6 +243,8 @@ class VolShell(cli.CommandLine):
 
         if partial_args.offline:
             constants.OFFLINE = partial_args.offline
+        elif partial_args.remote_isf_url:
+            constants.REMOTE_ISF_URL = partial_args.remote_isf_url
 
         # Do the initialization
         ctx = contexts.Context()  # Construct a blank context


### PR DESCRIPTION
The changes in this PR allow you to set a remote ISF URL from the command line without needing to modify a source file, i.e. [constants.REMOTE_ISF_URL](https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/constants/__init__.py#L113)
```shell
$ python3 ./vol.py \
    --remote-isf-url "https://url/isf.json" \
   -f ./linux-sample-1.bin \
   linux.pslist
```
It's mutually exclusive with `--offline`, which I believe is the desired behavior.
```shell
$ python3 ./vol.py \
    --remote-isf-url "https://url/isf.json" \
    --offline \
    -f ./linux-sample-1.bin \
    linux.pslist
usage: volatility [-h] [-c CONFIG] [--parallelism [{processes,threads,off}]] [-e EXTEND] [-p PLUGIN_DIRS] [-s SYMBOL_DIRS] [-v] [-l LOG] [-o OUTPUT_DIR] [-q] [-r RENDERER] [-f FILE]
                  [--write-config] [--save-config SAVE_CONFIG] [--clear-cache] [--cache-path CACHE_PATH] [--offline | -u URL] [--filters FILTERS]
volatility: error: argument --offline: not allowed with argument -u/--remote-isf-url
```