### PR TITLE
Add Linux ptrace plugin

### DIFF
--- a/volatility3/framework/constants/linux/__init__.py
+++ b/volatility3/framework/constants/linux/__init__.py
@@ -5,7 +5,7 @@
 
 Linux-specific values that aren't found in debug symbols
 """
-from enum import IntEnum
+from enum import IntEnum, Flag
 
 KERNEL_NAME = "__kernel__"
 
@@ -302,3 +302,40 @@ class ELF_CLASS(IntEnum):
     ELFCLASSNONE = 0
     ELFCLASS32 = 1
     ELFCLASS64 = 2
+
+
+PT_OPT_FLAG_SHIFT = 3
+
+PTRACE_EVENT_FORK = 1
+PTRACE_EVENT_VFORK = 2
+PTRACE_EVENT_CLONE = 3
+PTRACE_EVENT_EXEC = 4
+PTRACE_EVENT_VFORK_DONE = 5
+PTRACE_EVENT_EXIT = 6
+PTRACE_EVENT_SECCOMP = 7
+
+PTRACE_O_EXITKILL = 1 << 20
+PTRACE_O_SUSPEND_SECCOMP = 1 << 21
+
+
+class PT_FLAGS(Flag):
+    "PTrace flags"
+    PT_PTRACED = 0x00001
+    PT_SEIZED = 0x10000
+
+    PT_TRACESYSGOOD = 1 << (PT_OPT_FLAG_SHIFT + 0)
+    PT_TRACE_FORK = 1 << (PT_OPT_FLAG_SHIFT + PTRACE_EVENT_FORK)
+    PT_TRACE_VFORK = 1 << (PT_OPT_FLAG_SHIFT + PTRACE_EVENT_VFORK)
+    PT_TRACE_CLONE = 1 << (PT_OPT_FLAG_SHIFT + PTRACE_EVENT_CLONE)
+    PT_TRACE_EXEC = 1 << (PT_OPT_FLAG_SHIFT + PTRACE_EVENT_EXEC)
+    PT_TRACE_VFORK_DONE = 1 << (PT_OPT_FLAG_SHIFT + PTRACE_EVENT_VFORK_DONE)
+    PT_TRACE_EXIT = 1 << (PT_OPT_FLAG_SHIFT + PTRACE_EVENT_EXIT)
+    PT_TRACE_SECCOMP = 1 << (PT_OPT_FLAG_SHIFT + PTRACE_EVENT_SECCOMP)
+
+    PT_EXITKILL = PTRACE_O_EXITKILL << PT_OPT_FLAG_SHIFT
+    PT_SUSPEND_SECCOMP = PTRACE_O_SUSPEND_SECCOMP << PT_OPT_FLAG_SHIFT
+
+    @property
+    def flags(self) -> str:
+        """Returns the ptrace flags string"""
+        return str(self).replace(self.__class__.__name__ + ".", "")

--- a/volatility3/framework/plugins/linux/ptrace.py
+++ b/volatility3/framework/plugins/linux/ptrace.py
@@ -19,7 +19,7 @@ class Ptrace(plugins.PluginInterface):
     """Enumerates ptrace's tracer and tracee tasks"""
 
     _required_framework_version = (2, 10, 0)
