### PR TITLE
Add in dwarf2json warning about sybmols with rust namespace

### DIFF
--- a/volatility3/schemas/__init__.py
+++ b/volatility3/schemas/__init__.py
@@ -86,7 +86,7 @@ def valid(
             int(x) for x in ".".split(producer.get("version"))
         ] < (0, 8, 0):
             vollog.warning(
-                "Dwarf2json < 0.8.0 is known to produce faulty symbols for kernels > 6.0.0"
+                "Dwarf2json < 0.9.0 is known to produce faulty symbols for kernels > 6.0.0"
             )
 
     if input_hash in cached_validations and use_cache:

--- a/volatility3/schemas/__init__.py
+++ b/volatility3/schemas/__init__.py
@@ -85,7 +85,7 @@ def valid(
         if producer.get("name") == "dwarf2json" and [
             int(x) for x in ".".split(producer.get("version"))
         ] < (0, 8, 0):
-            raise UserWarning(
+            vollog.warning(
                 "Dwarf2json < 0.8.0 is known to produce faulty symbols for kernels > 6.0.0"
             )
 

--- a/volatility3/schemas/__init__.py
+++ b/volatility3/schemas/__init__.py
@@ -84,7 +84,7 @@ def valid(
     if producer:
         if producer.get("name") == "dwarf2json" and [
             int(x) for x in ".".split(producer.get("version"))
-        ] < (0, 8, 0):
+        ] < (0, 9, 0):
             vollog.warning(
                 "Dwarf2json < 0.9.0 is known to produce faulty symbols for kernels > 6.0.0"
             )

--- a/volatility3/schemas/__init__.py
+++ b/volatility3/schemas/__init__.py
@@ -78,6 +78,17 @@ def valid(
 ) -> bool:
     """Validates a json schema."""
     input_hash = create_json_hash(input, schema)
+
+    # Warn about using known bad
+    producer = input.get("metadata", {}).get("producer", {})
+    if producer:
+        if producer.get("name") == "dwarf2json" and [
+            int(x) for x in ".".split(producer.get("version"))
+        ] < (0, 8, 0):
+            raise UserWarning(
+                "Dwarf2json < 0.8.0 is known to produce faulty symbols for kernels > 6.0.0"
+            )
+
     if input_hash in cached_validations and use_cache:
         return True
     try:


### PR DESCRIPTION
This should raise a warning if loading a file produced by dwarf2json < 0.8.0.  Unfortunately dwarf2json didn't include the kernel version in the metadata, so we have to warn on all symbols generated by dwarf2json < 0.8.0.

Can someone please check the specific version of linux where this started to be an issue (rust namespace symbols were included), and if possible can we update dwarf2json to include the version of the kernel in the metadata somewhere?