### PR TITLE
Framework: Add 'Data' type to base types

### DIFF
--- a/volatility3/framework/interfaces/renderers.py
+++ b/volatility3/framework/interfaces/renderers.py
@@ -105,9 +105,10 @@ class BaseAbsentValue(object):
 class Data(object):
     """Class that represents a view of data in a particular layer"""
 
-    def __init__(self, offset: int, layer_name: str):
+    def __init__(self, offset: int, layer_name: str, length: int):
         self.layer_name = layer_name
         self.offset = offset
+        self.length = length
 
 
 class Disassembly(object):

--- a/volatility3/framework/interfaces/renderers.py
+++ b/volatility3/framework/interfaces/renderers.py
@@ -102,6 +102,14 @@ class BaseAbsentValue(object):
     """Class that represents values which are not present for some reason."""
 
 
+class Data(object):
+    """Class that represents a view of data in a particular layer"""
+
+    def __init__(self, offset: int, layer_name: str):
+        self.layer_name = layer_name
+        self.offset = offset
+
+
 class Disassembly(object):
     """A class to indicate that the bytes provided should be disassembled
     (based on the architecture)"""
@@ -132,6 +140,7 @@ BaseTypes = Union[
     Type[datetime.datetime],
     Type[BaseAbsentValue],
     Type[Disassembly],
+    Type[Data],
 ]
 ColumnsType = List[Tuple[str, BaseTypes]]
 VisitorSignature = Callable[[TreeNode, _Type], _Type]
@@ -157,6 +166,7 @@ class TreeGrid(object, metaclass=ABCMeta):
         bytes,
         datetime.datetime,
         Disassembly,
+        Data,
     )
 
     def __init__(self, columns: ColumnsType, generator: Generator) -> None:


### PR DESCRIPTION
This adds a `Data` base type, which will provide the information
(layer_name and offset) required to view variable amounts of data
both before and after that offset, instead of handing fixed-sized
chunks of data back.

This will allow plugin consumers to flexibly determine how much
data to render/extract without having to re-run the plugin with
different parameter values.

This PR is the first step in the outline proposed as part of 
the discussion surrounding #1287 - subsequent PRs will follow
that implement rendering of this new data type in the CLI and 
configuration of default parameters, and the conversion of existing
plugins to return this new data type where appropriate (yarascan,
vadyarascan, vmayarascan).
