### PR TITLE
Linux: Netfilter - fix traceback on missing module name

### DIFF
--- a/volatility3/framework/plugins/linux/netfilter.py
+++ b/volatility3/framework/plugins/linux/netfilter.py
@@ -714,7 +714,7 @@ class Netfilter(interfaces.plugins.PluginInterface):
             hook_name,
             priority,
             format_hints.Hex(hook_func),
-            module_name,
+            module_name or renderers.NotAvailableValue(),
             str(hooked),
         )
 


### PR DESCRIPTION
When the module name can't be found, `None` ends up in this field,
causing a traceback when rendering. This fixes it by replacing `None`
with `renderers.NotAvailableValue()`.

This occurred in the context of a netfilter hook from a hidden module.
