### PR TITLE
Linux: vfsmount type: Fix type comparison

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1299,7 +1299,7 @@ class vfsmount(objects.StructType):
             bool: 'True' if the given argument points to the the same 'vfsmount'
             as 'self'.
         """
-        if type(vfsmount_ptr) == objects.Pointer:
+        if isinstance(vfsmount_ptr, objects.Pointer):
             return self.vol.offset == vfsmount_ptr
         else:
             raise exceptions.VolatilityException(


### PR DESCRIPTION
This PR fixes an incorrect type comparison in the vfsmount object extension, which i.e. caused Flake to flag it as an error.