### PR TITLE
Print plugin description on plugin --help

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -367,7 +367,9 @@ class CommandLine:
         )
         for plugin in sorted(plugin_list):
             plugin_parser = subparser.add_parser(
-                plugin, help=plugin_list[plugin].__doc__
+                plugin,
+                help=plugin_list[plugin].__doc__,
+                description=plugin_list[plugin].__doc__,
             )
             self.populate_requirements_argparse(plugin_parser, plugin_list[plugin])
 


### PR DESCRIPTION
This makes plugins print their description when using `--help`:

### Before
```
usage: volatility linux.pslist.PsList [-h] [--pid [PID ...]] [--threads] [--decorate-comm] [--dump]

options:
  -h, --help       show this help message and exit
  --pid [PID ...]  Filter on specific process IDs
  --threads        Include user threads
  --decorate-comm  Show `user threads` comm in curly brackets, and `kernel threads` comm in square brackets
  --dump           Extract listed processes
```

### After
```
Volatility 3 Framework 2.11.0
usage: volatility linux.pslist.PsList [-h] [--pid [PID ...]] [--threads] [--decorate-comm] [--dump]

Lists the processes present in a particular linux memory image.

options:
  -h, --help       show this help message and exit
  --pid [PID ...]  Filter on specific process IDs
  --threads        Include user threads
  --decorate-comm  Show `user threads` comm in curly brackets, and `kernel threads` comm in square brackets
  --dump           Extract listed processes
```