### PR TITLE
Linux adds hlist_head object extension

### DIFF
--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -245,7 +245,7 @@ class Module(interfaces.context.ModuleInterface):
         """
         if constants.BANG not in object_type:
             object_type = self.symbol_table_name + constants.BANG + object_type
-        else:
+        elif not object_type.startswith(self.symbol_table_name + constants.BANG):
             raise ValueError(
                 "Cannot reference another module when constructing an object"
             )

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -22,6 +22,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         # Set-up Linux specific types
         self.set_type_class("file", extensions.struct_file)
         self.set_type_class("list_head", extensions.list_head)
+        self.set_type_class("hlist_head", extensions.hlist_head)
         self.set_type_class("mm_struct", extensions.mm_struct)
         self.set_type_class("super_block", extensions.super_block)
         self.set_type_class("task_struct", extensions.task_struct)

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -994,9 +994,6 @@ class hlist_head(objects.StructType, collections.abc.Iterable):
 
             current = current.next
 
-    def __iter__(self) -> Iterator[interfaces.objects.ObjectInterface]:
-        return self.to_list(self.vol.parent.vol.type_name, self.vol.member_name)
-
 
 class files_struct(objects.StructType):
     def get_fds(self) -> interfaces.objects.ObjectInterface:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -844,7 +844,7 @@ class dentry(objects.StructType):
         if self.has_member("d_sib") and self.has_member("d_children"):
             # kernels >= 6.8
             walk_member = "d_sib"
-            list_head_member = self.d_children.first
+            list_head_member = self.d_children
         elif self.has_member("d_child") and self.has_member("d_subdirs"):
             # 2.5.0 <= kernels < 6.8
             walk_member = "d_child"
@@ -956,6 +956,43 @@ class list_head(objects.StructType, collections.abc.Iterable):
                 link = getattr(link, direction).dereference()
             except exceptions.InvalidAddressException:
                 break
+
+    def __iter__(self) -> Iterator[interfaces.objects.ObjectInterface]:
+        return self.to_list(self.vol.parent.vol.type_name, self.vol.member_name)
+
+
+class hlist_head(objects.StructType, collections.abc.Iterable):
+    def to_list(
+        self,
+        symbol_type: str,
+        member: str,
+    ) -> Iterator[interfaces.objects.ObjectInterface]:
+        """Returns an iterator of the entries in the list.
+
+        This is a doubly linked list; however, it is not circular, so the 'forward' field
+        doesn't make sense. Also, the sentinel concept doesn't make sense here either;
+        unlike list_head, the head and nodes each have their own distinct types. A list_head
+        cannot be a node by itself.
+        - The 'pprev' of the first 'hlist_node' points to the 'hlist_head', not to the last node.
+        - The last element 'next' member is NULL
+
+        Args:
+            symbol_type: Type of the list elements
+            member: Name of the list_head member in the list elements
+
+        Yields:
+            Objects of the type specified via the "symbol_type" argument.
+
+        """
+        vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
+
+        current = self.first
+        while current and current.is_readable():
+            yield linux.LinuxUtilities.container_of(
+                current, symbol_type, member, vmlinux
+            )
+
+            current = current.next
 
     def __iter__(self) -> Iterator[interfaces.objects.ObjectInterface]:
         return self.to_list(self.vol.parent.vol.type_name, self.vol.member_name)


### PR DESCRIPTION
The primary goal of this PR is to fix issue #1313 for kernels version 6.8 and above. However, to achieve this, two additional fixes are also required. 

- First, it needs the RBTree implementation from https://github.com/volatilityfoundation/volatility3/pull/1238 to be merged before this.

## Module.object() fix
Additionally, this PR includes a fix for `Module.object()` which doesn't allow to create an object even if the symbol type name is from the same symbol table, see [here](https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/contexts/__init__.py#L249). That makes `linux.LinuxUtilities.container_of()` to fail when it's called from some places. Additionally, it's inconsistent with other functions that allow the use of the same symbol name even when they are called from the same object.
```python
>>> self.context.symbol_space.get_type('symbol_table_name1!dentry')
<volatility3.framework.objects.templates.ObjectTemplate object at 0x71c7328074c0>

>>> vmlinux.get_type('symbol_table_name1!dentry')
<volatility3.framework.objects.templates.ObjectTemplate object at 0x71c7328074c0>

>>> vmlinux.object(object_type='symbol_table_name1!dentry', offset=container_addr, absolute=True)
Traceback (most recent call last):
...
    raise ValueError(
ValueError: Cannot reference another module when constructing an object
```

So, `Module.object() `only works if it's called with only the symbol name i.e. `dentry` and it creates the full names [here](https://github.com/volatilityfoundation/volatility3/blob/develop/volatility3/framework/contexts/__init__.py#L246):
```python
object_type = self.symbol_table_name + constants.BANG + object_type
```

But if it's already called with the full symbol name, it fails:
```python
>>> object_type
'symbol_table_name1!dentry'

>>> self.symbol_table_name
'symbol_table_name1'
```

On the other hand, the exception message doesn’t seem to accurately reflect what it’s checking. It talks about "module" when it's checking the symbol table name. Is this correct @ikelos? 

```PYTHON
        if constants.BANG not in object_type:
            object_type = self.symbol_table_name + constants.BANG + object_type
        else:
            raise ValueError(
                "Cannot reference another module when constructing an object"
            )
```

## hlist_head object extension 
This PR adds a `hlist_head` object extension that other Linux plugins can benefit from. This resolves issue #1313.

```shell
$ python3 ./vol.py \
   -f ./ubuntu2404amd64_6.8.0-41.core \
    linux.pagecache.Files 
Volatility 3 Framework 2.11.0
SuperblockAddr  MountPoint      Device  InodeNum        InodeAddr       FileType        InodePages      CachedPages     FileMode        AccessTime      ModificationTime        ChangeTime      FilePath

0x91f7812e1800  /sys/kernel/security    0:6     1       0x91f781405680  DIR     0       0       drwxr-xr-x      2024-09-18 06:10:26.296421 UTC  2024-09-18 06:10:26.296421 UTC  2024-09-18 06:10:26.296421 UTC  /sys/kernel/security
0x91f7812e1800  /sys/kernel/security    0:6     2431    0x91f783ace780  LNK     0       0       lr--r--r--      2024-09-18 06:10:26.661000 UTC  2024-09-18 06:10:26.661000 UTC  2024-09-18 06:10:26.661000 UTC  /sys/kernel/security/evm -> integrity/evm/evm
0x91f7812e1800  /sys/kernel/security    0:6     2423    0x91f783aa8280  LNK     0       0       lr--r--r--      2024-09-18 06:10:27.828000 UTC  2024-09-18 06:10:26.653000 UTC  2024-09-18 06:10:26.653000 UTC  /sys/kernel/security/ima -> integrity/ima
0x91f7812e1800  /sys/kernel/security    0:6     2421    0x91f783aa9b80  DIR     0       0       drwxr-xr-x      2024-09-18 06:10:26.646000 UTC  2024-09-18 06:10:26.646000 UTC  2024-09-18 06:10:26.646000 UTC  /sys/kernel/security/integrity
0x91f7812e1800  /sys/kernel/security    0:6     2429    0x91f783aa9180  DIR     0       0       drwxr-xr-x      2024-09-18
...
```

Please, read my comment [here](https://github.com/gcmoreira/volatility3/blob/f00c4c3c392a26bea29ba87d961c3a8f51092829/volatility3/framework/symbols/linux/extensions/__init__.py#L972):
>         This is a doubly linked list; however, it is not circular, so the 'forward' field
>         doesn't make sense. Also, the sentinel concept doesn't make sense here either;
>         unlike list_head, the head and nodes each have their own distinct types. A list_head
>         cannot be a node by itself.

Please avoid adding a `forward` or `sentinel` arguments! This list is not designed to be traversed in reverse order. Finding the tail requires O(n).