### PR TITLE
Allow to import external locals in volshell environment

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -95,8 +95,8 @@ class Volshell(interfaces.plugins.PluginInterface):
 
         sys.ps1 = f"({self.current_layer}) >>> "
         # Dict self._construct_locals_dict() will have priority on keys
-        combined_locals = self._construct_locals_dict().copy()
-        combined_locals.update(additional_locals)
+        combined_locals = additional_locals.copy()
+        combined_locals.update(self._construct_locals_dict())
         self.__console = code.InteractiveConsole(locals=combined_locals)
         # Since we have to do work to add the option only once for all different modes of volshell, we can't
         # rely on the default having been set

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -58,7 +58,7 @@ class Volshell(interfaces.plugins.PluginInterface):
         ]
 
     def run(
-        self, additional_locals: Dict[str, Any] = None
+        self, additional_locals: Dict[str, Any] = {}
     ) -> interfaces.renderers.TreeGrid:
         """Runs the interactive volshell plugin.
 
@@ -94,7 +94,10 @@ class Volshell(interfaces.plugins.PluginInterface):
 """
 
         sys.ps1 = f"({self.current_layer}) >>> "
-        self.__console = code.InteractiveConsole(locals=self._construct_locals_dict())
+        # Dict self._construct_locals_dict() will have priority on keys
+        combined_locals = self._construct_locals_dict().copy()
+        combined_locals.update(additional_locals)
+        self.__console = code.InteractiveConsole(locals=combined_locals)
         # Since we have to do work to add the option only once for all different modes of volshell, we can't
         # rely on the default having been set
         if self.config.get("script", None) is not None:


### PR DESCRIPTION
Hi,

this PR adds the possibility to import external locals in a volshell environment. It was needed to import Volshell in the current context, when developing and debugging a plugin. 

By the way, this is a cool feature that allows to setup an environment and then analyze created objects efficiently (without pasting and declaring functions directly in volshell). To use it, add the following to your plugin (temporarily of course) : 

```python 
# Imports
from volatility3.cli.volshell import generic 

# Plugin requirements 
            requirements.PluginRequirement(
                name="volshell", plugin=generic.Volshell, version=(0, 0, 0)
            ),

# Wherever needed
self.context.config[self.config_path + "." + "primary"] = kernel.layer_name
generic.Volshell(self.context, self.config_path).run(additional_locals=locals()) # or even {**locals(), **globals()} if needed
# Then, an interactive session will start :)
```