### PR TITLE
Fix vmware layer so that files without a vmss or vmsn are still constructed with the warning is shown

### DIFF
--- a/volatility3/framework/layers/vmware.py
+++ b/volatility3/framework/layers/vmware.py
@@ -238,7 +238,6 @@ class VmwareStacker(interfaces.automagic.StackerLayerInterface):
                 vollog.warning(
                     f"No metadata file found alongside VMEM file. A VMSS or VMSN file may be required to correctly process a VMEM file. These should be placed in the same directory with the same file name, e.g. {vmem_file_basename} and {example_vmss_file_basename}.",
                 )
-                return None
             new_layer_name = context.layers.free_layer_name("VmwareLayer")
             context.config[
                 interfaces.configuration.path_join(current_config_path, "base_layer")


### PR DESCRIPTION
Hello :wave: 

User Super_Snorlax on slack raised an issue where a vmware sample failed to work with a `.vmem` extension but did with a `.raw` extension.

They've yet to report having tested this change but I suspect it will fix the issue. 

I believe this return None incorrectly stops some samples for working. The warning says `may be required` but the `return None` is meaning it will never be stacked.

:fox_face: 