### PR TITLE
Enable Remote ISF server for Linux testcases

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,23 +32,13 @@ jobs:
         curl -sLO "https://downloads.volatilityfoundation.org/volatility3/images/win-xp-laptop-2005-06-25.img.gz"
         gunzip win-xp-laptop-2005-06-25.img.gz
 
-    - name: Download and Extract symbols
-      run: |
-        cd ./volatility3/symbols
-        curl -sLO https://downloads.volatilityfoundation.org/volatility3/symbols/linux.zip
-        unzip linux.zip
-        cd -
-
     - name: Testing...
       run: |
-        py.test ./test/test_volatility.py --volatility=vol.py --image win-xp-laptop-2005-06-25.img -k test_windows -v
-        py.test ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin -k test_linux -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image win-xp-laptop-2005-06-25.img -k test_windows -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin --remote-isf-url=https://github.com/Abyss-W4tcher/volatility3-symbols/raw/master/banners/banners.json" -k test_linux -v
 
     - name: Clean up post-test
       run: |
         rm -rf *.bin
         rm -rf *.img
-        cd volatility3/symbols
-        rm -rf linux
-        rm -rf linux.zip
         cd -

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Testing...
       run: |
         pytest ./test/test_volatility.py --volatility=vol.py --image win-xp-laptop-2005-06-25.img -k test_windows -v
-        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin --remote-isf-url=https://github.com/Abyss-W4tcher/volatility3-symbols/raw/master/banners/banners.json" -k test_linux -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin --remote-isf-url="https://github.com/Abyss-W4tcher/volatility3-symbols/raw/master/banners/banners.json" -k test_linux -v
 
     - name: Clean up post-test
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,4 +41,4 @@ jobs:
       run: |
         rm -rf *.bin
         rm -rf *.img
-        cd -
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,11 @@
 name: Test Volatility3
+
 on: [push, pull_request]
+
+env:
+  REMOTE_ISF_URL: https://github.com/Abyss-W4tcher/volatility3-symbols/raw/master/banners/banners.json
+  IMAGES_URL: https://downloads.volatilityfoundation.org/volatility3/images
+
 jobs:
 
   build:
@@ -27,15 +33,15 @@ jobs:
 
     - name: Download images
       run: |
-        curl -sLO "https://downloads.volatilityfoundation.org/volatility3/images/linux-sample-1.bin.gz"
+        curl -sLO "${{env.IMAGES_URL}}/linux-sample-1.bin.gz"
         gunzip linux-sample-1.bin.gz
-        curl -sLO "https://downloads.volatilityfoundation.org/volatility3/images/win-xp-laptop-2005-06-25.img.gz"
+        curl -sLO "${{env.IMAGES_URL}}/win-xp-laptop-2005-06-25.img.gz"
         gunzip win-xp-laptop-2005-06-25.img.gz
 
     - name: Testing...
       run: |
         pytest ./test/test_volatility.py --volatility=vol.py --image win-xp-laptop-2005-06-25.img -k test_windows -v
-        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin --remote-isf-url="https://github.com/Abyss-W4tcher/volatility3-symbols/raw/master/banners/banners.json" -k test_linux -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin --remote-isf-url="${{env.REMOTE_ISF_URL}}" -k test_linux -v
 
     - name: Clean up post-test
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,8 @@ name: Test Volatility3
 on: [push, pull_request]
 
 env:
-  REMOTE_ISF_URL: https://github.com/Abyss-W4tcher/volatility3-symbols/raw/master/banners/banners.json
   IMAGES_URL: https://downloads.volatilityfoundation.org/volatility3/images
+  REMOTE_ISF_URL: https://github.com/Abyss-W4tcher/volatility3-symbols/raw/master/banners/banners.json
 
 jobs:
 
@@ -33,15 +33,15 @@ jobs:
 
     - name: Download images
       run: |
-        curl -sLO "${{env.IMAGES_URL}}/linux-sample-1.bin.gz"
+        curl -sLO "${{ env.IMAGES_URL }}/linux-sample-1.bin.gz"
         gunzip linux-sample-1.bin.gz
