### PR TITLE
Improve windows.amcache plugin description

### DIFF
--- a/volatility3/framework/plugins/windows/amcache.py
+++ b/volatility3/framework/plugins/windows/amcache.py
@@ -215,7 +215,7 @@ def _get_datetime_str_value(
 
 
 class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
-    """Scans for windows services."""
+    """Extract information on executed applications from the AmCache."""
 
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)


### PR DESCRIPTION
The description of the `windows.amcache.Amcache` plugin seems to have been copied from the `windows.svclist.SvcList` plugin and was not changed. This PR changes the description to reflect the actual use of the plugin:

```
    windows.amcache.Amcache
                        Extract information on executed applications from the
                        AmCache.
```