-    _version = (1, 0, 1)
+    _version = (1, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/ptrace.py
+++ b/volatility3/framework/plugins/linux/ptrace.py
@@ -1,0 +1,120 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List
+
+from volatility3.framework import renderers, interfaces, constants, objects
+from volatility3.framework.constants.linux import PT_FLAGS
+from volatility3.framework.constants.architectures import LINUX_ARCHS
+from volatility3.framework.objects import utility
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.plugins.linux import pslist
+
+vollog = logging.getLogger(__name__)
+
+
+class Ptrace(plugins.PluginInterface):
+    """Enumerates tracer and tracee tasks"""
+
+    _required_framework_version = (2, 10, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Linux kernel",
+                architectures=LINUX_ARCHS,
+            ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(2, 2, 1)
+            ),
+        ]
+
+    @classmethod
+    def enumerate_ptraced_tasks(
+        cls,
+        context: interfaces.context.ContextInterface,
+        symbol_table: str,
+    ):
+        vmlinux = context.modules[symbol_table]
+
+        tsk_struct_symname = vmlinux.symbol_table_name + constants.BANG + "task_struct"
+
+        tasks = pslist.PsList.list_tasks(
+            context,
+            symbol_table,
+            filter_func=pslist.PsList.create_pid_filter(),
+            include_threads=True,
+        )
+
+        for task in tasks:
+            tracing_tid_list = [
+                int(task_being_traced.pid)
+                for task_being_traced in task.ptraced.to_list(
+                    tsk_struct_symname, "ptrace_entry"
+                )
+            ]
+
+            if task.ptrace == 0 and not tracing_tid_list:
+                continue
+
+            flags = (
+                PT_FLAGS(task.ptrace).flags
+                if task.ptrace != 0
+                else renderers.NotAvailableValue()
+            )
+
+            traced_by_tid = (
+                task.parent.pid
+                if task.real_parent != task.parent
+                else renderers.NotAvailableValue()
+            )
+
+            tracing_tids = ",".join(map(str, tracing_tid_list))
+
+            yield task.comm, task.tgid, task.pid, traced_by_tid, tracing_tids, flags
+
+    def _generator(self, symbol_table):
+        for fields in self.enumerate_ptraced_tasks(self.context, symbol_table):
+            yield (0, fields)
+
+    @staticmethod
+    def format_fields_with_headers(headers, generator):
+        """Uses the headers type to cast the fields obtained from the generator"""
+        for level, fields in generator:
+            formatted_fields = []
+            for header, field in zip(headers, fields):
+                header_type = header[1]
+
+                if isinstance(
+                    field, (header_type, interfaces.renderers.BaseAbsentValue)
+                ):
+                    formatted_field = field
+                elif isinstance(field, objects.Array) and header_type is str:
+                    formatted_field = utility.array_to_string(field)
+                else:
+                    formatted_field = header_type(field)
+
+                formatted_fields.append(formatted_field)
+            yield level, formatted_fields
+
+    def run(self):
+        symbol_table = self.config["kernel"]
+
+        headers = [
+            ("Process", str),
+            ("PID", int),
+            ("TID", int),
+            ("Traced by TID", int),
+            ("Tracing TIDs", str),
+            ("Flags", str),
+        ]
+        return renderers.TreeGrid(
+            headers,
+            self.format_fields_with_headers(headers, self._generator(symbol_table)),
+        )

--- a/volatility3/framework/plugins/linux/ptrace.py
+++ b/volatility3/framework/plugins/linux/ptrace.py
@@ -31,7 +31,7 @@ class Ptrace(plugins.PluginInterface):
                 architectures=LINUX_ARCHS,
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 2, 1)
+                name="pslist", plugin=pslist.PsList, version=(2, 2, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/ptrace.py
+++ b/volatility3/framework/plugins/linux/ptrace.py
@@ -72,16 +72,16 @@ class Ptrace(plugins.PluginInterface):
             ]
             flags = task.get_ptrace_tracee_flags() or renderers.NotAvailableValue()
 
-            for tree, tracing_tid in enumerate(tracee_tids):
+            for level, tracee_tid in enumerate(tracee_tids):
                 fields = [
                     task_comm,
                     user_pid,
                     user_tid,
                     tracer_tid,
-                    tracing_tid,
+                    tracee_tid,
                     flags,
                 ]
-                yield (tree, fields)
+                yield (level, fields)
 
     def run(self):
         vmlinux_module_name = self.config["kernel"]
@@ -90,8 +90,8 @@ class Ptrace(plugins.PluginInterface):
             ("Process", str),
             ("PID", int),
             ("TID", int),
