### PR TITLE
[plugin] Add dirty state IoC detection to malfind

### DIFF
--- a/volatility3/framework/plugins/windows/malfind.py
+++ b/volatility3/framework/plugins/windows/malfind.py
@@ -122,10 +122,30 @@ class Malfind(interfaces.plugins.PluginInterface):
                 vadinfo.winnt_protections,
             )
             write_exec = "EXECUTE" in protection_string and "WRITE" in protection_string
+            dirty_page_check = False
 
-            # the write/exec check applies to everything
             if not write_exec:
-                continue
+                """
+                # Inspect "PAGE_EXECUTE_READ" VAD pages to detect
+                # non writable memory regions having been injected
+                # using elevated WriteProcessMemory().
+                """
+                if "EXECUTE" in protection_string:
+                    for page in range(
+                        vad.get_start(), vad.get_end(), proc_layer.page_size
+                    ):
+                        try:
+                            # If we have a dirty page in a non writable "EXECUTE" region, it is suspicious.
+                            if proc_layer.is_dirty(page):
+                                dirty_page_check = True
+                                break
+                        except exceptions.InvalidAddressException:
+                            # Abort as it is likely that other addresses in the same range will also fail
+                            break
+                    if not dirty_page_check:
+                        continue
+                else:
+                    continue
 
             if (vad.get_private_memory() == 1 and vad.get_tag() == "VadS") or (
                 vad.get_private_memory() == 0
@@ -134,6 +154,11 @@ class Malfind(interfaces.plugins.PluginInterface):
                 if cls.is_vad_empty(proc_layer, vad):
                     continue
 
+                if dirty_page_check:
+                    # Useful information to investigate the page content with volshell afterwards.
+                    vollog.warning(
+                        f"[proc_id {proc_id}] Found suspicious DIRTY + {protection_string} page at {hex(page)}",
+                    )
                 data = proc_layer.read(vad.get_start(), 64, pad=True)
                 yield vad, data
 

--- a/volatility3/framework/plugins/windows/malfind.py
+++ b/volatility3/framework/plugins/windows/malfind.py
@@ -140,7 +140,7 @@ class Malfind(interfaces.plugins.PluginInterface):
                                 dirty_page_check = True
                                 break
                         except exceptions.InvalidAddressException:
-                            # Abort as it is likely that other addresses in the same range will also fail
+                            # Abort as it is likely that other addresses in the same range will also fail.
                             break
                     if not dirty_page_check:
                         continue


### PR DESCRIPTION
Hi,

The current `windows.malfind` implementation does not leverage the dirty state indicator to identify potential threats, and filters out non writable VADs. However, some evasion techniques use an elevated `WriteProcessMemory` call to inject data inside remote processes `PAGE_EXECUTE_READ` regions :

- https://www.covertswarm.com/post/exploiting-microsoft-windows-11-via-process-no-hollowing

> As expected, we invoked WriteProcessMemory, specifying 0x00007FF7519BOECO as
target address (address of entry point in our example), and successfully changed the
read-only region.

> When using WriteProcessMemory to write to Read-only memory addresses we have
observed that associated errors and exceptions are not raised within the OS if we have
sufficient privileges on the target process. The question is, why?

- https://devblogs.microsoft.com/oldnewthing/20181206-00/?p=100415

> If the page is read-only, Write­Process­Memory temporarily changes the permission to read-write, updates the memory, and then restores the original permission.

To identify this behaviour, I edited the malfind code to scan each VAD page with `(R)-X` protection for any dirty state marker. 

If necessary, I can develop a PoC + sample (which might come handy for unit tests).

Inspired from Linux https://github.com/volatilityfoundation/volatility3/pull/995.