### PR TITLE
Add first version of regex scanning plugins

### DIFF
--- a/volatility3/framework/plugins/linux/vmaregexscan.py
+++ b/volatility3/framework/plugins/linux/vmaregexscan.py
@@ -4,8 +4,9 @@
 
 import logging
 import re
+from typing import List
 
-from volatility3.framework import renderers
+from volatility3.framework import renderers, interfaces
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.layers import scanners
@@ -24,7 +25,7 @@ class VmaRegExScan(plugins.PluginInterface):
     MAXSIZE_DEFAULT = 128
 
     @classmethod
-    def get_requirements(cls):
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
             requirements.ModuleRequirement(

--- a/volatility3/framework/plugins/linux/vmaregexscan.py
+++ b/volatility3/framework/plugins/linux/vmaregexscan.py
@@ -1,0 +1,127 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import re
+
+from volatility3.framework import renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.layers import scanners
+from volatility3.framework.objects import utility
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.linux import pslist
+
+vollog = logging.getLogger(__name__)
+
+
+class VmaRegExScan(plugins.PluginInterface):
+    """Scans all virtual memory areas for tasks using RegEx."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+    MAXSIZE_DEFAULT = 128
+
+    @classmethod
+    def get_requirements(cls):
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Linux kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                description="Filter on specific process IDs",
+                element_type=int,
+                optional=True,
+            ),
+            requirements.StringRequirement(
+                name="pattern", description="RegEx pattern", optional=False
+            ),
+            requirements.IntRequirement(
+                name="maxsize",
+                description="Maximum size in bytes for displayed context",
+                default=cls.MAXSIZE_DEFAULT,
+                optional=True,
+            ),
+        ]
+
+    def _generator(self, regex_pattern, tasks):
+        regex_pattern = bytes(regex_pattern, "UTF-8")
+        vollog.debug(f"RegEx Pattern: {regex_pattern}")
+
+        for task in tasks:
+
+            if not task.mm:
+                continue
+            name = utility.array_to_string(task.comm)
+
+            # attempt to create a process layer for each task and skip those
+            # that cannot (e.g. kernel threads)
+            proc_layer_name = task.add_process_layer()
+            if not proc_layer_name:
+                continue
+
+            # get the proc_layer object from the context
+            proc_layer = self.context.layers[proc_layer_name]
+
+            # get process sections for scanning
+            sections = [
+                (start, size) for (start, size) in task.get_process_memory_sections()
+            ]
+
+            for offset in proc_layer.scan(
+                context=self.context,
+                scanner=scanners.RegExScanner(regex_pattern),
+                sections=sections,
+                progress_callback=self._progress_callback,
+            ):
+                result_data = proc_layer.read(offset, self.MAXSIZE_DEFAULT, pad=True)
+
+                # reapply the regex in order to extact just the match
+                regex_result = re.match(regex_pattern, result_data)
+
+                if regex_result:
+                    # the match is within the results_data (e.g. it fits within MAXSIZE_DEFAULT)
+                    # extract just the match itself
+                    regex_match = regex_result.group(0)
+                    text_result = str(regex_match, encoding="UTF-8", errors="replace")
+                    bytes_result = regex_match
+                else:
+                    # the match is not with the results_data (e.g. it doesn't fit within MAXSIZE_DEFAULT)
+                    text_result = str(result_data, encoding="UTF-8", errors="replace")
+                    bytes_result = result_data
+
+                user_pid = task.tgid
+                yield 0, (
+                    user_pid,
+                    name,
+                    format_hints.Hex(offset),
+                    text_result,
+                    bytes_result,
+                )
+
+    def run(self):
+        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+
+        return renderers.TreeGrid(
+            [
+                ("PID", int),
+                ("Process", str),
+                ("Offset", format_hints.Hex),
+                ("Text", str),
+                ("Hex", bytes),
+            ],
+            self._generator(
+                self.config.get("pattern"),
+                pslist.PsList.list_tasks(
+                    self.context, self.config["kernel"], filter_func=filter_func
+                ),
+            ),
+        )

--- a/volatility3/framework/plugins/regexscan.py
+++ b/volatility3/framework/plugins/regexscan.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+from typing import List
 
 from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements

--- a/volatility3/framework/plugins/regexscan.py
+++ b/volatility3/framework/plugins/regexscan.py
@@ -1,0 +1,77 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import re
+
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.layers import scanners
+from volatility3.framework.renderers import format_hints
+
+vollog = logging.getLogger(__name__)
+
+
+class RegExScan(plugins.PluginInterface):
+    """Scans kernel memory using RegEx patterns."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+    MAXSIZE_DEFAULT = 128
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.TranslationLayerRequirement(
+                name="primary",
+                description="Memory layer for the kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.StringRequirement(
+                name="pattern", description="RegEx pattern", optional=False
+            ),
+            requirements.IntRequirement(
+                name="maxsize",
+                description="Maximum size in bytes for displayed context",
+                default=cls.MAXSIZE_DEFAULT,
+                optional=True,
+            ),
+        ]
+
+    def _generator(self, regex_pattern):
+        regex_pattern = bytes(regex_pattern, "UTF-8")
+        vollog.debug(f"RegEx Pattern: {regex_pattern}")
+
+        layer = self.context.layers[self.config["primary"]]
+        for offset in layer.scan(
+            context=self.context, scanner=scanners.RegExScanner(regex_pattern)
+        ):
+            result_data = layer.read(offset, self.MAXSIZE_DEFAULT, pad=True)
+
+            # reapply the regex in order to extact just the match
+            regex_result = re.match(regex_pattern, result_data)
+
+            if regex_result:
+                # the match is within the results_data (e.g. it fits within MAXSIZE_DEFAULT)
+                # extract just the match itself
+                regex_match = regex_result.group(0)
+                text_result = str(regex_match, encoding="UTF-8", errors="replace")
+                bytes_result = regex_match
+            else:
+                # the match is not with the results_data (e.g. it doesn't fit within MAXSIZE_DEFAULT)
+                text_result = str(result_data, encoding="UTF-8", errors="replace")
+                bytes_result = result_data
+
+            yield 0, (format_hints.Hex(offset), text_result, bytes_result)
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Offset", format_hints.Hex),
+                ("Text", str),
+                ("Hex", bytes),
+            ],
+            self._generator(self.config.get("pattern")),
+        )

