### PR TITLE
Linux - miscellaneous fixes

### DIFF
--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -454,7 +454,7 @@ class InodePages(plugins.PluginInterface):
                     if current_fp + len(page_bytes) > inode_size:
                         vollog.error(
                             "Page out of file bounds: inode 0x%x, inode size %d, page index %d",
-                            inode.vol.object,
+                            inode.vol.offset,
                             inode_size,
                             page_idx,
                         )

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -240,7 +240,7 @@ class module(generic.GenericIntelProcess):
             for sym in syms:
                 yield sym
 
-    def get_symbols_names_and_addresses(self) -> Tuple[str, int]:
+    def get_symbols_names_and_addresses(self) -> Iterable[Tuple[str, int]]:
         """Get names and addresses for each symbol of the module
 
         Yields:
@@ -1098,7 +1098,7 @@ class dentry(objects.StructType):
             current_dentry = current_dentry.d_parent
         return None
 
-    def get_subdirs(self) -> interfaces.objects.ObjectInterface:
+    def get_subdirs(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Walks dentry subdirs
 
         Yields:
@@ -2435,7 +2435,7 @@ class inode(objects.StructType):
         """
         return stat.filemode(self.i_mode)
 
-    def get_pages(self) -> interfaces.objects.ObjectInterface:
+    def get_pages(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Gets the inode's cached pages
 
         Yields:
@@ -2643,7 +2643,7 @@ class IDR(objects.StructType):
 
         return idr_layer
 
-    def _old_kernel_get_entries(self) -> int:
+    def _old_kernel_get_entries(self) -> Iterable[int]:
         # Kernels < 4.11
         cur = self.cur
         total = next_id = 0
@@ -2655,7 +2655,7 @@ class IDR(objects.StructType):
 
             next_id += 1
 
-    def _new_kernel_get_entries(self) -> int:
+    def _new_kernel_get_entries(self) -> Iterable[int]:
         # Kernels >= 4.11
         id_storage = linux.IDStorage.choose_id_storage(
             self._context, kernel_module_name="kernel"
@@ -2663,7 +2663,7 @@ class IDR(objects.StructType):
         for page_addr in id_storage.get_entries(root=self.idr_rt):
             yield page_addr
 
-    def get_entries(self) -> int:
+    def get_entries(self) -> Iterable[int]:
         """Walks the IDR and yield a pointer associated with each element.
 
         Args:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -287,7 +287,7 @@ class module(generic.GenericIntelProcess):
             return self.kallsyms.symtab
         elif self.has_member("symtab"):
             return self.symtab
-        raise AttributeError("module -> symtab: Unable to get symtab")
+        raise AttributeError("Unable to get symtab")
 
     @property
     def num_symtab(self):
@@ -295,9 +295,7 @@ class module(generic.GenericIntelProcess):
             return int(self.kallsyms.num_symtab)
         elif self.has_member("num_symtab"):
             return int(self.member("num_symtab"))
-        raise AttributeError(
-            "module -> num_symtab: Unable to determine number of symbols"
-        )
+        raise AttributeError("Unable to determine number of symbols")
 
     @property
     def section_strtab(self):
@@ -307,7 +305,7 @@ class module(generic.GenericIntelProcess):
         # Older kernels
         elif self.has_member("strtab"):
             return self.strtab
-        raise AttributeError("module -> strtab: Unable to get strtab")
+        raise AttributeError("Unable to get strtab")
 
 
 class task_struct(generic.GenericIntelProcess):

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -294,7 +294,7 @@ class module(generic.GenericIntelProcess):
         if self.has_member("kallsyms"):
             return int(self.kallsyms.num_symtab)
         elif self.has_member("num_symtab"):
-            return int(self.num_symtab)
+            return int(self.member("num_symtab"))
         raise AttributeError(
             "module -> num_symtab: Unable to determine number of symbols"
         )


### PR DESCRIPTION
This PR addresses two bugs: one in a Page Cache log message and another that causes call recursion in the module object extension. Additionally, it enhances type annotations and refines log messages.