### PR TITLE
Docs: Add warning around LiME raw format

### DIFF
--- a/doc/source/getting-started-linux-tutorial.rst
+++ b/doc/source/getting-started-linux-tutorial.rst
@@ -11,6 +11,7 @@ Volatility3 does not provide the ability to acquire memory.  Below are some exam
 * `AVML - Acquire Volatile Memory for Linux <https://github.com/microsoft/avml>`_
 * `LiME - Linux Memory Extract <https://github.com/504ensicsLabs/LiME>`_
 
+Be aware that LiME raw format is not supported by volatility3, the padded or lime option should be used instead. `This issue contains further information <https://github.com/504ensicsLabs/LiME/issues/111>`_.
 
 Procedure to create symbol tables for linux
 --------------------------------------------


### PR DESCRIPTION
Hello :wave: 

I was looking at the docs and thought it might be useful to have a little warning against using the LiME raw format. The raw format doesn't include the padding needing for vol to be able to parse the memory as the different segments of raw memory get misaligned. 

It's caused a few issues for us:
- https://github.com/volatilityfoundation/volatility3/issues/965
- https://github.com/volatilityfoundation/volatility3/issues/413
- https://github.com/volatilityfoundation/volatility3/issues/1265

:fox_face: 