### PR TITLE
Linux: Add kthreads plugin to enumerate kernel threads start address

### DIFF
--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -34,6 +34,12 @@ class Kthreads(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
             ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(2, 3, 0)
+            ),
+            requirements.PluginRequirement(
+                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            ),
         ]
 
     def _generator(self):

--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -1,0 +1,109 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+import logging
+from typing import List
+
+from volatility3.framework import constants, exceptions, interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.symbols import linux
+from volatility3.framework.constants import architectures
+from volatility3.framework.objects import utility
+from volatility3.plugins.linux import pslist, lsmod
+
+vollog = logging.getLogger(__name__)
+
+
+class Kthreads(plugins.PluginInterface):
+    """Enumerates kthread functions"""
+
+    _required_framework_version = (2, 0, 0)
+
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Linux kernel",
+                architectures=architectures.LINUX_ARCHS,
+            ),
+            requirements.VersionRequirement(
+                name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
+            ),
+        ]
+
+    def _generator(self):
+        vmlinux = self.context.modules[self.config["kernel"]]
+
+        modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
+        handlers = linux.LinuxUtilities.generate_kernel_handler_info(
+            self.context, vmlinux.name, modules
+        )
+
+        kthread_type = vmlinux.get_type(
+            vmlinux.symbol_table_name + constants.BANG + "kthread"
+        )
+
+        if not kthread_type.has_member("threadfn"):
+            raise exceptions.VolatilityException(
+                "Unsupported kthread implementation. This plugin only works with kernels >= 5.8"
+            )
+
+        for task in pslist.PsList.list_tasks(
+            self.context, vmlinux.name, include_threads=True
+        ):
+            if not task.is_kernel_thread:
+                continue
+
+            if task.has_member("worker_private"):
+                # kernels >= 5.17 e32cf5dfbe227b355776948b2c9b5691b84d1cbd
+                ktread_base_pointer = task.worker_private
+            else:
+                # 5.8 <= kernels < 5.17 in 52782c92ac85c4e393eb4a903a62e6c24afa633f threadfn
+                # was added to struct kthread. task.set_child_tid is safe on those versions.
+                ktread_base_pointer = task.set_child_tid
+
+            if not ktread_base_pointer.is_readable():
+                continue
+
+            kthread = ktread_base_pointer.dereference().cast("kthread")
+            threadfn = kthread.threadfn
+            if not (threadfn and threadfn.is_readable()):
+                continue
+
+            task_name = utility.array_to_string(task.comm)
+
+            # kernels >= 5.17 in d6986ce24fc00b0638bd29efe8fb7ba7619ed2aa full_name was added to kthread
+            thread_name = (
+                utility.pointer_to_string(kthread.full_name, count=255)
+                if kthread.has_member("full_name")
+                else task_name
+            )
+            module_name, symbol_name = linux.LinuxUtilities.lookup_module_address(
+                vmlinux, handlers, threadfn
+            )
+
+            fields = [
+                task.pid,
+                thread_name,
+                format_hints.Hex(threadfn),
+                module_name,
+                symbol_name,
+            ]
+            yield 0, fields
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("TID", int),
+                ("Thread Name", str),
+                ("Handler Address", format_hints.Hex),
+                ("Module", str),
+                ("Symbol", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -19,7 +19,7 @@ vollog = logging.getLogger(__name__)
 class Kthreads(plugins.PluginInterface):
     """Enumerates kthread functions"""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 11, 0)
 
     _version = (1, 0, 0)
 


### PR DESCRIPTION
This PR adds a new Linux plugin to enumerate kernel threads (kthreads), including their function start addresses and, where available, the associated module and symbol names. 

This helps to identify malicious code executed by a kernel module --which may no longer be running-- but persisted its malicious behavior through a kthread.

This functionality is supported starting from kernel 5.8. In earlier kernels, obtaining the kthread function start address is much more complex and requires significantly more effort.