--- a/volatility3/framework/plugins/windows/vadregexscan.py
+++ b/volatility3/framework/plugins/windows/vadregexscan.py
@@ -1,0 +1,128 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+import re
+
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.layers import scanners
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import pslist, vadyarascan
+
+vollog = logging.getLogger(__name__)
+
+
+class VadRegExScan(plugins.PluginInterface):
+    """Scans all virtual memory areas for tasks using RegEx."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+    MAXSIZE_DEFAULT = 128
+
+    @classmethod
+    def get_requirements(cls):
+        # Since we're calling the plugin, make sure we have the plugin's requirements
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.PluginRequirement(
+                name="vadyarascan", plugin=vadyarascan.VadYaraScan, version=(1, 0, 0)
+            ),
+            requirements.ListRequirement(
+                name="pid",
+                description="Filter on specific process IDs",
+                element_type=int,
+                optional=True,
+            ),
+            requirements.StringRequirement(
+                name="pattern", description="RegEx pattern", optional=False
+            ),
+            requirements.IntRequirement(
+                name="maxsize",
+                description="Maximum size in bytes for displayed context",
+                default=cls.MAXSIZE_DEFAULT,
+                optional=True,
+            ),
+        ]
+
+    def _generator(self, regex_pattern, procs):
+        regex_pattern = bytes(regex_pattern, "UTF-8")
+        vollog.debug(f"RegEx Pattern: {regex_pattern}")
+
+        for proc in procs:
+
+            # attempt to create a process layer for each proc
+            proc_layer_name = proc.add_process_layer()
+            if not proc_layer_name:
+                continue
+
+            # get the proc_layer object from the context
+            proc_layer = self.context.layers[proc_layer_name]
+
+            # get process sections for scanning
+            sections = sections = vadyarascan.VadYaraScan.get_vad_maps(proc)
+
+            for offset in proc_layer.scan(
+                context=self.context,
+                scanner=scanners.RegExScanner(regex_pattern),
+                sections=sections,
+                progress_callback=self._progress_callback,
+            ):
+                result_data = proc_layer.read(offset, self.MAXSIZE_DEFAULT, pad=True)
+
+                # reapply the regex in order to extact just the match
+                regex_result = re.match(regex_pattern, result_data)
+
+                if regex_result:
+                    # the match is within the results_data (e.g. it fits within MAXSIZE_DEFAULT)
+                    # extract just the match itself
+                    regex_match = regex_result.group(0)
+                    text_result = str(regex_match, encoding="UTF-8", errors="replace")
+                    bytes_result = regex_match
+                else:
+                    # the match is not with the results_data (e.g. it doesn't fit within MAXSIZE_DEFAULT)
+                    text_result = str(result_data, encoding="UTF-8", errors="replace")
+                    bytes_result = result_data
+
+                proc_id = proc.UniqueProcessId
+                process_name = proc.ImageFileName.cast(
+                    "string",
+                    max_length=proc.ImageFileName.vol.count,
+                    errors="replace",
+                )
+                yield 0, (
+                    proc_id,
+                    process_name,
+                    format_hints.Hex(offset),
+                    text_result,
+                    bytes_result,
+                )
+
+    def run(self):
+        filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+        kernel = self.context.modules[self.config["kernel"]]
+        procs = pslist.PsList.list_processes(
+            self.context,
+            kernel.layer_name,
+            kernel.symbol_table_name,
+            filter_func=filter_func,
+        )
+        return renderers.TreeGrid(
+            [
+                ("PID", int),
+                ("Process", str),
+                ("Offset", format_hints.Hex),
+                ("Text", str),
+                ("Hex", bytes),
+            ],
+            self._generator(self.config.get("pattern"), procs),
+        )

--- a/volatility3/framework/plugins/windows/vadregexscan.py
+++ b/volatility3/framework/plugins/windows/vadregexscan.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+from typing import List
 
 from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
@@ -23,7 +24,7 @@ class VadRegExScan(plugins.PluginInterface):
     MAXSIZE_DEFAULT = 128
 
     @classmethod
-    def get_requirements(cls):
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
             requirements.ModuleRequirement(

--- a/volatility3/framework/plugins/windows/vadregexscan.py
+++ b/volatility3/framework/plugins/windows/vadregexscan.py
@@ -70,7 +70,7 @@ class VadRegExScan(plugins.PluginInterface):
             proc_layer = self.context.layers[proc_layer_name]
 
             # get process sections for scanning
-            sections = sections = vadyarascan.VadYaraScan.get_vad_maps(proc)
+            sections = vadyarascan.VadYaraScan.get_vad_maps(proc)
 
             for offset in proc_layer.scan(
                 context=self.context,

--- a/volatility3/framework/plugins/windows/vadregexscan.py
+++ b/volatility3/framework/plugins/windows/vadregexscan.py
@@ -6,9 +6,9 @@ import logging
 import re
 from typing import List
 
-from volatility3.framework import interfaces, renderers
+from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
-from volatility3.framework.interfaces import plugins
+from volatility3.framework.interfaces import plugins, configuration
 from volatility3.framework.layers import scanners
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.windows import pslist
@@ -24,7 +24,7 @@ class VadRegExScan(plugins.PluginInterface):
     MAXSIZE_DEFAULT = 128
 
     @classmethod
-    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+    def get_requirements(cls) -> List[configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
             requirements.ModuleRequirement(

--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -5,7 +5,8 @@
 import logging
 from typing import Iterable, List, Tuple
 
-from volatility3.framework import interfaces, renderers
+from volatility3.framework import renderers
+from volatility3.framework.interfaces import plugins, configuration, objects
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins import yarascan
@@ -14,14 +15,14 @@ from volatility3.plugins.windows import pslist
 vollog = logging.getLogger(__name__)
 
 
-class VadYaraScan(interfaces.plugins.PluginInterface):
+class VadYaraScan(plugins.PluginInterface):
     """Scans all the Virtual Address Descriptor memory maps using yara."""
 
     _required_framework_version = (2, 4, 0)
     _version = (1, 1, 1)
 
     @classmethod
-    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+    def get_requirements(cls) -> List[configuration.RequirementInterface]:
         # create a list of requirements for vadyarascan
         vadyarascan_requirements = [
             requirements.ModuleRequirement(
@@ -112,7 +113,7 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
 
     @staticmethod
     def get_vad_maps(
-        task: interfaces.objects.ObjectInterface,
+        task: objects.ObjectInterface,
     ) -> Iterable[Tuple[int, int]]:
         """Creates a map of start/end addresses within a virtual address
         descriptor tree.

