### PR TITLE
Linux refactory module extension object mod_mem_type cache

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -32,7 +32,7 @@ vollog = logging.getLogger(__name__)
 class module(generic.GenericIntelProcess):
 
     @functools.cached_property
-    def mod_mem_type(self):
+    def mod_mem_type(self) -> Dict:
         """Return the mod_mem_type enum choices if available or an empty dict if not"""
         # mod_mem_type and module_memory were added in kernel 6.4 which replaces
         # module_layout for storing the information around core_layout etc.

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -31,29 +31,24 @@ vollog = logging.getLogger(__name__)
 
 class module(generic.GenericIntelProcess):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._mod_mem_type = None  # Initialize _mod_mem_type to None for memoization
-
-    @property
+    @functools.cached_property
     def mod_mem_type(self):
         """Return the mod_mem_type enum choices if available or an empty dict if not"""
         # mod_mem_type and module_memory were added in kernel 6.4 which replaces
         # module_layout for storing the information around core_layout etc.
         # see commit ac3b43283923440900b4f36ca5f9f0b1ca43b70e for more information
+        symbol_table_name = self.get_symbol_table_name()
+        mod_mem_type_symname = symbol_table_name + constants.BANG + "mod_mem_type"
+        symbol_space = self._context.symbol_space
+        try:
+            mod_mem_type = symbol_space.get_enumeration(mod_mem_type_symname).choices
+        except exceptions.SymbolError:
+            mod_mem_type = {}
+            vollog.debug(
+                "Unable to find mod_mem_type enum. This message can be ignored for kernels < 6.4"
+            )
 
-        if self._mod_mem_type is None:
-            try:
-                self._mod_mem_type = self._context.symbol_space.get_enumeration(
-                    self.get_symbol_table_name() + constants.BANG + "mod_mem_type"
-                ).choices
-            except exceptions.SymbolError:
-                vollog.debug(
-                    "Unable to find mod_mem_type enum. This message can be ignored for kernels < 6.4"
-                )
-                # set to empty dict to show that the enum was not found, and so shouldn't be searched for again
-                self._mod_mem_type = {}
-        return self._mod_mem_type
+        return mod_mem_type
 
     def get_module_base(self):
         if self.has_member("mem"):  # kernels 6.4+


### PR DESCRIPTION
From Python 3.8, the built-in `functools` module provides a `cached_property` decorator. This allow us to simplify the custom made property cache in `module::mod_mem_type`. This PR replaces that code with the decorator.

_Note that both this implementation and the previous one perform caching on a per-instance basis. While this may help in some scenarios, it’s not the most efficient approach; for instance, the `lsmod plugin` repeatedly resolves the enumerator for each module individually, making the cache ineffective. 
A more effective solution would be to adopt a similar strategy to the previous implementation but implement caching at the class level using a class variable._ 

@ikelos Do you think caching per instance is a reasonable trade-off, or would you prefer to enhance efficiency by caching the enumerator at the class level?