### PR TITLE
Volshell: add regex_scan

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -149,7 +149,7 @@ class Volshell(interfaces.plugins.PluginInterface):
             (["cc", "create_configurable"], self.create_configurable),
             (["lf", "load_file"], self.load_file),
             (["rs", "run_script"], self.run_script),
-            (["re", "regex_scan"], self.regex_scan),
+            (["rx", "regex_scan"], self.regex_scan),
         ]
 
     def _construct_locals_dict(self) -> Dict[str, Any]:
@@ -292,7 +292,7 @@ class Volshell(interfaces.plugins.PluginInterface):
     def regex_scan(self, pattern, count=128, layer_name=None):
         """Scans for regex pattern in layer using RegExScanner."""
         if not isinstance(pattern, bytes):
-            raise TypeError("pattern must be bytes, e.g. re(b'pattern')")
+            raise TypeError("pattern must be bytes, e.g. rx(b'pattern')")
         layer_name_to_scan = layer_name or self.current_layer
         for offset in self.context.layers[layer_name_to_scan].scan(
             scanner=scanners.RegExScanner(pattern),

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -14,7 +14,7 @@ from urllib import parse, request
 from volatility3.cli import text_renderer, volshell
 from volatility3.framework import exceptions, interfaces, objects, plugins, renderers
 from volatility3.framework.configuration import requirements
-from volatility3.framework.layers import intel, physical, resources
+from volatility3.framework.layers import intel, physical, resources, scanners
 
 try:
     import capstone
@@ -149,6 +149,7 @@ class Volshell(interfaces.plugins.PluginInterface):
             (["cc", "create_configurable"], self.create_configurable),
             (["lf", "load_file"], self.load_file),
             (["rs", "run_script"], self.run_script),
+            (["re", "regex_scan"], self.regex_scan),
         ]
 
     def _construct_locals_dict(self) -> Dict[str, Any]:
