### PR TITLE
Follow XDG Base Directory Specification for cache directory

### DIFF
--- a/doc/source/symbol-tables.rst
+++ b/doc/source/symbol-tables.rst
@@ -9,7 +9,7 @@ How Volatility finds symbol tables
 
 All files are stored as JSON data, they can be in pure JSON files as ``.json``, or compressed as ``.json.gz`` or ``.json.xz``.
 Volatility will automatically decompress them on use.  It will also cache their contents (compressed) when used, located
-under the user's home directory, in :file:`.cache/volatility3`, along with other useful data.  The cache directory currently
+under the user's home directory, in :file:`.cache/volatility3` or when `XDG_CACHE_HOME` is set in :file:`${XDG_CACHE_HOME}/volatility3`, along with other useful data.  The cache directory currently
 cannot be altered.
 
 Symbol table JSON files live, by default, under the :file:`volatility3/symbols` directory.  The symbols directory is

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -68,7 +68,8 @@ LOGLEVEL_VVVV = 6
 
 
 CACHE_PATH = os.path.join(
-    os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache"), "volatility3"
+    os.environ.get("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache"),
+    "volatility3",
 )
 """Default path to store cached data"""
 

--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -6,6 +6,7 @@
 Stores all the constant values that are generally fixed throughout
 volatility This includes default scanning block sizes, etc.
 """
+
 import enum
 import os.path
 import sys
@@ -65,7 +66,10 @@ LOGLEVEL_VVV = 7
 LOGLEVEL_VVVV = 6
 """Logging level for four levels of detail: -vvvvvv"""
 
-CACHE_PATH = os.path.join(os.path.expanduser("~"), ".cache", "volatility3")
+
+CACHE_PATH = os.path.join(
+    os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache"), "volatility3"
+)
 """Default path to store cached data"""
 
 SQLITE_CACHE_PERIOD = "-3 days"


### PR DESCRIPTION
currently vol3 doesn't follow the [XDG BASE Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)

> `$XDG_CACHE_HOME` defines the base directory relative to which user-specific non-essential data files should be stored. If `$XDG_CACHE_HOME` is either not set or empty, a default equal to `$HOME/.cache` should be used. 

As it is right now, whenever i use vol3 it creates a `~/.cache/volatility3` which isn't really ideal.

```bash
$ echo $XDG_CACHE_HOME
/home/arthurd/.local/var/cache

$ ls -a
.cert  .kube  .local  .mozilla  .sage  .ssh  .thunderbird  __all__

$ vol --help
[...]

$ ls -a
.cache .cert .kube .local .mozilla .sage .ssh .thunderbird __all__

$ ls .cache
volatility3
```

This PR fixes this.

```py
>>> import os
>>> os.path.join(os.path.expanduser("~"), ".cache", "volatility3")
'/home/arthurd/.cache/volatility3'
>>> os.path.join(os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache"), "volatility3")
'/home/arthurd/.local/var/cache/volatility3'
>>> os.environ["XDG_CACHE_HOME"] = ""
>>> os.path.join(os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache"), "volatility3")
'/home/arthurd/.cache/volatility3'
```

