### PR TITLE
Linux pslist dependencies fix 1366

### DIFF
--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -386,6 +386,171 @@ def test_linux_library_list(image, volatility, python):
     assert rc == 0
 
 
+def test_linux_pstree(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.pstree.PsTree", image, volatility, python)
+    out = out.lower()
+
+    assert (out.find(b"init") != -1) or (out.find(b"systemd") != -1)
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_pidhashtable(image, volatility, python):
+    rc, out, _err = runvol_plugin(
+        "linux.pidhashtable.PIDHashTable", image, volatility, python
+    )
+    out = out.lower()
+
+    assert (out.find(b"init") != -1) or (out.find(b"systemd") != -1)
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_bash(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.bash.Bash", image, volatility, python)
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_boottime(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.boottime.Boottime", image, volatility, python)
+    out = out.lower()
+
+    assert out.count(b"utc") >= 1
+    assert rc == 0
+
+
+def test_linux_capabilities(image, volatility, python):
+    rc, out, err = runvol_plugin(
+        "linux.capabilities.Capabilities",
+        image,
+        volatility,
+        python,
+        globalargs=["-vvv"],
+    )
+    if rc != 0 and err.count(b"Unsupported kernel capabilities implementation") > 0:
+        # The linux-sample-1.bin kernel implementation isn't supported.
+        # However, we can still check that the plugin requirements are met.
+        return None
+
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_check_creds(image, volatility, python):
+    rc, out, _err = runvol_plugin(
+        "linux.check_creds.Check_creds", image, volatility, python
+    )
+    out = out.lower()
+
+    # linux-sample-1.bin has no processes sharing credentials.
+    # This validates that plugin requirements are met and exceptions are not raised.
+    assert rc == 0
+
+
+def test_linux_elfs(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.elfs.Elfs", image, volatility, python)
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_envars(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.envars.Envars", image, volatility, python)
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_kthreads(image, volatility, python):
+    rc, out, err = runvol_plugin(
+        "linux.kthreads.Kthreads",
+        image,
+        volatility,
+        python,
+        globalargs=["-vvv"],
+    )
+    out = out.lower()
+
+    if rc != 0 and err.count(b"Unsupported kthread implementation") > 0:
+        # The linux-sample-1.bin kernel implementation isn't supported.
+        # However, we can still check that the plugin requirements are met.
+        return None
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_malfind(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.malfind.Malfind", image, volatility, python)
+    out = out.lower()
+
+    # linux-sample-1.bin has no process memory ranges with potential injected code.
+    # This validates that plugin requirements are met and exceptions are not raised.
+    assert rc == 0
+
+
+def test_linux_mountinfo(image, volatility, python):
+    rc, out, _err = runvol_plugin(
+        "linux.mountinfo.MountInfo", image, volatility, python
+    )
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_psaux(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.psaux.PsAux", image, volatility, python)
+    out = out.lower()
+
+    assert out.count(b"\n") > 50
+    assert rc == 0
+
+
+def test_linux_ptrace(image, volatility, python):
+    rc, out, _err = runvol_plugin("linux.ptrace.Ptrace", image, volatility, python)
+    out = out.lower()
+
+    # linux-sample-1.bin has no processes being ptreaced.
+    # This validates that plugin requirements are met and exceptions are not raised.
+    assert rc == 0
+
+
+def test_linux_vmaregexscan(image, volatility, python):
+    rc, out, _err = runvol_plugin(
+        "linux.vmaregexscan.VmaRegExScan",
+        image,
+        volatility,
+        python,
+        pluginargs=["--pid", "1", "--pattern", "\\x7fELF"],
+    )
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
+def test_linux_vmayarascan(image, volatility, python):
+    rc, out, _err = runvol_plugin(
+        "linux.vmayarascan.VmaYaraScan",
+        image,
+        volatility,
+        python,
+        pluginargs=["--pid", "1", "--yara-string", "ELF"],
+    )
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
+    assert rc == 0
+
+
 # MAC
 
 

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -61,7 +61,7 @@ def runvol_plugin(plugin, img, volatility, python, pluginargs=[], globalargs=[])
 
 
 def test_windows_pslist(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.pslist.PsList", image, volatility, python)
+    rc, out, _err = runvol_plugin("windows.pslist.PsList", image, volatility, python)
     out = out.lower()
     assert out.find(b"system") != -1
     assert out.find(b"csrss.exe") != -1
@@ -69,7 +69,7 @@ def test_windows_pslist(image, volatility, python):
     assert out.count(b"\n") > 10
     assert rc == 0
 
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "windows.pslist.PsList", image, volatility, python, pluginargs=["--pid", "4"]
     )
     out = out.lower()
@@ -79,7 +79,7 @@ def test_windows_pslist(image, volatility, python):
 
 
 def test_windows_psscan(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.psscan.PsScan", image, volatility, python)
+    rc, out, _err = runvol_plugin("windows.psscan.PsScan", image, volatility, python)
     out = out.lower()
     assert out.find(b"system") != -1
     assert out.find(b"csrss.exe") != -1
@@ -89,21 +89,21 @@ def test_windows_psscan(image, volatility, python):
 
 
 def test_windows_dlllist(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.dlllist.DllList", image, volatility, python)
+    rc, out, _err = runvol_plugin("windows.dlllist.DllList", image, volatility, python)
     out = out.lower()
     assert out.count(b"\n") > 10
     assert rc == 0
 
 
 def test_windows_modules(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.modules.Modules", image, volatility, python)
+    rc, out, _err = runvol_plugin("windows.modules.Modules", image, volatility, python)
     out = out.lower()
     assert out.count(b"\n") > 10
     assert rc == 0
 
 
 def test_windows_hivelist(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "windows.registry.hivelist.HiveList", image, volatility, python
     )
     out = out.lower()
@@ -136,7 +136,7 @@ def test_windows_dumpfiles(image, volatility, python):
 
             path = tempfile.mkdtemp()
 
-            rc, out, err = runvol_plugin(
+            rc, _out, _err = runvol_plugin(
                 "windows.dumpfiles.DumpFiles",
                 image,
                 volatility,
@@ -166,7 +166,7 @@ def test_windows_dumpfiles(image, volatility, python):
 
 
 def test_windows_handles(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "windows.handles.Handles", image, volatility, python, pluginargs=["--pid", "4"]
     )
 
@@ -183,7 +183,7 @@ def test_windows_handles(image, volatility, python):
 
 
 def test_windows_svcscan(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.svcscan.SvcScan", image, volatility, python)
+    rc, out, _err = runvol_plugin("windows.svcscan.SvcScan", image, volatility, python)
 
     assert out.find(b"Microsoft ACPI Driver") != -1
     assert out.count(b"\n") > 250
@@ -191,17 +191,19 @@ def test_windows_svcscan(image, volatility, python):
 
 
 def test_windows_thrdscan(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.thrdscan.ThrdScan", image, volatility, python)
+    rc, out, _err = runvol_plugin(
+        "windows.thrdscan.ThrdScan", image, volatility, python
+    )
     # find pid 4 (of system process) which starts with lowest tids
     assert out.find(b"\t4\t8") != -1
     assert out.find(b"\t4\t12") != -1
     assert out.find(b"\t4\t16") != -1
-    #assert out.find(b"this raieses AssertionError") != -1
+    # assert out.find(b"this raieses AssertionError") != -1
     assert rc == 0
 
 
 def test_windows_privileges(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "windows.privileges.Privs", image, volatility, python, pluginargs=["--pid", "4"]
     )
 
@@ -213,7 +215,7 @@ def test_windows_privileges(image, volatility, python):
 
 
 def test_windows_getsids(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "windows.getsids.GetSIDs", image, volatility, python, pluginargs=["--pid", "4"]
     )
 
@@ -225,7 +227,7 @@ def test_windows_getsids(image, volatility, python):
 
 
 def test_windows_envars(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.envars.Envars", image, volatility, python)
+    rc, out, _err = runvol_plugin("windows.envars.Envars", image, volatility, python)
 
     assert out.find(b"PATH") != -1
     assert out.find(b"PROCESSOR_ARCHITECTURE") != -1
@@ -237,7 +239,7 @@ def test_windows_envars(image, volatility, python):
 
 
 def test_windows_callbacks(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "windows.callbacks.Callbacks", image, volatility, python
     )
 
@@ -249,7 +251,7 @@ def test_windows_callbacks(image, volatility, python):
 
 
 def test_windows_vadwalk(image, volatility, python):
-    rc, out, err = runvol_plugin("windows.vadwalk.VadWalk", image, volatility, python)
+    rc, out, _err = runvol_plugin("windows.vadwalk.VadWalk", image, volatility, python)
 
     assert out.find(b"Vad") != -1
     assert out.find(b"VadS") != -1
@@ -260,7 +262,7 @@ def test_windows_vadwalk(image, volatility, python):
 
 
 def test_windows_devicetree(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "windows.devicetree.DeviceTree", image, volatility, python
     )
 
@@ -277,7 +279,7 @@ def test_windows_devicetree(image, volatility, python):
 
 
 def test_linux_pslist(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.pslist.PsList", image, volatility, python)
+    rc, out, _err = runvol_plugin("linux.pslist.PsList", image, volatility, python)
     out = out.lower()
 
     assert (out.find(b"init") != -1) or (out.find(b"systemd") != -1)
@@ -287,7 +289,9 @@ def test_linux_pslist(image, volatility, python):
 
 
 def test_linux_check_idt(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.check_idt.Check_idt", image, volatility, python)
+    rc, out, _err = runvol_plugin(
+        "linux.check_idt.Check_idt", image, volatility, python
+    )
     out = out.lower()
 
     assert out.count(b"__kernel__") >= 10
@@ -296,7 +300,7 @@ def test_linux_check_idt(image, volatility, python):
 
 
 def test_linux_check_syscall(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "linux.check_syscall.Check_syscall", image, volatility, python
     )
     out = out.lower()
@@ -308,7 +312,7 @@ def test_linux_check_syscall(image, volatility, python):
 
 
 def test_linux_lsmod(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.lsmod.Lsmod", image, volatility, python)
+    rc, out, _err = runvol_plugin("linux.lsmod.Lsmod", image, volatility, python)
     out = out.lower()
 
     assert out.count(b"\n") > 10
@@ -316,7 +320,7 @@ def test_linux_lsmod(image, volatility, python):
 
 
 def test_linux_lsof(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.lsof.Lsof", image, volatility, python)
+    rc, out, _err = runvol_plugin("linux.lsof.Lsof", image, volatility, python)
     out = out.lower()
 
     assert out.count(b"socket:") >= 10
@@ -325,7 +329,7 @@ def test_linux_lsof(image, volatility, python):
 
 
 def test_linux_proc_maps(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.proc.Maps", image, volatility, python)
+    rc, out, _err = runvol_plugin("linux.proc.Maps", image, volatility, python)
     out = out.lower()
 
     assert out.count(b"anonymous mapping") >= 10
@@ -334,15 +338,18 @@ def test_linux_proc_maps(image, volatility, python):
 
 
 def test_linux_tty_check(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.tty_check.tty_check", image, volatility, python)
+    rc, out, _err = runvol_plugin(
+        "linux.tty_check.tty_check", image, volatility, python
+    )
     out = out.lower()
 
     assert out.find(b"__kernel__") != -1
     assert out.count(b"\n") >= 5
     assert rc == 0
 
+
 def test_linux_sockstat(image, volatility, python):
-    rc, out, err = runvol_plugin("linux.sockstat.Sockstat", image, volatility, python)
+    rc, out, _err = runvol_plugin("linux.sockstat.Sockstat", image, volatility, python)
 
     assert out.count(b"AF_UNIX") >= 354
     assert out.count(b"AF_BLUETOOTH") >= 5
@@ -354,7 +361,7 @@ def test_linux_sockstat(image, volatility, python):
 
 
 def test_linux_library_list(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "linux.library_list.LibraryList", image, volatility, python
     )
 
@@ -383,7 +390,7 @@ def test_linux_library_list(image, volatility, python):
 
 
 def test_mac_pslist(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.pslist.PsList", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.pslist.PsList", image, volatility, python)
     out = out.lower()
 
     assert (out.find(b"kernel_task") != -1) or (out.find(b"launchd") != -1)
@@ -392,7 +399,7 @@ def test_mac_pslist(image, volatility, python):
 
 
 def test_mac_check_syscall(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "mac.check_syscall.Check_syscall", image, volatility, python
     )
     out = out.lower()
@@ -405,7 +412,7 @@ def test_mac_check_syscall(image, volatility, python):
 
 
 def test_mac_check_sysctl(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "mac.check_sysctl.Check_sysctl", image, volatility, python
     )
     out = out.lower()
@@ -416,7 +423,7 @@ def test_mac_check_sysctl(image, volatility, python):
 
 
 def test_mac_check_trap_table(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "mac.check_trap_table.Check_trap_table", image, volatility, python
     )
     out = out.lower()
@@ -427,7 +434,7 @@ def test_mac_check_trap_table(image, volatility, python):
 
 
 def test_mac_ifconfig(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.ifconfig.Ifconfig", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.ifconfig.Ifconfig", image, volatility, python)
     out = out.lower()
 
     assert out.find(b"127.0.0.1") != -1
@@ -437,7 +444,7 @@ def test_mac_ifconfig(image, volatility, python):
 
 
 def test_mac_lsmod(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.lsmod.Lsmod", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.lsmod.Lsmod", image, volatility, python)
     out = out.lower()
 
     assert out.find(b"com.apple") != -1
@@ -446,7 +453,7 @@ def test_mac_lsmod(image, volatility, python):
 
 
 def test_mac_lsof(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.lsof.Lsof", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.lsof.Lsof", image, volatility, python)
     out = out.lower()
 
     assert out.count(b"\n") > 50
@@ -454,7 +461,7 @@ def test_mac_lsof(image, volatility, python):
 
 
 def test_mac_malfind(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.malfind.Malfind", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.malfind.Malfind", image, volatility, python)
     out = out.lower()
 
     assert out.count(b"\n") > 20
@@ -462,7 +469,7 @@ def test_mac_malfind(image, volatility, python):
 
 
 def test_mac_mount(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.mount.Mount", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.mount.Mount", image, volatility, python)
     out = out.lower()
 
     assert out.find(b"/dev") != -1
@@ -471,7 +478,7 @@ def test_mac_mount(image, volatility, python):
 
 
 def test_mac_netstat(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.netstat.Netstat", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.netstat.Netstat", image, volatility, python)
 
     assert out.find(b"TCP") != -1
     assert out.find(b"UDP") != -1
@@ -481,7 +488,7 @@ def test_mac_netstat(image, volatility, python):
 
 
 def test_mac_proc_maps(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.proc_maps.Maps", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.proc_maps.Maps", image, volatility, python)
     out = out.lower()
 
     assert out.find(b"[heap]") != -1
@@ -490,7 +497,7 @@ def test_mac_proc_maps(image, volatility, python):
 
 
 def test_mac_psaux(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.psaux.Psaux", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.psaux.Psaux", image, volatility, python)
     out = out.lower()
 
     assert out.find(b"executable_path") != -1
@@ -499,7 +506,7 @@ def test_mac_psaux(image, volatility, python):
 
 
 def test_mac_socket_filters(image, volatility, python):
-    rc, out, err = runvol_plugin(
+    rc, out, _err = runvol_plugin(
         "mac.socket_filters.Socket_filters", image, volatility, python
     )
     out = out.lower()
@@ -509,7 +516,7 @@ def test_mac_socket_filters(image, volatility, python):
 
 
 def test_mac_timers(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.timers.Timers", image, volatility, python)
+    rc, out, _err = runvol_plugin("mac.timers.Timers", image, volatility, python)
     out = out.lower()
 
     assert out.count(b"\n") > 6
@@ -517,7 +524,9 @@ def test_mac_timers(image, volatility, python):
 
 
 def test_mac_trustedbsd(image, volatility, python):
-    rc, out, err = runvol_plugin("mac.trustedbsd.Trustedbsd", image, volatility, python)
+    rc, out, _err = runvol_plugin(
+        "mac.trustedbsd.Trustedbsd", image, volatility, python
+    )
     out = out.lower()
 
     assert out.count(b"\n") > 10

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -315,7 +315,7 @@ def test_windows_vadyarascan_yara_rule(image, volatility, python):
     assert rc == 0
 
 
-def test_windows_vadyarascan(image, volatility, python):
+def test_windows_vadyarascan_yara_string(image, volatility, python):
     rc, out, _err = runvol_plugin(
         "windows.vadyarascan.VadYaraScan",
         image,
@@ -476,6 +476,7 @@ def test_linux_capabilities(image, volatility, python):
         python,
         globalargs=["-vvv"],
     )
+
     if rc != 0 and err.count(b"Unsupported kernel capabilities implementation") > 0:
         # The linux-sample-1.bin kernel implementation isn't supported.
         # However, we can still check that the plugin requirements are met.
@@ -521,12 +522,13 @@ def test_linux_kthreads(image, volatility, python):
         python,
         globalargs=["-vvv"],
     )
-    out = out.lower()
 
     if rc != 0 and err.count(b"Unsupported kthread implementation") > 0:
         # The linux-sample-1.bin kernel implementation isn't supported.
         # However, we can still check that the plugin requirements are met.
         return None
+
+    out = out.lower()
 
     assert out.count(b"\n") > 10
     assert rc == 0
@@ -580,20 +582,6 @@ def test_linux_vmaregexscan(image, volatility, python):
     assert rc == 0
 
 
-def test_linux_vmayarascan(image, volatility, python):
-    rc, out, _err = runvol_plugin(
-        "linux.vmayarascan.VmaYaraScan",
-        image,
-        volatility,
-        python,
-        pluginargs=["--pid", "1", "--yara-string", "ELF"],
-    )
-    out = out.lower()
-
-    assert out.count(b"\n") > 10
-    assert rc == 0
-
-
 def test_linux_vmayarascan_yara_rule(image, volatility, python):
     yara_rule_01 = r"""
         rule fullvmayarascan
@@ -627,6 +615,20 @@ def test_linux_vmayarascan_yara_rule(image, volatility, python):
 
     out = out.lower()
     assert out.count(b"\n") > 4
+    assert rc == 0
+
+
+def test_linux_vmayarascan_yara_string(image, volatility, python):
+    rc, out, _err = runvol_plugin(
+        "linux.vmayarascan.VmaYaraScan",
+        image,
+        volatility,
+        python,
+        pluginargs=["--pid", "1", "--yara-string", "ELF"],
+    )
+    out = out.lower()
+
+    assert out.count(b"\n") > 10
     assert rc == 0
 
 

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -362,27 +362,19 @@ def test_linux_sockstat(image, volatility, python):
 
 def test_linux_library_list(image, volatility, python):
     rc, out, _err = runvol_plugin(
-        "linux.library_list.LibraryList", image, volatility, python
+        "linux.library_list.LibraryList",
+        image,
+        volatility,
+        python,
+        pluginargs=["--pids", "2363"],
     )
 
     assert re.search(
         rb"NetworkManager\s2363\s0x7f52cdda0000\s/lib/x86_64-linux-gnu/libnss_files.so.2",
         out,
     )
-    assert re.search(
-        rb"gnome-settings-\s3807\s0x7f7e660b5000\s/lib/x86_64-linux-gnu/libbz2.so.1.0",
-        out,
-    )
-    assert re.search(
-        rb"gdu-notificatio\s3878\s0x7f25ce33e000\s/usr/lib/x86_64-linux-gnu/libXau.so.6",
-        out,
-    )
-    assert re.search(
-        rb"bash\s8600\s0x7fe78a85f000\s/lib/x86_64-linux-gnu/libnss_files.so.2",
-        out,
-    )
 
-    assert out.count(b"\n") >= 2677
+    assert out.count(b"\n") > 10
     assert rc == 0
 
 

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -442,10 +442,9 @@ def test_linux_capabilities(image, volatility, python):
 
 
 def test_linux_check_creds(image, volatility, python):
-    rc, out, _err = runvol_plugin(
+    rc, _out, _err = runvol_plugin(
         "linux.check_creds.Check_creds", image, volatility, python
     )
-    out = out.lower()
 
     # linux-sample-1.bin has no processes sharing credentials.
     # This validates that plugin requirements are met and exceptions are not raised.
@@ -488,8 +487,7 @@ def test_linux_kthreads(image, volatility, python):
 
 
 def test_linux_malfind(image, volatility, python):
-    rc, out, _err = runvol_plugin("linux.malfind.Malfind", image, volatility, python)
-    out = out.lower()
+    rc, _out, _err = runvol_plugin("linux.malfind.Malfind", image, volatility, python)
 
     # linux-sample-1.bin has no process memory ranges with potential injected code.
     # This validates that plugin requirements are met and exceptions are not raised.
@@ -515,8 +513,7 @@ def test_linux_psaux(image, volatility, python):
 
 
 def test_linux_ptrace(image, volatility, python):
-    rc, out, _err = runvol_plugin("linux.ptrace.Ptrace", image, volatility, python)
-    out = out.lower()
+    rc, _out, _err = runvol_plugin("linux.ptrace.Ptrace", image, volatility, python)
 
     # linux-sample-1.bin has no processes being ptreaced.
     # This validates that plugin requirements are met and exceptions are not raised.

--- a/volatility3/framework/plugins/linux/bash.py
+++ b/volatility3/framework/plugins/linux/bash.py
@@ -22,6 +22,7 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Recovers bash command history from memory."""
 
     _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -32,7 +33,7 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/boottime.py
+++ b/volatility3/framework/plugins/linux/boottime.py
@@ -16,7 +16,7 @@ class Boottime(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
 
     _required_framework_version = (2, 11, 0)
 
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -27,7 +27,7 @@ class Boottime(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 3, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/boottime.py
+++ b/volatility3/framework/plugins/linux/boottime.py
@@ -15,7 +15,6 @@ class Boottime(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
     """Shows the time the system was started"""
 
     _required_framework_version = (2, 11, 0)
-
     _version = (1, 0, 1)
 
     @classmethod

--- a/volatility3/framework/plugins/linux/capabilities.py
+++ b/volatility3/framework/plugins/linux/capabilities.py
@@ -50,8 +50,7 @@ class Capabilities(plugins.PluginInterface):
     """Lists process capabilities"""
 
     _required_framework_version = (2, 0, 0)
-
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -62,7 +61,7 @@ class Capabilities(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pids",
@@ -87,7 +86,7 @@ class Capabilities(plugins.PluginInterface):
         try:
             kernel_cap_last_cap = vmlinux.object_from_symbol(symbol_name="cap_last_cap")
         except exceptions.SymbolError:
-            # It should be a kernel < 3.2
+            # It should be a kernel < 3.2 See 73efc0394e148d0e15583e13712637831f926720
             return None
 
         vol2_last_cap = extensions.kernel_cap_struct.get_last_cap_value()

--- a/volatility3/framework/plugins/linux/check_creds.py
+++ b/volatility3/framework/plugins/linux/check_creds.py
@@ -12,8 +12,7 @@ class Check_creds(interfaces.plugins.PluginInterface):
     """Checks if any processes are sharing credential structures"""
 
     _required_framework_version = (2, 0, 0)
-
-    _version = (2, 0, 0)
+    _version = (2, 0, 1)
 
     @classmethod
     def get_requirements(cls):
@@ -24,7 +23,7 @@ class Check_creds(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -25,7 +25,7 @@ class Elfs(plugins.PluginInterface):
     """Lists all memory mapped ELF files for all processes."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (2, 0, 1)
+    _version = (2, 0, 2)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -36,7 +36,7 @@ class Elfs(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/envars.py
+++ b/volatility3/framework/plugins/linux/envars.py
@@ -17,6 +17,7 @@ class Envars(plugins.PluginInterface):
     """Lists processes with their environment variables"""
 
     _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls):
@@ -28,7 +29,7 @@ class Envars(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -20,8 +20,7 @@ class Kthreads(plugins.PluginInterface):
     """Enumerates kthread functions"""
 
     _required_framework_version = (2, 11, 0)
-
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -35,7 +34,7 @@ class Kthreads(plugins.PluginInterface):
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 3, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.PluginRequirement(
                 name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)

--- a/volatility3/framework/plugins/linux/library_list.py
+++ b/volatility3/framework/plugins/linux/library_list.py
@@ -21,8 +21,7 @@ class LibraryList(interfaces.plugins.PluginInterface):
     """Enumerate libraries loaded into processes"""
 
     _required_framework_version = (2, 0, 0)
-
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls):
@@ -33,7 +32,7 @@ class LibraryList(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 2, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pids",

--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -110,7 +110,7 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists open files for each processes."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (2, 0, 0)
+    _version = (2, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -121,7 +121,7 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -4,7 +4,7 @@
 
 from typing import List
 import logging
-from volatility3.framework import constants, interfaces
+from volatility3.framework import interfaces
 from volatility3.framework import renderers, symbols
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
@@ -18,6 +18,7 @@ class Malfind(interfaces.plugins.PluginInterface):
     """Lists process memory ranges that potentially contain injected code."""
 
     _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -28,7 +29,7 @@ class Malfind(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/mountinfo.py
+++ b/volatility3/framework/plugins/linux/mountinfo.py
@@ -36,8 +36,7 @@ class MountInfo(plugins.PluginInterface):
     """Lists mount points on processes mount namespaces"""
 
     _required_framework_version = (2, 2, 0)
-
-    _version = (1, 2, 1)
+    _version = (1, 2, 2)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -48,7 +47,7 @@ class MountInfo(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -19,8 +19,7 @@ class PIDHashTable(plugins.PluginInterface):
     """Enumerates processes through the PID hash table"""
 
     _required_framework_version = (2, 0, 0)
-
-    _version = (1, 0, 1)
+    _version = (1, 0, 2)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -31,7 +30,7 @@ class PIDHashTable(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
@@ -236,8 +235,8 @@ class PIDHashTable(plugins.PluginInterface):
         self, decorate_comm: bool = False
     ) -> interfaces.objects.ObjectInterface:
         for task in self.get_tasks():
-            offset, pid, tid, ppid, name = pslist.PsList.get_task_fields(
-                task, decorate_comm
+            offset, pid, tid, ppid, name, _creation_time = (
+                pslist.PsList.get_task_fields(task, decorate_comm)
             )
             fields = format_hints.Hex(offset), pid, tid, ppid, name
             yield 0, fields

--- a/volatility3/framework/plugins/linux/proc.py
+++ b/volatility3/framework/plugins/linux/proc.py
@@ -21,7 +21,8 @@ class Maps(plugins.PluginInterface):
     """Lists all memory maps for all processes."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
+
     MAXSIZE_DEFAULT = 1024 * 1024 * 1024  # 1 Gb
 
     @classmethod
@@ -34,7 +35,7 @@ class Maps(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/psaux.py
+++ b/volatility3/framework/plugins/linux/psaux.py
@@ -15,6 +15,7 @@ class PsAux(plugins.PluginInterface):
     """Lists processes with their command line arguments"""
 
     _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls):
@@ -26,7 +27,7 @@ class PsAux(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -18,8 +18,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists the processes present in a particular linux memory image."""
 
     _required_framework_version = (2, 0, 0)
-
-    _version = (2, 3, 0)
+    _version = (3, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -13,6 +13,7 @@ class PsTree(interfaces.plugins.PluginInterface):
     ID."""
 
     _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls):
@@ -24,7 +25,7 @@ class PsTree(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 2, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",
@@ -100,13 +101,11 @@ class PsTree(interfaces.plugins.PluginInterface):
         def yield_processes(pid):
             task = self._tasks[pid]
 
-            row = pslist.PsList.get_task_fields(task, decorate_comm)
-            # update the first element, the offset, in the row tuple to use format_hints.Hex
-            # as a simple int is returned from get_task_fields.
-            row = (format_hints.Hex(row[0]),) + row[1:]
-
-            tid = task.pid
-            yield (self._levels[tid] - 1, row)
+            offset, pid, tid, ppid, name, _creation_time = (
+                pslist.PsList.get_task_fields(task, decorate_comm)
+            )
+            fields = format_hints.Hex(offset), pid, tid, ppid, name
+            yield (self._levels[tid] - 1, fields)
 
             for child_pid in sorted(self._children.get(tid, [])):
                 yield from yield_processes(child_pid)

--- a/volatility3/framework/plugins/linux/ptrace.py
+++ b/volatility3/framework/plugins/linux/ptrace.py
@@ -19,7 +19,7 @@ class Ptrace(plugins.PluginInterface):
     """Enumerates ptrace's tracer and tracee tasks"""
 
     _required_framework_version = (2, 10, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -30,7 +30,7 @@ class Ptrace(plugins.PluginInterface):
                 architectures=architectures.LINUX_ARCHS,
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 2, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -12,6 +12,7 @@ from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols import linux
 from volatility3.plugins.linux import lsof
+from volatility3.plugins.linux import pslist
 
 
 vollog = logging.getLogger(__name__)
@@ -21,7 +22,6 @@ class SockHandlers(interfaces.configuration.VersionableInterface):
     """Handles several socket families extracting the sockets information."""
 
     _required_framework_version = (2, 0, 0)
-
     _version = (3, 0, 0)
 
     def __init__(self, vmlinux, task, *args, **kwargs):
@@ -438,8 +438,7 @@ class Sockstat(plugins.PluginInterface):
     """Lists all network connections for all processes."""
 
     _required_framework_version = (2, 0, 0)
-
-    _version = (3, 0, 0)
+    _version = (3, 0, 1)
 
     @classmethod
     def get_requirements(cls):
@@ -454,6 +453,9 @@ class Sockstat(plugins.PluginInterface):
             ),
             requirements.PluginRequirement(
                 name="lsof", plugin=lsof.Lsof, version=(2, 0, 0)
+            ),
+            requirements.PluginRequirement(
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
@@ -591,7 +593,7 @@ class Sockstat(plugins.PluginInterface):
             tasks: String with a list of tasks and FDs using a socket. It can also have
                    extended information such as socket filters, bpf info, etc.
         """
-        filter_func = lsof.pslist.PsList.create_pid_filter(pids)
+        filter_func = pslist.PsList.create_pid_filter(pids)
         socket_generator = self.list_sockets(
             self.context, symbol_table, filter_func=filter_func
         )

--- a/volatility3/framework/plugins/linux/vmaregexscan.py
+++ b/volatility3/framework/plugins/linux/vmaregexscan.py
@@ -21,7 +21,8 @@ class VmaRegExScan(plugins.PluginInterface):
     """Scans all virtual memory areas for tasks using RegEx."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
+
     MAXSIZE_DEFAULT = 128
 
     @classmethod
@@ -34,7 +35,7 @@ class VmaRegExScan(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/vmayarascan.py
+++ b/volatility3/framework/plugins/linux/vmayarascan.py
@@ -15,7 +15,7 @@ class VmaYaraScan(interfaces.plugins.PluginInterface):
     """Scans all virtual memory areas for tasks using yara."""
 
     _required_framework_version = (2, 4, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -28,7 +28,7 @@ class VmaYaraScan(interfaces.plugins.PluginInterface):
                 optional=True,
             ),
             requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.PluginRequirement(
                 name="yarascan", plugin=yarascan.YaraScan, version=(2, 0, 0)


### PR DESCRIPTION
In the context of #1366, this PR updates pslist major version and its 18 dependent plugins.

Additionally, it adds 15 new test cases for the remaining plugins that didn't have a test case before. This will help maintain compatibility and ensure we don't face issues with the plugin requirements in the future. 

The `linux_library_list` test case was taking too long to execute, which was delaying the entire testing task. With the increasing number of testcases, it's become crucial to address this issue. This PR reduces the scope of the plugin to handle just one process, making it faster.

Please note that the **linux.vmayarascan plugin test** will fail until the issue discussed in [Volatility3 issue #1367](https://github.com/volatilityfoundation/volatility3/issues/1367) is addressed.