### PR TITLE
Linux - PROT_NONE, L1TF mitigation and layer address translation fix

### DIFF
--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -80,14 +80,14 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
                     context, table_name, layer_name, progress_callback=progress_callback
                 )
 
-                layer_class: Type = intel.Intel
                 if "init_top_pgt" in table.symbols:
-                    layer_class = intel.Intel32e
+                    layer_class = intel.LinuxIntel32e
                     dtb_symbol_name = "init_top_pgt"
                 elif "init_level4_pgt" in table.symbols:
-                    layer_class = intel.Intel32e
+                    layer_class = intel.LinuxIntel32e
                     dtb_symbol_name = "init_level4_pgt"
                 else:
+                    layer_class = intel.LinuxIntel
                     dtb_symbol_name = "swapper_pg_dir"
 
                 dtb = cls.virtual_to_physical_address(

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 11  # Number of changes that only add to the interface
+VERSION_MINOR = 12  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/constants/linux/__init__.py
+++ b/volatility3/framework/constants/linux/__init__.py
@@ -11,14 +11,6 @@ KERNEL_NAME = "__kernel__"
 
 """The value hard coded from the Linux Kernel (hence not extracted from the layer itself)"""
 
-# Translation Layer constants
-PAGE_BIT_PRESENT = 0
-PAGE_BIT_PSE = 7  # Page Size Extension: 4 MB (or 2MB) page
-PAGE_BIT_PROTNONE = 8
-PAGE_BIT_PAT_LARGE = 12  # 2MB or 1GB pages
-PAGE_PRESENT = 1 << PAGE_BIT_PRESENT
-PAGE_PROTNONE = 1 << PAGE_BIT_PROTNONE
-
 # include/linux/sched.h
 PF_KTHREAD = 0x00200000  # I'm a kernel thread
 

--- a/volatility3/framework/constants/linux/__init__.py
+++ b/volatility3/framework/constants/linux/__init__.py
@@ -11,6 +11,14 @@ KERNEL_NAME = "__kernel__"
 
 """The value hard coded from the Linux Kernel (hence not extracted from the layer itself)"""
 
+# Translation Layer constants
+PAGE_BIT_PRESENT = 0
+PAGE_BIT_PSE = 7  # Page Size Extension: 4 MB (or 2MB) page
+PAGE_BIT_PROTNONE = 8
+PAGE_BIT_PAT_LARGE = 12  # 2MB or 1GB pages
+PAGE_PRESENT = 1 << PAGE_BIT_PRESENT
+PAGE_PROTNONE = 1 << PAGE_BIT_PROTNONE
+
 # include/linux/sched.h
 PF_KTHREAD = 0x00200000  # I'm a kernel thread
 

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -136,7 +136,7 @@ class DataLayerInterface(
     def minimum_address(self) -> int:
         """Returns the minimum valid address of the space."""
 
-    @property
+    @functools.cached_property
     def address_mask(self) -> int:
         """Returns a mask which encapsulates all the active bits of an address
         for this layer."""

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -569,7 +569,7 @@ class LinuxMixin(Intel):
 
     def _protnone_mask(self, entry: int) -> int:
         """Gets a mask to XOR with the page table entry to get the correct PFN"""
-        return ~0 & self._register_mask if self._pte_needs_invert(entry) else 0
+        return self._register_mask if self._pte_needs_invert(entry) else 0
 
     def _pte_pfn(self, entry: int) -> int:
         """Extracts the page frame number from the page table entry"""

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -563,8 +563,9 @@ class LinuxMixin(Intel):
         return self._is_pte_present(entry)
 
     def _pte_needs_invert(self, entry) -> bool:
-        # Entries that were set to PROT_NONE (PAGE_PRESENT/PAGE_GLOBAL) are inverted
-        return not (entry & self._PAGE_PRESENT)
+        # Entries that were set to PROT_NONE (PAGE_PRESENT) are inverted
+        # A clear PTE shouldn't be inverted. See f19f5c4
+        return entry and not (entry & self._PAGE_PRESENT)
 
     def _protnone_mask(self, entry: int) -> int:
         """Gets a mask to XOR with the page table entry to get the correct PFN"""

--- a/volatility3/framework/layers/intel.py
+++ b/volatility3/framework/layers/intel.py
@@ -252,7 +252,7 @@ class Intel(linear.LinearlyMappedLayer):
 
         return entry, position
 
-    @functools.lru_cache(1025)
+    @functools.lru_cache(maxsize=1025)
     def _get_valid_table(self, base_address: int) -> Optional[bytes]:
         """Extracts the table, validates it and returns it if it's valid."""
         table = self._context.layers.read(


### PR DESCRIPTION
This PR introduces improvements and fixes for address translation in the Linux Intel layers

# PROT_NONE pages 
First, this PR fixes one of the oldest issues in the queue https://github.com/volatilityfoundation/volatility3/issues/134, adding support for PROT_NONE protected pages.

Using the @gleeda PoC from their excellent post [Using mprotect PROT_NONE on Linux](https://volatility-labs.blogspot.com/2015/05/using-mprotect-protnone-on-linux.html). 
```shell
$ ./victim 
PID 2116
buffer at 0x76f63a132000       <= PROT_NONE vma
buffer2 at 0x76f63a133000
```

Before:
```python
>>> task.pid
2116

>>> proc_layer.read(0x76F63A133000, 10)
b'not here\x00\x00'

>>> proc_layer.read(0x76F63A132000, 10)
Traceback (most recent call last):
  File "/home/user/vol3/volatility3/framework/layers/linear.py", line 45, in read
    for offset, _, mapped_offset, mapped_length, layer in self.mapping(
  File "/home/user/vol3/volatility3/framework/layers/intel.py", line 295, in mapping
    for offset, size, mapped_offset, mapped_size, map_layer in self._mapping(
  File "/home/user/vol3/volatility3/framework/layers/intel.py", line 351, in _mapping
    chunk_offset, page_size, layer_name = self._translate(offset)
  File "/home/user/vol3/volatility3/framework/layers/intel.py", line 159, in _translate
    raise exceptions.PagedInvalidAddressException(
volatility3.framework.exceptions.PagedInvalidAddressException: Page Fault at entry 0x40fffffed82d920 in page entry
```

After:
```python
>>> proc_layer.read(0x76F63A133000, 10)
b'not here\x00\x00'

>>> proc_layer.read(0x76F63A132000, 10)
b'find me\x00\x00\x00'
```

# Intel Side Channel Vulnerability L1TF mitigation.

In 2018, to mitigate Intel's L1TF (L1 Terminal Fault) vulnerability, that code in Linux kernel was again updated in [this commit](https://github.com/torvalds/linux/commit/6b28baca9b1f0d4a42b865da7a05b1c81424bd5c), incorporating PFN inversion to calculate the PTE. This PR includes support for handling these cases as well.

# __PHYSICAL_MASK_SHIFT and _maxphyaddr
While addressing the previous issues, I found that the changes didn't work for older kernels. After further investigation, it turned out the problem was the `physical_mask` and the reason was [this](https://github.com/torvalds/linux/commit/b83ce5ee91471d19c403ff91227204fb37c95fb2) commit. 

In the Linux kernel, the [__PHYSICAL_MASK_SHIFT](https://elixir.bootlin.com/linux/v6.11.6/source/arch/x86/include/asm/page_64_types.h#L54) is a mask used to extract the physical address from a PTE. In Volatility3, this is referred to as `_maxphyaddr`.

Until kernel version 4.17, Linux x86-64 used a 46-bit mask. With [this](https://github.com/torvalds/linux/commit/b83ce5ee91471d19c403ff91227204fb37c95fb2) commit, this was extended to 52 bits, applying to both 4 and 5-level page tables.

We previously used 52 bits for all Intel 64-bit systems, but this produced incorrect results for **PROT_NONE** pages. Since the mask value is defined by a preprocessor macro, it's difficult to detect the exact bit shift used in the current kernel. 
Using 46 bits has proven reliable for our use case, as seen in tools like crashtool. See [this](https://github.com/crash-utility/crash/blob/master/x86_64.c#L293) and [this](https://github.com/crash-utility/crash/blob/master/defs.h#L4073).