--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -5,8 +5,7 @@
 import logging
 from typing import Iterable, List, Tuple
 
-from volatility3.framework import renderers
-from volatility3.framework.interfaces import plugins, configuration, objects
+from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins import yarascan
@@ -15,14 +14,14 @@ from volatility3.plugins.windows import pslist
 vollog = logging.getLogger(__name__)
 
 
-class VadYaraScan(plugins.PluginInterface):
+class VadYaraScan(interfaces.plugins.PluginInterface):
     """Scans all the Virtual Address Descriptor memory maps using yara."""
 
     _required_framework_version = (2, 4, 0)
     _version = (1, 1, 1)
 
     @classmethod
-    def get_requirements(cls) -> List[configuration.RequirementInterface]:
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # create a list of requirements for vadyarascan
         vadyarascan_requirements = [
             requirements.ModuleRequirement(
@@ -113,7 +112,7 @@ class VadYaraScan(plugins.PluginInterface):
 
     @staticmethod
     def get_vad_maps(
-        task: objects.ObjectInterface,
+        task: interfaces.objects.ObjectInterface,
     ) -> Iterable[Tuple[int, int]]:
         """Creates a map of start/end addresses within a virtual address
         descriptor tree.


### PR DESCRIPTION
Hello :wave: 

This PR introduces new regex scanning plugins for Linux and Windows, providing a simple way to search memory for specific patterns using regular expressions. While the existing yarascan plugins can achieve similar results, they require Yara to be installed and involve writing full Yara rules. For some users, crafting simple regex patterns is faster and more intuitive. I know I've struggled explaining to some people about using yara rules in this way. 

This feature was inspired by a question from a user who asked if a plugin like this could be created. I hope it simplifies some work and makes memory analysis more accessible.

Here is some example output:

Generic kernel version:
```bash
$ python3 vol.py -f linux-sample-1.dmp regexscan.RegExScan --pattern "(Linux version|Darwin Kernel Version) [0-9]+\.[0-9]+\.[0-9]+"
Volatility 3 Framework 2.11.0
Progress:  100.00               PDB scanning finished                      
Offset  Text    Hex

0x880001400070  Linux version 3.2.0     4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e 32 2e 30
0x880001769027  Linux version 3.2.0     4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e 32 2e 30
0xffff81400070  Linux version 3.2.0     4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e 32 2e 30
0xffff81769027  Linux version 3.2.0     4c 69 6e 75 78 20 76 65 72 73 69 6f 6e 20 33 2e 32 2e 30
```

Windows version:
```bash
$ python3 vol.py -r pretty -f win-xp-laptop-2005-06-25.img windows.vadregexscan --pattern '((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}' --pid 944
Volatility 3 Framework 2.11.0
Formatting...0.00               PDB scanning finished                        
  | PID |      Process |     Offset |            Text |                                          Hex
* | 944 | PluckSvr.exe |   0x162cfc |   66.179.81.247 |       36 36 2e 31 37 39 2e 38 31 2e 32 34 37
* | 944 | PluckSvr.exe |   0x185a54 |   66.179.81.247 |       36 36 2e 31 37 39 2e 38 31 2e 32 34 37
* | 944 | PluckSvr.exe |   0x18cc84 |   66.179.81.247 |       36 36 2e 31 37 39 2e 38 31 2e 32 34 37
* | 944 | PluckSvr.exe | 0x2009fe1c |        49.1.1.4 |                      34 39 2e 31 2e 31 2e 34
* | 944 | PluckSvr.exe | 0x2026117d |       2.6.32.68 |                   32 2e 36 2e 33 32 2e 36 38
* | 944 | PluckSvr.exe | 0x4d4f16aa | 255.255.255.255 | 32 35 35 2e 32 35 35 2e 32 35 35 2e 32 35 35
* | 944 | PluckSvr.exe | 0x749c1848 |       127.0.0.1 |                   31 32 37 2e 30 2e 30 2e 31
* | 944 | PluckSvr.exe | 0x76f235dc | 255.255.255.255 | 32 35 35 2e 32 35 35 2e 32 35 35 2e 32 35 35
```

Linux version:
```bash
$ python3 vol.py -r pretty -f linux-sample-1.dmp linux.vmaregexscan --pattern '((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}' --pid 8503
Volatility 3 Framework 2.11.0
Formatting...0.00               Stacking attempts finished                 
  |  PID | Process |         Offset |            Text |                                          Hex
* | 8503 |    bash |      0x135dcc8 |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash |      0x135dd13 |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash |      0x135ddc8 |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash |      0x135dddc | 192.168.201.161 | 31 39 32 2e 31 36 38 2e 32 30 31 2e 31 36 31
* | 8503 |    bash |      0x135de17 |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash |      0x135de2b | 192.168.201.161 | 31 39 32 2e 31 36 38 2e 32 30 31 2e 31 36 31
* | 8503 |    bash |      0x1361a93 |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash |      0x1362417 |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash |      0x136242b | 192.168.201.161 | 31 39 32 2e 31 36 38 2e 32 30 31 2e 31 36 31
* | 8503 |    bash | 0x7fff765b1f29 |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash | 0x7fff765b1f4f |   192.168.201.1 |       31 39 32 2e 31 36 38 2e 32 30 31 2e 31
* | 8503 |    bash | 0x7fff765b1f63 | 192.168.201.161 | 31 39 32 2e 31 36 38 2e 32 30 31 2e 31 36 31
```


Let me know what you think, thanks!
:fox_face: 