### PR TITLE
Volshell: Make the default number of bytes returned by db, dw, dd, dq, rx, and dis use a constant

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -29,6 +29,8 @@ class Volshell(interfaces.plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
+    DEFAULT_NUM_DISPLAY_BYTES = 128
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__current_layer: Optional[str] = None
@@ -269,27 +271,31 @@ class Volshell(interfaces.plugins.PluginInterface):
             self.__current_kernel_name = kernel_name
         print(f"Current kernel : {self.current_kernel_name}")
 
-    def display_bytes(self, offset, count=128, layer_name=None):
+    def display_bytes(self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None):
         """Displays byte values and ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
         self._display_data(offset, remaining_data)
 
-    def display_quadwords(self, offset, count=128, layer_name=None):
+    def display_quadwords(
+        self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None
+    ):
         """Displays quad-word values (8 bytes) and corresponding ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
         self._display_data(offset, remaining_data, format_string="Q")
 
-    def display_doublewords(self, offset, count=128, layer_name=None):
+    def display_doublewords(
+        self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None
+    ):
         """Displays double-word values (4 bytes) and corresponding ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
         self._display_data(offset, remaining_data, format_string="I")
 
-    def display_words(self, offset, count=128, layer_name=None):
+    def display_words(self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None):
         """Displays word values (2 bytes) and corresponding ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
         self._display_data(offset, remaining_data, format_string="H")
 
-    def regex_scan(self, pattern, count=128, layer_name=None):
+    def regex_scan(self, pattern, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None):
         """Scans for regex pattern in layer using RegExScanner."""
         if not isinstance(pattern, bytes):
             raise TypeError("pattern must be bytes, e.g. rx(b'pattern')")
@@ -304,7 +310,13 @@ class Volshell(interfaces.plugins.PluginInterface):
             self._display_data(offset, remaining_data)
             print("")
 
-    def disassemble(self, offset, count=128, layer_name=None, architecture=None):
+    def disassemble(
+        self,
+        offset,
+        count=DEFAULT_NUM_DISPLAY_BYTES,
+        layer_name=None,
+        architecture=None,
+    ):
         """Disassembles a number of instructions from the code at offset"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
         if not has_capstone:


### PR DESCRIPTION
Hello :wave:

In this recent PR https://github.com/volatilityfoundation/volatility3/pull/1347 (Volshell: add regex_scan) we saw that all of the display commands all use the number of 128 bytes as the default number to display. 

This PR simply makes that a constant so that they can all be kept in sync. Perhaps overkill but I thought it might be a good idea. 

No offense taken if you feel this is unnecessary. 

Thanks!
:fox_face: 