### PR TITLE
linux: hidden_modules: Fix mess with merge #1283

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -63,19 +63,18 @@ class module(generic.GenericIntelProcess):
         # mod_mem_type and module_memory were added in kernel 6.4 which replaces
         # module_layout for storing the information around core_layout etc.
         # see commit ac3b43283923440900b4f36ca5f9f0b1ca43b70e for more information
+        symbol_table_name = self.get_symbol_table_name()
+        mod_mem_type_symname = symbol_table_name + constants.BANG + "mod_mem_type"
+        symbol_space = self._context.symbol_space
+        try:
+            mod_mem_type = symbol_space.get_enumeration(mod_mem_type_symname).choices
+        except exceptions.SymbolError:
+            mod_mem_type = {}
+            vollog.debug(
+                "Unable to find mod_mem_type enum. This message can be ignored for kernels < 6.4"
+            )
 
-        if self._mod_mem_type is None:
-            try:
-                self._mod_mem_type = self._context.symbol_space.get_enumeration(
-                    self.get_symbol_table_name() + constants.BANG + "mod_mem_type"
-                ).choices
-            except exceptions.SymbolError:
-                vollog.debug(
-                    "Unable to find mod_mem_type enum. This message can be ignored for kernels < 6.4"
-                )
-                # set to empty dict to show that the enum was not found, and so shouldn't be searched for again
-                self._mod_mem_type = {}
-        return self._mod_mem_type
+        return mod_mem_type
 
     def _get_mem_type(self, mod_mem_type_name):
         module_mem_index = self.mod_mem_type.get(mod_mem_type_name)


### PR DESCRIPTION
In the context of #1283, the last merge with `develop` didn't go as planned, resulting in the changes from #1328 being overwritten, this PR fixes that.