### PR TITLE
Linux: Extensions - removes abc.Iterable definition

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1004,7 +1004,7 @@ class list_head(objects.StructType, collections.abc.Iterable):
         return self.to_list(self.vol.parent.vol.type_name, self.vol.member_name)
 
 
-class hlist_head(objects.StructType, collections.abc.Iterable):
+class hlist_head(objects.StructType):
     def to_list(
         self,
         symbol_type: str,
@@ -1036,9 +1036,6 @@ class hlist_head(objects.StructType, collections.abc.Iterable):
             )
 
             current = current.next
-
-    def __iter__(self) -> Iterator[interfaces.objects.ObjectInterface]:
-        return self.to_list(self.vol.parent.vol.type_name, self.vol.member_name)
 
 
 class files_struct(objects.StructType):

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1037,6 +1037,9 @@ class hlist_head(objects.StructType, collections.abc.Iterable):
 
             current = current.next
 
+    def __iter__(self) -> Iterator[interfaces.objects.ObjectInterface]:
+        return self.to_list(self.vol.parent.vol.type_name, self.vol.member_name)
+
 
 class files_struct(objects.StructType):
     def get_fds(self) -> interfaces.objects.ObjectInterface:


### PR DESCRIPTION
`hlist_head` is missing an implementation for `collections.abc.Iterable`, resulting in a crash at runtime. This fixes the issue by providing the required `__iter__` implementation for `hlist_head`.
