### PR TITLE
Fix black stable version issue with Python 3.8

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,3 +11,5 @@ jobs:
         with:
           options: "--check --diff --verbose"
           src: "./volatility3"
+          # FIXME: Remove when Volatility3 minimum Python version is >3.8
+          version: "24.8.0"


### PR DESCRIPTION
@ikelos the problem with black is as follows:
- Black no longer supports Python 3.8 see https://github.com/psf/black/pull/4452.
- 12 hours ago, Black releases its latest stable version 24.10.0, which includes the above.
- [uses: psf/black@stable](https://github.com/volatilityfoundation/volatility3/blob/d1c5fc2ac14abdabdcc81ec22bd4413d4fdf8b03/.github/workflows/black.yml#L10C9-L10C31) is forcing to use the latest stable version. This means after releasing 24.10.0, our workflows are broken. See:
  - https://github.com/volatilityfoundation/volatility3/pull/1288
  - https://github.com/volatilityfoundation/volatility3/pull/1300

On the other hand:
- Black latest supported version for Python 3.8 is `24.8.0`. See
 ```shell
$ pip install black==24.10.0
ERROR: Ignored the following yanked versions: 21.11b0
ERROR: Ignored the following versions that require a different python version: 24.10.0 Requires-Python >=3.9

ERROR: Could not find a version that satisfies the requirement black==24.10.0 (from versions: 18.3a0, 18.3a1, 18.3a2, 18.3a3, 18.3a4, 18.4a0, 18.4a1, 18.4a2, 18.4a3, 18.4a4, 18.5b0, 18.5b1, 18.6b0, 18.6b1, 18.6b2, 18.6b3, 18.6b4, 18.9b0, 19.3b0, 19.10b0, 20.8b0, 20.8b1, 21.4b0, 21.4b1, 21.4b2, 21.5b0, 21.5b1, 21.5b2, 21.6b0, 21.7b0, 21.8b0, 21.9b0, 21.10b0, 21.11b1, 21.12b0, 22.1.0, 22.3.0, 22.6.0, 22.8.0, 22.10.0, 22.12.0, 23.1a1, 23.1.0, 23.3.0, 23.7.0, 23.9.0, 23.9.1, 23.10.0, 23.10.1, 23.11.0, 23.12.0, 23.12.1, 24.1a1, 24.1.0, 24.1.1, 24.2.0, 24.3.0, 24.4.0, 24.4.1, 24.4.2, 24.8.0)
```

This PR provides a workaround to keep our workflows running until we raise the minimum supported version to 3.9 or higher.