-        curl -sLO "${{env.IMAGES_URL}}/win-xp-laptop-2005-06-25.img.gz"
+        curl -sLO "${{ env.IMAGES_URL }}/win-xp-laptop-2005-06-25.img.gz"
         gunzip win-xp-laptop-2005-06-25.img.gz
 
     - name: Testing...
       run: |
         pytest ./test/test_volatility.py --volatility=vol.py --image win-xp-laptop-2005-06-25.img -k test_windows -v
-        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin --remote-isf-url="${{env.REMOTE_ISF_URL}}" -k test_linux -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin --remote-isf-url="${{ env.REMOTE_ISF_URL }}" -k test_linux -v
 
     - name: Clean up post-test
       run: |

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,6 +31,13 @@ def pytest_addoption(parser):
         help="path to a directory containing images to test",
     )
 
+    parser.addoption(
+        "--remote-isf-url",
+        action="store",
+        default=None,
+        help="Search online for ISF json files",
+    )
+
 
 def pytest_generate_tests(metafunc):
     """Parameterize tests based on image names"""
@@ -57,3 +64,8 @@ def volatility(request):
 @pytest.fixture
 def python(request):
     return request.config.getoption("--python")
+
+
+@pytest.fixture
+def remote_isf_url(request):
+    return request.config.getoption("--remote-isf-url")

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -12,7 +12,6 @@ import sys
 import shutil
 import tempfile
 import hashlib
-import ntpath
 import json
 
 #
@@ -137,10 +136,7 @@ def test_windows_dumpfiles(image, volatility, python):
 
     failed_chksms = 0
 
-    if sys.platform == "win32":
-        file_name = ntpath.basename(image)
-    else:
-        file_name = os.path.basename(image)
+    file_name = os.path.basename(image)
 
     try:
         for addr in known_files["windows_dumpfiles"][file_name]:

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -38,19 +38,30 @@ def runvol(args, volatility, python):
     return p.returncode, stdout, stderr
 
 
-def runvol_plugin(plugin, img, volatility, python, pluginargs=[], globalargs=[]):
-    args = (
-        globalargs
-        + [
-            "--single-location",
-            img,
-            "-q",
-            plugin,
-        ]
-        + pluginargs
-    )
+def runvol_plugin(
+    plugin,
+    img,
+    volatility,
+    python,
+    remote_isf_url=None,
+    pluginargs=None,
+    globalargs=None,
+):
+    plugin_args = [plugin]
+    plugin_args += pluginargs if pluginargs else []
+    global_args = globalargs or []
 
-    return runvol(args, volatility, python)
+    common_args = [
+        "--single-location",
+        img,
+        "-q",
+    ]
+    if remote_isf_url:
+        common_args += ["--remote-isf-url", remote_isf_url]
+
+    final_args = global_args + common_args + plugin_args
+
+    return runvol(final_args, volatility, python)
 
 
 #

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -203,7 +203,6 @@ def test_windows_thrdscan(image, volatility, python):
     assert out.find(b"\t4\t8") != -1
     assert out.find(b"\t4\t12") != -1
     assert out.find(b"\t4\t16") != -1
-    #assert out.find(b"this raieses AssertionError") != -1
     assert rc == 0
 
 

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -287,8 +287,10 @@ def test_windows_devicetree(image, volatility, python):
 # LINUX
 
 
