### PR TITLE
Core: Add in generic cache-manager chooser function

### DIFF
--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -27,16 +27,6 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
         progress_callback: constants.ProgressCallback = None,
     ) -> Optional[interfaces.layers.DataLayerInterface]:
         """Attempts to identify linux within this layer."""
-        # Version check the SQlite cache
-        required = (1, 0, 0)
-        if not requirements.VersionRequirement.matches_required(
-            required, symbol_cache.SqliteCache.version
-        ):
-            vollog.info(
-                f"SQLiteCache version not suitable: required {required} found {symbol_cache.SqliteCache.version}"
-            )
-            return None
-
         # Bail out by default unless we can stack properly
         layer = context.layers[layer_name]
         join = interfaces.configuration.path_join
@@ -46,12 +36,9 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
         if isinstance(layer, intel.Intel):
             return None
 
-        identifiers_path = os.path.join(
-            constants.CACHE_PATH, constants.IDENTIFIERS_FILENAME
+        linux_banners = symbol_cache.load_cache_manager().get_identifier_dictionary(
+            operating_system="linux"
         )
-        linux_banners = symbol_cache.SqliteCache(
-            identifiers_path
-        ).get_identifier_dictionary(operating_system="linux")
         # If we have no banners, don't bother scanning
         if not linux_banners:
             vollog.info(

--- a/volatility3/framework/automagic/mac.py
+++ b/volatility3/framework/automagic/mac.py
@@ -28,16 +28,6 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
         progress_callback: constants.ProgressCallback = None,
     ) -> Optional[interfaces.layers.DataLayerInterface]:
         """Attempts to identify mac within this layer."""
-        # Version check the SQlite cache
-        required = (1, 0, 0)
-        if not requirements.VersionRequirement.matches_required(
-            required, symbol_cache.SqliteCache.version
-        ):
-            vollog.info(
-                f"SQLiteCache version not suitable: required {required} found {symbol_cache.SqliteCache.version}"
-            )
-            return None
-
         # Bail out by default unless we can stack properly
         layer = context.layers[layer_name]
         new_layer = None
@@ -48,12 +38,9 @@ class MacIntelStacker(interfaces.automagic.StackerLayerInterface):
         if isinstance(layer, intel.Intel):
             return None
 
-        identifiers_path = os.path.join(
-            constants.CACHE_PATH, constants.IDENTIFIERS_FILENAME
+        mac_banners = symbol_cache.load_cache_manager().get_identifier_dictionary(
+            operating_system="mac"
         )
-        mac_banners = symbol_cache.SqliteCache(
-            identifiers_path
-        ).get_identifier_dictionary(operating_system="mac")
         # If we have no banners, don't bother scanning
         if not mac_banners:
             vollog.info(

--- a/volatility3/framework/automagic/symbol_cache.py
+++ b/volatility3/framework/automagic/symbol_cache.py
@@ -492,6 +492,21 @@ class SqliteCache(CacheManagerInterface):
         return output
 
 
+def load_cache_manager(cache_file: Optional[str] = None) -> CacheManagerInterface:
+    """Loads a cache manager based on a specific cache file"""
+    if cache_file is None:
+        cache_file = os.path.join(constants.CACHE_PATH, constants.IDENTIFIERS_FILENAME)
+    # Different implementations of cache
+    if not os.path.exists(cache_file):
+        raise ValueError("Non-existant cache file provided")
+    with open(cache_file, "rb") as fp:
+        header = fp.read(4)
+        if header not in [b"SQLi"]:
+            raise ValueError("Identifier file not in recognized format")
+    # Currently only one choice, so use that
+    return SqliteCache(cache_file)
+
+
 ### Automagic
 
 


### PR DESCRIPTION
We've got a nice interface to use a generic cache manager, better to use that than require bits of the framework to specifically pull in our cache manager.