## Kernel 5.8.0-53
```shell
$ ./vol.py \
   -r pretty \
   -f ram-5.8.0-53-ubuntu20.04-64bit.core \
    linux.kthreads.Kthreads 
Volatility 3 Framework 2.11.0
  |   TID |     Thread Name | Handler Address |     Module |                 Symbol
* |     3 |          rcu_gp |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |     4 |      rcu_par_gp |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |     6 |    kworker/0:0H |  0xffff810bb730 | __kernel__ |          worker_thread
* |     9 |    mm_percpu_wq |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    10 |     ksoftirqd/0 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    11 |       rcu_sched |  0xffff81121d50 | __kernel__ |         rcu_gp_kthread
* |    12 |     migration/0 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    13 |   idle_inject/0 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    14 |         cpuhp/0 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    15 |         cpuhp/1 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    16 |   idle_inject/1 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    17 |     migration/1 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    18 |     ksoftirqd/1 |  0xffff810ca690 | __kernel__ |      smpboot_thread_fn
* |    20 |    kworker/1:0H |  0xffff810bb730 | __kernel__ |          worker_thread
* |    21 |       kdevtmpfs |  0xffff8175ce20 | __kernel__ |              devtmpfsd
* |    22 |           netns |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    23 | rcu_tasks_kthre |  0xffff8111c440 | __kernel__ |      rcu_tasks_kthread
* |    24 | rcu_tasks_rude_ |  0xffff8111c440 | __kernel__ |      rcu_tasks_kthread
* |    25 | rcu_tasks_trace |  0xffff8111c440 | __kernel__ |      rcu_tasks_kthread
* |    26 |         kauditd |  0xffff8116ea50 | __kernel__ |         kauditd_thread
* |    28 |      khungtaskd |  0xffff8118a710 | __kernel__ |                    N/A
* |    29 |      oom_reaper |  0xffff81237870 | __kernel__ |             oom_reaper
* |    30 |       writeback |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    31 |      kcompactd0 |  0xffff812636b0 | __kernel__ |              kcompactd
* |    32 |            ksmd |  0xffff812b30c0 | __kernel__ |        ksm_scan_thread
* |    33 |      khugepaged |  0xffff812cf3a0 | __kernel__ |             khugepaged
* |    80 |     kintegrityd |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    81 |         kblockd |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    82 |  blkcg_punt_bio |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    83 |      tpm_dev_wq |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    84 |         ata_sff |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    85 |              md |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    86 |     edac-poller |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    87 |      devfreq_wq |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    88 |       watchdogd |  0xffff810c2440 | __kernel__ |      kthread_worker_fn
* |    90 |           pm_wq |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    92 |         kswapd0 |  0xffff81249a50 | __kernel__ |                 kswapd
* |    93 | ecryptfs-kthrea |  0xffff81439340 | __kernel__ |      ecryptfs_threadfn
* |    95 |        kthrotld |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |    96 |   irq/24-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |    97 |   irq/25-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |    98 |   irq/26-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |    99 |   irq/27-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   100 |   irq/28-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   101 |   irq/29-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   102 |   irq/30-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   103 |   irq/31-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   104 |   irq/32-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   105 |   irq/33-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   106 |   irq/34-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   107 |   irq/35-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   108 |   irq/36-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   109 |   irq/37-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   110 |   irq/38-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   111 |   irq/39-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   112 |   irq/40-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   113 |   irq/41-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   114 |   irq/42-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   115 |   irq/43-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   116 |   irq/44-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   117 |   irq/45-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   118 |   irq/46-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   119 |   irq/47-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   120 |   irq/48-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   121 |   irq/49-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   122 |   irq/50-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   123 |   irq/51-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   124 |   irq/52-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   125 |   irq/53-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   126 |   irq/54-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   127 |   irq/55-pciehp |  0xffff81110140 | __kernel__ |             irq_thread
* |   128 | acpi_thermal_pm |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   129 |       scsi_eh_0 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   130 |      scsi_tmf_0 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   131 |       scsi_eh_1 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   132 |      scsi_tmf_1 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   134 | vfio-irqfd-clea |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   136 |   ipv6_addrconf |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   145 |           kstrp |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   148 |    zswap-shrink |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   149 |  kworker/u257:0 |  0xffff810bb730 | __kernel__ |          worker_thread
* |   154 | charger_manager |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   200 |       scsi_eh_2 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   201 |      scsi_tmf_2 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   202 |       scsi_eh_3 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   203 |      scsi_tmf_3 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   204 |      mpt_poll_0 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   205 |       scsi_eh_4 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   206 |      scsi_tmf_4 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   207 |       scsi_eh_5 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   208 |           mpt/0 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   209 |      scsi_tmf_5 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   211 |       scsi_eh_6 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   212 |      scsi_tmf_6 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   213 |       scsi_eh_7 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   214 |      scsi_tmf_7 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   215 |       scsi_eh_8 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   216 |      scsi_tmf_8 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   217 |       scsi_eh_9 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   218 |      scsi_tmf_9 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   219 |      scsi_eh_10 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   220 |     scsi_tmf_10 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   221 |      scsi_eh_11 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   222 |     scsi_tmf_11 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   223 |      scsi_eh_12 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   224 |     scsi_tmf_12 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   225 |      scsi_eh_13 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   226 |     scsi_tmf_13 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   227 |      scsi_eh_14 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   228 |     scsi_tmf_14 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   229 |      scsi_eh_15 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   230 |     scsi_tmf_15 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   231 |      scsi_eh_16 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   232 |     scsi_tmf_16 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   233 |      scsi_eh_17 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   234 |     scsi_tmf_17 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   235 |      scsi_eh_18 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   236 |     scsi_tmf_18 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   237 |      scsi_eh_19 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   238 |     scsi_tmf_19 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   239 |      scsi_eh_20 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   240 |     scsi_tmf_20 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   241 |      scsi_eh_21 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   242 |     scsi_tmf_21 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   243 |      scsi_eh_22 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   244 |     scsi_tmf_22 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   245 |      scsi_eh_23 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   246 |     scsi_tmf_23 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   247 |      scsi_eh_24 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   248 |     scsi_tmf_24 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   249 |      scsi_eh_25 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   250 |     scsi_tmf_25 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   251 |      scsi_eh_26 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   252 |     scsi_tmf_26 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   253 |      scsi_eh_27 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   254 |     scsi_tmf_27 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   255 |      scsi_eh_28 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   256 |     scsi_tmf_28 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   257 |      scsi_eh_29 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   258 |     scsi_tmf_29 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   259 |      scsi_eh_30 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   260 |     scsi_tmf_30 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   261 |      scsi_eh_31 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   262 |     scsi_tmf_31 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   290 |    kworker/0:1H |  0xffff810bb730 | __kernel__ |          worker_thread
* |   291 |      scsi_eh_32 |  0xffff817c0d20 | __kernel__ |     scsi_error_handler
* |   292 |     scsi_tmf_32 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   294 |    kworker/1:1H |  0xffff810bb730 | __kernel__ |          worker_thread
* |   315 |     jbd2/sda5-8 |  0xffff81417e70 | __kernel__ |             kjournald2
* |   316 | ext4-rsv-conver |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   375 |           loop0 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   378 |   irq/16-vmwgfx |  0xffff81110140 | __kernel__ |             irq_thread
* |   383 |           loop1 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   385 |        ttm_swap |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* |   388 |           loop2 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   401 |           loop4 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   403 |           loop5 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   404 |           loop6 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   406 |           loop7 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   427 |           loop8 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   429 |          loop10 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* |   564 |          cryptd |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* | 10787 |        xfsalloc |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* | 10793 |   xfs_mru_cache |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* | 10798 |           jfsIO |  0xffffc0774310 |        jfs |                    N/A
* | 10799 |       jfsCommit |  0xffffc0777200 |        jfs |                    N/A
* | 10800 |       jfsCommit |  0xffffc0777200 |        jfs |                    N/A
* | 10801 |         jfsSync |  0xffffc0777740 |        jfs |                    N/A
* | 14595 |        cfg80211 |  0xffff810bbb20 | __kernel__ |         rescuer_thread
* | 19095 |          loop11 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* | 22064 |           loop3 |  0xffff8177e000 | __kernel__ | loop_kthread_worker_fn
* | 59607 |     kworker/1:0 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 59670 |  kworker/u256:2 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 61407 |     kworker/0:3 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 61863 |     kworker/0:1 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 61880 |  kworker/u256:0 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 61910 |  kworker/u256:3 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 62023 |     kworker/1:2 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 62039 |     kworker/0:0 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 62088 |     kworker/0:2 |  0xffff810bb730 | __kernel__ |          worker_thread
* | 62188 |  kworker/u256:1 |  0xffff810bb730 | __kernel__ |          worker_thread

```