-def test_linux_pslist(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.pslist.PsList", image, volatility, python)
+def test_linux_pslist(image, volatility, python, remote_isf_url):
+    rc, out, err = runvol_plugin(
+        "linux.pslist.PsList", image, volatility, python, remote_isf_url
+    )
     out = out.lower()
 
     assert (out.find(b"init") != -1) or (out.find(b"systemd") != -1)
@@ -297,8 +299,10 @@ def test_linux_pslist(image, volatility, python):
     assert rc == 0
 
 
-def test_linux_check_idt(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.check_idt.Check_idt", image, volatility, python)
+def test_linux_check_idt(image, volatility, python, remote_isf_url):
+    rc, out, err = runvol_plugin(
+        "linux.check_idt.Check_idt", image, volatility, python, remote_isf_url
+    )
     out = out.lower()
 
     assert out.count(b"__kernel__") >= 10
@@ -306,9 +310,9 @@ def test_linux_check_idt(image, volatility, python):
     assert rc == 0
 
 
-def test_linux_check_syscall(image, volatility, python):
+def test_linux_check_syscall(image, volatility, python, remote_isf_url):
     rc, out, err = runvol_plugin(
-        "linux.check_syscall.Check_syscall", image, volatility, python
+        "linux.check_syscall.Check_syscall", image, volatility, python, remote_isf_url
     )
     out = out.lower()
 
@@ -318,16 +322,20 @@ def test_linux_check_syscall(image, volatility, python):
     assert rc == 0
 
 
-def test_linux_lsmod(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.lsmod.Lsmod", image, volatility, python)
+def test_linux_lsmod(image, volatility, python, remote_isf_url):
+    rc, out, err = runvol_plugin(
+        "linux.lsmod.Lsmod", image, volatility, python, remote_isf_url
+    )
     out = out.lower()
 
     assert out.count(b"\n") > 10
     assert rc == 0
 
 
-def test_linux_lsof(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.lsof.Lsof", image, volatility, python)
+def test_linux_lsof(image, volatility, python, remote_isf_url):
+    rc, out, err = runvol_plugin(
+        "linux.lsof.Lsof", image, volatility, python, remote_isf_url
+    )
     out = out.lower()
 
     assert out.count(b"socket:") >= 10
@@ -335,8 +343,10 @@ def test_linux_lsof(image, volatility, python):
     assert rc == 0
 
 
-def test_linux_proc_maps(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.proc.Maps", image, volatility, python)
+def test_linux_proc_maps(image, volatility, python, remote_isf_url):
+    rc, out, err = runvol_plugin(
+        "linux.proc.Maps", image, volatility, python, remote_isf_url
+    )
     out = out.lower()
 
     assert out.count(b"anonymous mapping") >= 10
@@ -344,16 +354,21 @@ def test_linux_proc_maps(image, volatility, python):
     assert rc == 0
 
 
-def test_linux_tty_check(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.tty_check.tty_check", image, volatility, python)
+def test_linux_tty_check(image, volatility, python, remote_isf_url):
+    rc, out, err = runvol_plugin(
+        "linux.tty_check.tty_check", image, volatility, python, remote_isf_url
+    )
     out = out.lower()
 
     assert out.find(b"__kernel__") != -1
     assert out.count(b"\n") >= 5
     assert rc == 0
 
-def test_linux_sockstat(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.sockstat.Sockstat", image, volatility, python)
+
+def test_linux_sockstat(image, volatility, python, remote_isf_url):
+    rc, out, err = runvol_plugin(
+        "linux.sockstat.Sockstat", image, volatility, python, remote_isf_url
+    )
 
     assert out.count(b"AF_UNIX") >= 354
     assert out.count(b"AF_BLUETOOTH") >= 5
@@ -364,9 +379,9 @@ def test_linux_sockstat(image, volatility, python):
     assert rc == 0
 
 
-def test_linux_library_list(image, volatility, python):
+def test_linux_library_list(image, volatility, python, remote_isf_url):
     rc, out, err = runvol_plugin(
-        "linux.library_list.LibraryList", image, volatility, python
+        "linux.library_list.LibraryList", image, volatility, python, remote_isf_url
     )
 
     assert re.search(


### PR DESCRIPTION
This PR introduces changes to enhance our testing capabilities by allowing Linux test cases to use the @Abyss-W4tcher ISF repository on GitHub. 
This not only provides greater flexibility for updating the ISF database and keeping it in sync with the latest `dwarf2json` version, but also establishes a fully open-source workflow. 
This will enable us to easily add more images later on, such as different Linux kernel versions and distributions, which will be immediately ready for testing our code.

If it's successful and accepted, we can also migrate the macOS test cases to use this repository.