### PR TITLE
Add flag --nofile to prevent a file from being written in the ConfigWriter plugin

### DIFF
--- a/volatility3/framework/plugins/configwriter.py
+++ b/volatility3/framework/plugins/configwriter.py
@@ -33,6 +33,12 @@ class ConfigWriter(plugins.PluginInterface):
                 default=False,
                 optional=True,
             ),
+            requirements.BooleanRequirement(
+                name="nofile",
+                description="Do not write file to output directory, only print to stdout",
+                default=False,
+                optional=True,
+            ),
         ]
 
     def _generator(self):
@@ -45,13 +51,14 @@ class ConfigWriter(plugins.PluginInterface):
             config = dict(self.context.config)
             filename = "config.extra"
         try:
-            with self.open(filename) as file_data:
-                file_data.write(
-                    bytes(
-                        json.dumps(config, sort_keys=True, indent=2),
-                        "raw_unicode_escape",
+            if not self.config.get("nofile"):
+                with self.open(filename) as file_data:
+                    file_data.write(
+                        bytes(
+                            json.dumps(config, sort_keys=True, indent=2),
+                            "raw_unicode_escape",
+                        )
                     )
-                )
         except Exception as excp:
             vollog.warning(f"Unable to JSON encode configuration: {excp}")
 


### PR DESCRIPTION
The configwriter plugin automatically writes configuration files (duh!) to disk. If one just needs the output of the configwriter plugin, a file is automatically written. Hence we added the flag `--nofile` to prevent the configuration file from being written.

A better approach would have been to not have the configwriter plugin write a file by default and have a `-o` flag determine where the file would be written to. This is not backwards compatible, and has hence not been added. If you would like us to do that instead, we'd be glad to.

N.B.: this is our first PR! Glad to be part of the Volatility community. Feel free to give us (extensive) feedback on the contributions we make :)