### PR TITLE
Environment variable for the Microsoft Symbol Server URL

### DIFF
--- a/development/pdbparse-to-json.py
+++ b/development/pdbparse-to-json.py
@@ -26,7 +26,7 @@ class PDBRetreiver:
     def retreive_pdb(self, guid: str, file_name: str) -> Optional[str]:
         logger.info("Download PDB file...")
         file_name = ".".join(file_name.split(".")[:-1] + ['pdb'])
-        for sym_url in ['http://msdl.microsoft.com/download/symbols']:
+        for sym_url in [os.environ.get("VOL3_MSSYMBOLSERVER", "http://msdl.microsoft.com/download/symbols")]:
             url = sym_url + f"/{file_name}/{guid}/"
 
             result = None

--- a/volatility3/framework/symbols/windows/pdbconv.py
+++ b/volatility3/framework/symbols/windows/pdbconv.py
@@ -949,7 +949,7 @@ class PdbRetreiver:
     ) -> Optional[str]:
         vollog.info("Download PDB file...")
         file_name = ".".join(file_name.split(".")[:-1] + ["pdb"])
-        for sym_url in ["http://msdl.microsoft.com/download/symbols"]:
+        for sym_url in [os.environ.get("VOL3_MSSYMBOLSERVER", "http://msdl.microsoft.com/download/symbols")]:
             url = sym_url + f"/{file_name}/{guid}/"
 
             result = None


### PR DESCRIPTION
I am running Volatility in an environment where I provide already downloaded symbols using a local caching mirror of the symbol server. To make volatility look for my custom remote I need to be able to overwrite the URL it contacts. I solved this using a environment variable `VOL3_MSSYMBOLSERVER` which is preferred if set but stays with the default value if not. I figured some might do the same or might want to the same in the future so I thought I could open a pull request and see if you are interested.
I didn't find documentation about environment variables which are already used by Volatility. The name of the variable could be changed of course.