### PR TITLE
Linux: netfilter plugin: Fix hooked field to match Volatility2 output

### DIFF
--- a/volatility3/framework/plugins/linux/netfilter.py
+++ b/volatility3/framework/plugins/linux/netfilter.py
@@ -675,7 +675,7 @@ class Netfilter(interfaces.plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 0)
+    _version = (1, 1, 0)
 
     _required_linuxutils_version = (2, 1, 0)
     _required_lsmod_version = (2, 0, 0)

--- a/volatility3/framework/plugins/linux/netfilter.py
+++ b/volatility3/framework/plugins/linux/netfilter.py
@@ -174,7 +174,7 @@ class AbstractNetfilter(ABC):
             priority [int]: Priority
             hook_ops_hook [int]: Hook address
             module_name [str]: Linux kernel module name
-            hooked [bool]: hooked?
+            hooked [bool]: "True" if the network stack has been hijacked
         """
         for netns, net in self.get_net_namespaces():
             for proto_idx, proto_name, hook_idx, hook_name in self._proto_hook_loop():

--- a/volatility3/framework/plugins/linux/netfilter.py
+++ b/volatility3/framework/plugins/linux/netfilter.py
@@ -190,7 +190,7 @@ class AbstractNetfilter(ABC):
                         priority = int(hook_ops.priority)
                         hook_ops_hook = hook_ops.hook
                         module_name = self.get_module_name_for_address(hook_ops_hook)
-                        hooked = module_name is not None
+                        hooked = module_name is None
 
                         yield netns, proto_name, hook_name, priority, hook_ops_hook, module_name, hooked
 


### PR DESCRIPTION
This PR fixes how the hooked module is interpreted to match the output of its Volatility2 counterpart.