### PR TITLE
Add --metadata-output flag to include metadata for generated jsonl/csv records

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -204,6 +204,13 @@ class CommandLine:
             choices=list(renderers),
         )
         parser.add_argument(
+            "-m",
+            "--metadata-output",
+            help="Add metadata to the output if the renderer is structured (JSON, JSONL, CSV)",
+            default=False,
+            action="store_true",
+        )
+        parser.add_argument(
             "-f",
             "--file",
             metavar="FILE",
@@ -499,9 +506,33 @@ class CommandLine:
                 renderer = renderers[args.renderer]()
                 renderer.filter = text_filter.CLIFilter(grid, args.filters)
                 renderer.column_hide_list = args.hide_columns
+                renderer.metadata_output = args.metadata_output
+                renderer.plugin = plugin
+                renderer.image_path = self.layer_location(ctx)
                 renderer.render(grid)
         except exceptions.VolatilityException as excp:
             self.process_exceptions(excp)
+
+    @classmethod
+    def layer_location(cls, ctx: contexts.Context) -> str:
+        """
+        Returns the path of the primary layer (the actual memory image file) that Volatility is run on
+        """
+        config: dict = ctx.config
+        # Check if Volatility is started by specifying a filepath
+        if config.get("automagic.LayerStacker.single_location"):
+            return ctx.config.get("automagic.LayerStacker.single_location")
+
+        # Check if Volatility is started by specifying a configuration
+        config_keys = list(config.keys())
+        if any([key for key in config_keys if "base_layer.location" in key]):
+            key = next(
+                (key for key in list(config.keys()) if "base_layer.location" in key)
+            )
+            return config[key]
+
+        # Return nothing if we can't find a filepath
+        return ""
 
     @classmethod
     def location_from_file(cls, filename: str) -> str:

--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -9,10 +9,11 @@ import random
 import string
 import sys
 from functools import wraps
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from volatility3.cli import text_filter
 
 from volatility3.framework import exceptions, interfaces, renderers
+from volatility3.framework.interfaces.plugins import PluginInterface
 from volatility3.framework.renderers import format_hints
 
 vollog = logging.getLogger(__name__)
@@ -138,10 +139,13 @@ def display_disassembly(disasm: interfaces.renderers.Disassembly) -> str:
 class CLIRenderer(interfaces.renderers.Renderer):
     """Class to add specific requirements for CLI renderers."""
 
-    name = "unnamed"
-    structured_output = False
+    name: str = "unnamed"
+    structured_output: bool = False
+    metadata_output: bool = False
     filter: text_filter.CLIFilter = None
     column_hide_list: list = None
+    plugin: PluginInterface = None
+    image_path: Optional[str] = None
 
     def ignored_columns(
         self,
@@ -165,6 +169,12 @@ class CLIRenderer(interfaces.renderers.Renderer):
             f"Hiding columns: {[column.name for column in ignored_column_list]}"
         )
         return ignored_column_list
+
+    @property
+    def plugin_name(self) -> Optional[str]:
+        """Return the name of the plugin the rendered output originates from."""
+        if self.plugin and hasattr(self.plugin, "__module__"):
+            return self.plugin.__module__.replace("volatility3.plugins.", "", 1)
 
 
 class QuickTextRenderer(CLIRenderer):
@@ -275,6 +285,11 @@ class CSVRenderer(CLIRenderer):
         ignore_columns = self.ignored_columns(grid)
 
         header_list = ["TreeDepth"]
+
+        if self.metadata_output:
+            header_list.append("__image_path")
+            header_list.append("__plugin")
+
         for column in grid.columns:
             # Ignore the type because namedtuples don't realize they have accessible attributes
             if column not in ignore_columns:
@@ -298,6 +313,10 @@ class CSVRenderer(CLIRenderer):
                     line.append(row[f"{column.name}"])
                 else:
                     del row[f"{column.name}"]
+
+            if self.metadata_output:
+                row["__image_path"] = self.image_path
+                row["__plugin"] = self.plugin_name
 
             if self.filter and self.filter.filter(line):
                 return accumulator
@@ -497,6 +516,10 @@ class JsonRenderer(CLIRenderer):
                     data = None
                 node_dict[column.name] = data
                 line.append(data)
+
+            if self.metadata_output:
+                node_dict["__image_path"] = self.image_path
+                node_dict["__plugin"] = self.plugin_name
 
             if self.filter and self.filter.filter(line):
                 return accumulator


### PR DESCRIPTION
In this pull request, we added the flag `--metadata-output` which adds metadata to each record that is generated by a plugin. Currently just two pieces of metadata are added: (1) the location of the primary layer/image ('this is the artefact from which I generated this record') and (2) the plugin name that generated the record.

The metadata is prefixed with two underscores. Example output would be:
```
vol3 -f image.raw --metadata-output -r jsonl linux.psaux
{"ARGS": "/sbin/init", [...], "__image_path": "<path to image>", "__plugin": "linux.psaux"}
[...]
```

In the future, one could imagine more metadata being added to each record. For example: the datetime of when the record was generated, the SHA256/MD5/SHA1 hashes of the primary layer/image, and the version of Volatility3 that generated the record. We did not add these fields in this pull request, to first gauge your reaction to adding metadata. If you like the idea, we can add the remaining fields as well (in a subsequent PR).

One could use this flag when storing large(r) amount of Volatility3 output for postprocessing. I.e. if one would fire all possible plugins on a single file and appends all jsonl/csv output to a single file, the `__plugin` field can then be used to postprocess the generated records.