-            ("Traced by TID", int),
-            ("Tracing TID", int),
+            ("Tracer TID", int),
+            ("Tracee TID", int),
             ("Flags", str),
         ]
         return renderers.TreeGrid(headers, self._generator(vmlinux_module_name))

--- a/volatility3/framework/plugins/linux/ptrace.py
+++ b/volatility3/framework/plugins/linux/ptrace.py
@@ -19,7 +19,7 @@ class Ptrace(plugins.PluginInterface):
     """Enumerates ptrace's tracer and tracee tasks"""
 
     _required_framework_version = (2, 10, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:


### PR DESCRIPTION
This PR adds the `linux.ptrace` plugin to enumerate tracer and tracee tasks. Ptrace is often leveraged by attackers to gather credentials and other sensitive information.

## Example 1: strace
Let's take a random process thread:
```shell
$ ps -eLf
UID        PID  PPID   LWP  C NLWP STIME TTY          TIME CMD
root       955     1  1047  0    3 05:34 ?        00:00:00 /usr/lib/accountsservice/accounts-daemon
...
```

Let's ptrace the thread/task 1047
```shell
$ sudo strace -p 1047
...
```

```shell
$ ps -eLf
UID        PID  PPID   LWP  C NLWP STIME TTY          TIME CMD
root      2963  2961  2963  0    1 05:38 pts/1    00:00:00 strace -p 1047
...
```

```shell
$ sudo cat /proc/1047/status
Name:	gmain
Umask:	0022
State:	S (sleeping)
Tgid:	955
Ngid:	0
Pid:	1047
PPid:	1
TracerPid:	2963
...
```

```shell
 $ ./vol.py -r pretty \
    -f ../dump_ubuntu180464bit_5.4.0-117-generic_ptrace.core \
    linux.ptrace 
Volatility 3 Framework 2.10.0        
  | Process |  PID |  TID | Tracer TID | Tracee TID |                                                            Flags
* |   gmain |  955 | 1047 |       2963 |          - | PT_SEIZED|PT_TRACE_EXIT|PT_TRACE_EXEC|PT_TRACESYSGOOD|PT_PTRACED
* |  strace | 2963 | 2963 |          - |       1047 |                                                                -
```

# Example 2: gdb
```shell
$ sudo gdb -p 1047
```

```
$ ps -eLf | grep gdb
UID        PID  PPID   LWP  C NLWP STIME TTY          TIME CMD
...
root      4278  4277  4278  1    1 09:42 pts/1    00:00:00 gdb -p 1047
```

```shell
$ sudo cat /proc/1047/status
Name:	gmain
Umask:	0022
State:	t (tracing stop)
Tgid:	955
Ngid:	0
Pid:	1047
PPid:	1
TracerPid:	4278
...
```

```shell
$ ./vol.py -r pretty \
    -f ./dump_ubuntu180464bit_5.4.0-117-generic_ptrace_gdb.core \
    linux.ptrace 
Volatility 3 Framework 2.10.0
  | Process |  PID |  TID | Tracer TID | Tracee TID |                                                                                                    Flags
* |   gmain |  955 | 1047 |       4278 |          - | PT_TRACE_VFORK_DONE|PT_TRACE_EXEC|PT_TRACE_CLONE|PT_TRACE_VFORK|PT_TRACE_FORK|PT_TRACESYSGOOD|PT_PTRACED
* |     gdb | 4278 | 4278 |          - |       1047 |                                                                                                        -
```

# Example 3: Ptracing from a thread
For this example, I wrote a simple C program that spawns a pthread and attaches to the same thread as described above. This shows that the information is always related to TID (and not to **user PID** / **kernel TGID**). This aligns with our discussion with @eve-mem here:
- https://github.com/volatilityfoundation/volatility3/issues/981
- https://github.com/volatilityfoundation/volatility3/pull/1000
- https://github.com/volatilityfoundation/volatility3/pull/1012

```shell
$ sudo ./pthread_ptraced 
Enter the TID of the process to attach to: 1047
```
```shell
$ ps -efL
UID        PID  PPID   LWP  C NLWP STIME TTY          TIME CMD
...
root      9491  2928  9491  0    1 10:32 pts/1    00:00:00 sudo ./pthread_ptraced
root      9492  9491  9492  0    2 10:32 pts/1    00:00:00 ./pthread_ptraced
root      9492  9491  9600  0    2 10:32 pts/1    00:00:00 ./pthread_ptraced
```
```shell
$ sudo cat /proc/1047/status
Name:	gmain
Umask:	0022
State:	t (tracing stop)
Tgid:	955
Ngid:	0
Pid:	1047
PPid:	1
TracerPid:	9600
...
```
As you can see, **PID** in **TracerPid** actually refers to the **user TID**, representing the internal **kernel PID**, and not the **kernel TGID** which corresponds to the **user PID**. Confused? Please refer to the links above for clarification.

```shell
$ ./vol.py -r pretty \
    -f ./dump_ubuntu180464bit_5.4.0-117-generic_ptrace_from_thread.core \
    linux.ptrace
Volatility 3 Framework 2.10.0
  |         Process |  PID |  TID | Tracer TID | Tracee TID |      Flags
* |           gmain |  955 | 1047 |       9600 |          - | PT_PTRACED
* | pthread_ptraced | 9492 | 9600 |          - |       1047 |          -
```

# Example 4: Ptracing multiple threads using PTRACE_O_TRACECLONE

```shell
$ sudo ./fork_seized
tracer: 1174, tracee: 1175
[*] Wait for the child process to stop
[1175] Tracee - Launching the 3 threads
Thread 0 created
Thread 1 created
Thread 2 created
[1175] Tracee - Waiting
[*] Joining 3 threads
```

```shell
$ ps -efL | grep fork_seized
...
root      1172  1146  1172  0    1 04:20 pts/0    00:00:00 sudo ./fork_seized
root      1174  1172  1174  0    1 04:20 pts/0    00:00:00 ./fork_seized
root      1175  1174  1175  0    4 04:20 pts/0    00:00:00 ./fork_seized
root      1175  1174  1176  0    4 04:20 pts/0    00:00:00 ./fork_seized
root      1175  1174  1177  0    4 04:20 pts/0    00:00:00 ./fork_seized
root      1175  1174  1178  0    4 04:20 pts/0    00:00:00 ./fork_seized
```

```shell
$ sudo grep -H TracerPid /proc/1175/task/*/status
/proc/1175/task/1175/status:TracerPid:	1174
/proc/1175/task/1176/status:TracerPid:	1174
/proc/1175/task/1177/status:TracerPid:	1174
/proc/1175/task/1178/status:TracerPid:	1174
```

```shell
$ python ./vol.py -r pretty \
    -f ./dump_ubuntu180464bit_5.4.0-117-generic_ptrace_seize_multiple.core \
    linux.ptrace 
Volatility 3 Framework 2.10.0           
     |     Process |  PID |  TID | Tracer TID | Tracee TID |                               Flags
*    | fork_seized | 1174 | 1174 |          - |       1178 |                                   -
**   | fork_seized | 1174 | 1174 |          - |       1177 |                                   -
***  | fork_seized | 1174 | 1174 |          - |       1176 |                                   -
**** | fork_seized | 1174 | 1174 |          - |       1175 |                                   -
*    | fork_seized | 1175 | 1175 |       1174 |          - | PT_SEIZED|PT_TRACE_CLONE|PT_PTRACED
*    | fork_seized | 1175 | 1176 |       1174 |          - | PT_SEIZED|PT_TRACE_CLONE|PT_PTRACED
*    | fork_seized | 1175 | 1177 |       1174 |          - | PT_SEIZED|PT_TRACE_CLONE|PT_PTRACED
*    | fork_seized | 1175 | 1178 |       1174 |          - | PT_SEIZED|PT_TRACE_CLONE|PT_PTRACED
```