@@ -287,6 +288,21 @@ class Volshell(interfaces.plugins.PluginInterface):
         """Displays word values (2 bytes) and corresponding ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
         self._display_data(offset, remaining_data, format_string="H")
+
+    def regex_scan(self, pattern, count=128, layer_name=None):
+        """Scans for regex pattern in layer using RegExScanner."""
+        if not isinstance(pattern, bytes):
+            raise TypeError("pattern must be bytes, e.g. re(b'pattern')")
+        layer_name_to_scan = layer_name or self.current_layer
+        for offset in self.context.layers[layer_name_to_scan].scan(
+            scanner=scanners.RegExScanner(pattern),
+            context=self.context,
+        ):
+            remaining_data = self._read_data(
+                offset, count=count, layer_name=layer_name_to_scan
+            )
+            self._display_data(offset, remaining_data)
+            print("")
 
     def disassemble(self, offset, count=128, layer_name=None, architecture=None):
         """Disassembles a number of instructions from the code at offset"""


### PR DESCRIPTION
Hello :wave:

This PR adds a quailty of life feature to volshell allowing easy use of the regex scanner. I often find myself needing to scan for some bytes or a pattern. I can use a scanner with a loop to display the results but I do it so frequently I thought a little wrapper would be nice to have.

An optional size can be given for the displayed results as with the other fuctions (`db`, `db`, `dq`, etc).

You can of course specify a different layer name as well. 

Here are some examples:
```python
(volatility3) eve@xps:~/Documents/volatility3$ python3 volshell.py -f linux-sample-1.dmp -l
Volshell (Volatility 3 Framework) 2.11.0
Readline imported successfully  Stacking attempts finished                 

    Call help() to see available functions

    Volshell mode        : Linux
    Current Layer        : layer_name
    Current Symbol Table : symbol_table_name1
    Current Kernel Name  : kernel

(layer_name) >>> re(rb"swapper(\/0|\x00\x00)\x00\x00\x00\x00\x00\x00", 32)
0x88000160d3b8    73 77 61 70 70 65 72 2f 30 00 00 00 00 00 00 00    swapper/0.......
0x88000160d3c8    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................

0x88001d80eb00    73 77 61 70 70 65 72 2f 30 00 00 00 00 00 00 00    swapper/0.......
0x88001d80eb10    01 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00    ................

0xffff8160d3b8    73 77 61 70 70 65 72 2f 30 00 00 00 00 00 00 00    swapper/0.......
0xffff8160d3c8    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................

(layer_name) >>> re(rb"swapper(\/0|\x00\x00)\x00\x00\x00\x00\x00\x00", 32, 'memory_layer')
0x160d3b8    73 77 61 70 70 65 72 2f 30 00 00 00 00 00 00 00    swapper/0.......
0x160d3c8    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................

0x1d80eb00    73 77 61 70 70 65 72 2f 30 00 00 00 00 00 00 00    swapper/0.......
0x1d80eb10    01 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00    ................
```

Running the linux version scan:
```python
(layer_name) >>> re(rb"(Linux version|Darwin Kernel Version) [0-9]+\.[0-9]+\.[0-9]+")
0x880001400070    4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e    Linux.version.3.
0x880001400080    32 2e 30 2d 34 2d 61 6d 64 36 34 20 28 64 65 62    2.0-4-amd64.(deb
0x880001400090    69 61 6e 2d 6b 65 72 6e 65 6c 40 6c 69 73 74 73    ian-kernel@lists
0x8800014000a0    2e 64 65 62 69 61 6e 2e 6f 72 67 29 20 28 67 63    .debian.org).(gc
0x8800014000b0    63 20 76 65 72 73 69 6f 6e 20 34 2e 36 2e 33 20    c.version.4.6.3.
0x8800014000c0    28 44 65 62 69 61 6e 20 34 2e 36 2e 33 2d 31 34    (Debian.4.6.3-14
0x8800014000d0    29 20 29 20 23 31 20 53 4d 50 20 44 65 62 69 61    ).).#1.SMP.Debia
0x8800014000e0    6e 20 33 2e 32 2e 35 37 2d 33 2b 64 65 62 37 75    n.3.2.57-3+deb7u

0x880001769027    4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e    Linux.version.3.
0x880001769037    32 2e 30 2d 34 2d 61 6d 64 36 34 20 28 64 65 62    2.0-4-amd64.(deb
0x880001769047    69 61 6e 2d 6b 65 72 6e 65 6c 40 6c 69 73 74 73    ian-kernel@lists
0x880001769057    2e 64 65 62 69 61 6e 2e 6f 72 67 29 20 28 67 63    .debian.org).(gc
0x880001769067    63 20 76 65 72 73 69 6f 6e 20 34 2e 36 2e 33 20    c.version.4.6.3.
0x880001769077    28 44 65 62 69 61 6e 20 34 2e 36 2e 33 2d 31 34    (Debian.4.6.3-14
0x880001769087    29 20 29 20 23 31 20 53 4d 50 20 44 65 62 69 61    ).).#1.SMP.Debia
0x880001769097    6e 20 33 2e 32 2e 35 37 2d 33 2b 64 65 62 37 75    n.3.2.57-3+deb7u

0xffff81400070    4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e    Linux.version.3.
0xffff81400080    32 2e 30 2d 34 2d 61 6d 64 36 34 20 28 64 65 62    2.0-4-amd64.(deb
0xffff81400090    69 61 6e 2d 6b 65 72 6e 65 6c 40 6c 69 73 74 73    ian-kernel@lists
0xffff814000a0    2e 64 65 62 69 61 6e 2e 6f 72 67 29 20 28 67 63    .debian.org).(gc
0xffff814000b0    63 20 76 65 72 73 69 6f 6e 20 34 2e 36 2e 33 20    c.version.4.6.3.
0xffff814000c0    28 44 65 62 69 61 6e 20 34 2e 36 2e 33 2d 31 34    (Debian.4.6.3-14
0xffff814000d0    29 20 29 20 23 31 20 53 4d 50 20 44 65 62 69 61    ).).#1.SMP.Debia
0xffff814000e0    6e 20 33 2e 32 2e 35 37 2d 33 2b 64 65 62 37 75    n.3.2.57-3+deb7u

0xffff81769027    4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e    Linux.version.3.
0xffff81769037    32 2e 30 2d 34 2d 61 6d 64 36 34 20 28 64 65 62    2.0-4-amd64.(deb
0xffff81769047    69 61 6e 2d 6b 65 72 6e 65 6c 40 6c 69 73 74 73    ian-kernel@lists
0xffff81769057    2e 64 65 62 69 61 6e 2e 6f 72 67 29 20 28 67 63    .debian.org).(gc
0xffff81769067    63 20 76 65 72 73 69 6f 6e 20 34 2e 36 2e 33 20    c.version.4.6.3.
0xffff81769077    28 44 65 62 69 61 6e 20 34 2e 36 2e 33 2d 31 34    (Debian.4.6.3-14
0xffff81769087    29 20 29 20 23 31 20 53 4d 50 20 44 65 62 69 61    ).).#1.SMP.Debia
0xffff81769097    6e 20 33 2e 32 2e 35 37 2d 33 2b 64 65 62 37 75    n.3.2.57-3+deb7u
```

Scanning within a process layer:
```python
(layer_name) >>> ct(8600)
(layer_name_Process8600) >>> re(b'root@debian-book-sample:')
<snip>
0x880018483a74    72 6f 6f 74 40 64 65 62 69 61 6e 2d 62 6f 6f 6b    root@debian-book
0x880018483a84    2d 73 61 6d 70 6c 65 3a 2f 68 6f 6d 65 2f 76 6f    -sample:/home/vo
0x880018483a94    6c 23 20 6e 65 74 73 74 61 74 20 2d 70 61 6e 20    l#.netstat.-pan.
0x880018483aa4    7c 20 67 72 65 70 20 4c 49 53 54 45 4e 20 7c 20    |.grep.LISTEN.|.
0x880018483ab4    67 72 65 70 20 74 63 70 00 00 00 00 00 00 00 00    grep.tcp........
0x880018483ac4    0a 74 63 70 20 20 20 20 20 20 20 20 30 20 20 20    .tcp........0...
0x880018483ad4    20 20 20 30 20 30 2e 30 2e 30 2e 30 3a 31 33 39    ...0.0.0.0.0:139
0x880018483ae4    20 20 20 20 20 20 20 20 20 20 20 20 20 30 2e 30    .............0.0

0x88001b78787d    72 6f 6f 74 40 64 65 62 69 61 6e 2d 62 6f 6f 6b    root@debian-book
0x88001b78788d    2d 73 61 6d 70 6c 65 3a 2f 68 6f 6d 65 2f 76 6f    -sample:/home/vo
0x88001b78789d    6c 2f 6c 69 6d 65 2f 73 72 63 23 20 2e 2f 6c 69    l/lime/src#../li
0x88001b7878ad    07 6d 65 07 08 1b 5b 4b 08 1b 5b 4b 08 1b 5b 4b    .me...[K..[K..[K
0x88001b7878bd    08 1b 5b 4b 08 1b 5b 4b 08 1b 5b 4b 07 20 20 20    ..[K..[K..[K....
0x88001b7878cd    20 20 69 6e 65 74 36 20 61 64 64 72 3a 20 3a 3a    ..inet6.addr:.::
0x88001b7878dd    31 2f 31 32 38 20 53 63 6f 70 65 3a 48 6f 73 74    1/128.Scope:Host
0x88001b7878ed    0d 0a 20 20 20 20 20 20 20 20 20 20 55 50 20 4c    ............UP.L

0x88001c395966    72 6f 6f 74 40 64 65 62 69 61 6e 2d 62 6f 6f 6b    root@debian-book
0x88001c395976    2d 73 61 6d 70 6c 65 3a 2f 68 6f 6d 65 2f 76 6f    -sample:/home/vo
0x88001c395986    6c 2f 6c 69 6d 65 2f 73 72 63 23 20 2e 2f 6c 69    l/lime/src#../li
0x88001c395996    07 6d 65 07 08 1b 5b 4b 08 1b 5b 4b 08 1b 5b 4b    .me...[K..[K..[K
0x88001c3959a6    08 1b 5b 4b 08 1b 5b 4b 08 1b 5b 4b 07 78 65 63    ..[K..[K..[K.xec
0x88001c3959b6    75 74 65 20 61 6e 79 20 63 6f 6d 6d 61 6e 64 1b    ute.any.command.
0x88001c3959c6    5b 32 34 3b 36 33 48 31 2c 31 1b 5b 31 31 43 54    [24;63H1,1.[11CT
0x88001c3959d6    6f 70 1b 5b 31 3b 31 48 1b 5b 3f 31 32 6c 1b 5b    op.[1;1H.[?12l.[

0x88001f5e1902    72 6f 6f 74 40 64 65 62 69 61 6e 2d 62 6f 6f 6b    root@debian-book
0x88001f5e1912    2d 73 61 6d 70 6c 65 3a 2f 68 6f 6d 65 2f 76 6f    -sample:/home/vo
0x88001f5e1922    6c 23 20 63 6c 65 00 00 00 00 00 00 00 00 00 00    l#.cle..........
0x88001f5e1932    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................
0x88001f5e1942    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................
0x88001f5e1952    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................
0x88001f5e1962    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................
0x88001f5e1972    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ................
<snip>
```

Thanks! :fox_face: 