## Kernel 6.8.0
```shell
$ ./vol.py \
    -r pretty \
    -f ./dump_ubuntu2404amd64_6.8.0-41-generic.core \
    linux.kthreads.Kthreads 
Volatility 3 Framework 2.11.0
  |  TID |                   Thread Name | Handler Address |     Module |             Symbol
* |    3 |        pool_workqueue_release |  0xffff8a736470 | __kernel__ |  kthread_worker_fn
* |    4 |              kworker/R-rcu_gp |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |    5 |          kworker/R-rcu_par_gp |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |    6 |        kworker/R-slub_flushwq |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |    7 |               kworker/R-netns |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |    9 |                  kworker/0:0H |  0xffff8a72be90 | __kernel__ |      worker_thread
* |   12 |        kworker/R-mm_percpu_wq |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   13 |             rcu_tasks_kthread |  0xffff8a7ce0b0 | __kernel__ |  rcu_tasks_kthread
* |   14 |        rcu_tasks_rude_kthread |  0xffff8a7ce0b0 | __kernel__ |  rcu_tasks_kthread
* |   15 |       rcu_tasks_trace_kthread |  0xffff8a7ce0b0 | __kernel__ |  rcu_tasks_kthread
* |   16 |                   ksoftirqd/0 |  0xffff8a742d20 | __kernel__ |  smpboot_thread_fn
* |   17 |                   rcu_preempt |  0xffff8a7de850 | __kernel__ |     rcu_gp_kthread
* |   18 |                   migration/0 |  0xffff8a742d20 | __kernel__ |  smpboot_thread_fn
* |   19 |                 idle_inject/0 |  0xffff8a742d20 | __kernel__ |  smpboot_thread_fn
* |   20 |                       cpuhp/0 |  0xffff8a742d20 | __kernel__ |  smpboot_thread_fn
* |   21 |                     kdevtmpfs |  0xffff8b832000 | __kernel__ |          devtmpfsd
* |   22 |        kworker/R-inet_frag_wq |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   24 |                       kauditd |  0xffff8a8567b0 | __kernel__ |     kauditd_thread
* |   25 |                    khungtaskd |  0xffff8a879960 | __kernel__ |           watchdog
* |   26 |                    oom_reaper |  0xffff8a9c1770 | __kernel__ |         oom_reaper
* |   28 |           kworker/R-writeback |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   29 |                    kcompactd0 |  0xffff8aa08c50 | __kernel__ |          kcompactd
* |   30 |                          ksmd |  0xffff8aa944a0 | __kernel__ |    ksm_scan_thread
* |   31 |         kworker/R-kintegrityd |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   32 |             kworker/R-kblockd |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   33 |      kworker/R-blkcg_punt_bio |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   34 |                    irq/9-acpi |  0xffff8a7b9ca0 | __kernel__ |         irq_thread
* |   35 |          kworker/R-tpm_dev_wq |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   36 |             kworker/R-ata_sff |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   37 |                  kworker/R-md |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   38 |           kworker/R-md_bitmap |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   39 |         kworker/R-edac-poller |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   40 |          kworker/R-devfreq_wq |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   41 |                     watchdogd |  0xffff8a736470 | __kernel__ |  kthread_worker_fn
* |   42 |                  kworker/0:1H |  0xffff8a72be90 | __kernel__ |      worker_thread
* |   43 |                       kswapd0 |  0xffff8a9e3d50 | __kernel__ |             kswapd
* |   44 |              ecryptfs-kthread |  0xffff8ac894d0 | __kernel__ |  ecryptfs_threadfn
* |   45 |            kworker/R-kthrotld |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   46 |     kworker/R-acpi_thermal_pm |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   47 |                     scsi_eh_0 |  0xffff8b22a160 | __kernel__ | scsi_error_handler
* |   48 |          kworker/R-scsi_tmf_0 |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   49 |                     scsi_eh_1 |  0xffff8b22a160 | __kernel__ | scsi_error_handler
* |   50 |          kworker/R-scsi_tmf_1 |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   53 |                 kworker/R-mld |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   54 |       kworker/R-ipv6_addrconf |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   61 |               kworker/R-kstrp |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   63 |                  kworker/u3:0 |  0xffff8a72be90 | __kernel__ |      worker_thread
* |   68 |              kworker/R-cryptd |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |   78 |     kworker/R-charger_manager |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  141 |      kworker/R-kdmflush/252:0 |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  167 |             kworker/R-raid5wq |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  206 |                   jbd2/dm-0-8 |  0xffff8ac5c390 | __kernel__ |         kjournald2
* |  207 | kworker/R-ext4-rsv-conversion |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  301 |             kworker/R-kmpathd |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  302 |     kworker/R-kmpath_handlerd |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  348 |                        psimon |  0xffff8a78fee0 | __kernel__ |  psi_rtpoll_worker
* |  404 |                   jbd2/vda2-8 |  0xffff8ac5c390 | __kernel__ |         kjournald2
* |  405 | kworker/R-ext4-rsv-conversion |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  531 |              kworker/R-rpciod |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  532 |             kworker/R-xprtiod |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  562 |            kworker/R-cfg80211 |  0xffff8a72ba60 | __kernel__ |     rescuer_thread
* |  782 |                        psimon |  0xffff8a78fee0 | __kernel__ |  psi_rtpoll_worker
* | 5892 |                  kworker/u2:0 |  0xffff8a72be90 | __kernel__ |      worker_thread
* | 5910 |                  kworker/u2:4 |  0xffff8a72be90 | __kernel__ |      worker_thread
* | 5928 |                   kworker/0:1 |  0xffff8a72be90 | __kernel__ |      worker_thread
* | 5930 |                  kworker/u2:1 |  0xffff8a72be90 | __kernel__ |      worker_thread
* | 6067 |                   kworker/0:2 |  0xffff8a72be90 | __kernel__ |      worker_thread
* | 6068 |                  kworker/u2:3 |  0xffff8a72be90 | __kernel__ |      worker_thread
* | 6084 |                  kworker/u2:2 |  0xffff8a72be90 | __kernel__ |      worker_thread
* | 6111 |                   kworker/0:0 |  0xffff8a72be90 | __kernel__ |      worker_thread
```