### PR TITLE
Linux/Mac: Log producer metadata information

### DIFF
--- a/volatility3/framework/automagic/symbol_finder.py
+++ b/volatility3/framework/automagic/symbol_finder.py
@@ -161,27 +161,29 @@ class SymbolFinder(interfaces.automagic.AutomagicInterface):
                 ] = layer.address_mask
 
                 # Keep track of the existing table names so we know which ones were added
-                old_table_names = set(context.symbol_space._dict)
+                old_table_names = set(context.symbol_space)
 
                 # Construct the appropriate symbol table
                 requirement.construct(context, config_path)
 
-                new_table_names = context.symbol_space._dict.keys() - old_table_names
+                new_table_names = set(context.symbol_space) - old_table_names
                 # It should add only one symbol table. Ignore the next steps if it doesn't
                 if len(new_table_names) == 1:
                     new_table_name = new_table_names.pop()
-                    symbol_table = context.symbol_space._dict[new_table_name]
-                    producer = symbol_table.producer
+                    symbol_table = context.symbol_space[new_table_name]
+                    producer_metadata = symbol_table.producer
                     vollog.debug(
-                        f"producer_name: {producer.name}, producer_version: {producer.version_string}"
+                        f"producer_name: {producer_metadata.name}, producer_version: {producer_metadata.version_string}"
                     )
-                    for category in symbol_table.metadata._json_data:
-                        vollog.debug(f"{category}:")
-                        for subkey in symbol_table.metadata._json_data[category]:
-                            subkey_item = ", ".join(
-                                f"{key}: '{value}'" for key, value in subkey.items()
-                            )
-                            vollog.debug(f"\t{subkey_item}")
+
+                    symbol_metadata = symbol_table.metadata
+                    vollog.debug("Types:")
+                    for types_source_dict in symbol_metadata.get_types_sources():
+                        vollog.debug(f"\t{types_source_dict}")
+
+                    vollog.debug("Symbols:")
+                    for symbol_source_dict in symbol_metadata.get_symbols_sources():
+                        vollog.debug(f"\t{symbol_source_dict}")
 
                 break
             else:

--- a/volatility3/framework/symbols/intermed.py
+++ b/volatility3/framework/symbols/intermed.py
@@ -738,10 +738,17 @@ class Version6Format(Version5Format):
     @property
     def metadata(self) -> Optional[interfaces.symbols.MetadataInterface]:
         """Returns a MetadataInterface object."""
-        if self._json_object.get("metadata", {}).get("windows"):
-            return metadata.WindowsMetadata(self._json_object["metadata"]["windows"])
-        if self._json_object.get("metadata", {}).get("linux"):
-            return metadata.LinuxMetadata(self._json_object["metadata"]["linux"])
+        if "metadata" not in self._json_object:
+            return None
+
+        json_metadata = self._json_object["metadata"]
+        if "windows" in json_metadata:
+            return metadata.WindowsMetadata(json_metadata["windows"])
+        if "linux" in json_metadata:
+            return metadata.LinuxMetadata(json_metadata["linux"])
+        if "mac" in json_metadata:
+            return metadata.MacMetadata(json_metadata["mac"])
+
         return None
 
 

--- a/volatility3/framework/symbols/metadata.py
+++ b/volatility3/framework/symbols/metadata.py
@@ -85,8 +85,8 @@ class WindowsMetadata(interfaces.symbols.MetadataInterface):
         return self._json_data.get("pdb", {}).get("age", None)
 
 
-class DwarfMetadata(interfaces.symbols.MetadataInterface):
-    """Base class to handle metadata of DWARF-based ISF sources"""
+class PosixMetadata(interfaces.symbols.MetadataInterface):
+    """Base class to handle metadata of Posix-based ISF sources"""
 
     def get_types_sources(self) -> List[Optional[Dict]]:
         """Returns the types sources metadata"""
@@ -97,9 +97,9 @@ class DwarfMetadata(interfaces.symbols.MetadataInterface):
         return self._json_data.get("symbols", [])
 
 
-class LinuxMetadata(DwarfMetadata):
+class LinuxMetadata(PosixMetadata):
     """Class to handle the metadata from a Linux symbol table."""
 
 
-class MacMetadata(DwarfMetadata):
+class MacMetadata(PosixMetadata):
     """Class to handle the metadata from a Mac symbol table."""

--- a/volatility3/framework/symbols/metadata.py
+++ b/volatility3/framework/symbols/metadata.py
@@ -19,9 +19,16 @@ class ProducerMetadata(interfaces.symbols.MetadataInterface):
         return self._json_data.get("name", None)
 
     @property
+    def version_string(self) -> str:
+        """Returns the ISF file producer's version as a string.
+        If no version is present, an empty string is returned.
+        """
+        return self._json_data.get("version", "")
+
+    @property
     def version(self) -> Optional[Tuple[int]]:
         """Returns the version of the ISF file producer"""
-        version = self._json_data.get("version", None)
+        version = self.version_string()
         if not version:
             return None
         if all(x in "0123456789." for x in version):
@@ -81,3 +88,7 @@ class WindowsMetadata(interfaces.symbols.MetadataInterface):
 
 class LinuxMetadata(interfaces.symbols.MetadataInterface):
     """Class to handle the metadata from a Linux symbol table."""
+
+
+class MacMetadata(interfaces.symbols.MetadataInterface):
+    """Class to handle the metadata from a Mac symbol table."""

--- a/volatility3/framework/symbols/metadata.py
+++ b/volatility3/framework/symbols/metadata.py
@@ -4,8 +4,7 @@
 
 import datetime
 import logging
-from typing import Optional, Tuple, Union
-
+from typing import Optional, Tuple, Union, List, Dict
 from volatility3.framework import constants, interfaces
 
 vollog = logging.getLogger(__name__)
@@ -86,9 +85,21 @@ class WindowsMetadata(interfaces.symbols.MetadataInterface):
         return self._json_data.get("pdb", {}).get("age", None)
 
 
-class LinuxMetadata(interfaces.symbols.MetadataInterface):
+class DwarfMetadata(interfaces.symbols.MetadataInterface):
+    """Base class to handle metadata of DWARF-based ISF sources"""
+
+    def get_types_sources(self) -> List[Optional[Dict]]:
+        """Returns the types sources metadata"""
+        return self._json_data.get("types", [])
+
+    def get_symbols_sources(self) -> List[Optional[Dict]]:
+        """Returns the symbols sources metadata"""
+        return self._json_data.get("symbols", [])
+
+
+class LinuxMetadata(DwarfMetadata):
     """Class to handle the metadata from a Linux symbol table."""
 
 
-class MacMetadata(interfaces.symbols.MetadataInterface):
+class MacMetadata(DwarfMetadata):
     """Class to handle the metadata from a Mac symbol table."""


### PR DESCRIPTION
This PR adds ISF metadata to log lines, including the producer name, version, types, and symbol sources for Mac and Linux. This makes it easier to understand the user's setup when they report an issue, saving time in troubleshooting. 
The information will be available at the `debug` log level, so `-vv`, `-vvv` and so on.

## Example 1 - Current GitHub ISF
This is the current `linux-sample-1.bin` ISF we are using for testing on GitHub, generated by `dwarf2json 0.9.0`. The types and symbols were extracted from `vmlinux-3.2.0-4-amd64`.

```shell
$ ./vol.py -vvv \
    -f ./linux-sample-1.bin \
    linux.pslist
Volatility 3 Framework 2.12.0
...
DEBUG    volatility3.framework.automagic.symbol_finder: Identified banner: b'Linux version 3.2.0-4-amd64 (debian-kernel@lists.debian.org) (gcc version 4.6.3 (Debian 4.6.3-14) ) #1 SMP Debian 3.2.57-3+deb7u2\n\x00'
DEBUG    volatility3.framework.automagic.symbol_finder: Using symbol library: file:///home/gmoreira/vol3_profiles/linux-image-3.2.0-4-amd64_3.2.57-3_deb7u2.json.xz
DEBUG    volatility3.framework.automagic.symbol_finder: producer_name: dwarf2json, producer_version: 0.9.0
DEBUG    volatility3.framework.automagic.symbol_finder: Types:
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'dwarf', 'name': 'vmlinux-3.2.0-4-amd64', 'hash_type': 'sha256', 'hash_value': '67f9060253c801bffd3c99615c41d0ec266f8284c755f5368dad95b021481962'}
DEBUG    volatility3.framework.automagic.symbol_finder: Symbols:
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'dwarf', 'name': 'vmlinux-3.2.0-4-amd64', 'hash_type': 'sha256', 'hash_value': '67f9060253c801bffd3c99615c41d0ec266f8284c755f5368dad95b021481962'}
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'symtab', 'name': 'vmlinux-3.2.0-4-amd64', 'hash_type': 'sha256', 'hash_value': '67f9060253c801bffd3c99615c41d0ec266f8284c755f5368dad95b021481962'}
```

## Example 2 - Previous GitHub ISF
The following is the output from the ISF we previously used on GitHub. It was generated with `dwarf2json 0.6.0`, with types extracted from `vmlinux-3.2.0-4-amd64` and symbols sourced from `System.map-3.2.0-4-amd64` and `vmlinux-3.2.0-4-amd64`.

```shell
$ ./vol.py -vvv \
    -f ./linux-sample-1.bin \
    linux.pslist
Volatility 3 Framework 2.12.0
...
DEBUG    volatility3.framework.automagic.symbol_finder: Identified banner: b'Linux version 3.2.0-4-amd64 (debian-kernel@lists.debian.org) (gcc version 4.6.3 (Debian 4.6.3-14) ) #1 SMP Debian 3.2.57-3+deb7u2\n\x00'
DEBUG    volatility3.framework.automagic.symbol_finder: Using symbol library: file:///home/gmoreira/vol3_profiles/linux-3.2.0-4-amd64-debian.json.xz
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
DEBUG    volatility3.framework.automagic.symbol_finder: producer_name: dwarf2json, producer_version: 0.6.0
DEBUG    volatility3.framework.automagic.symbol_finder: Types:
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'dwarf', 'name': 'vmlinux-3.2.0-4-amd64', 'hash_type': 'sha256', 'hash_value': 'b0b6a369b37c3a4764e6c0f8a57e1336490ba6c33bb1d83ca14e253a48ea359a'}
DEBUG    volatility3.framework.automagic.symbol_finder: Symbols:
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'dwarf', 'name': 'vmlinux-3.2.0-4-amd64', 'hash_type': 'sha256', 'hash_value': 'b0b6a369b37c3a4764e6c0f8a57e1336490ba6c33bb1d83ca14e253a48ea359a'}
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'symtab', 'name': 'vmlinux-3.2.0-4-amd64', 'hash_type': 'sha256', 'hash_value': 'b0b6a369b37c3a4764e6c0f8a57e1336490ba6c33bb1d83ca14e253a48ea359a'}
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'system-map', 'name': 'System.map-3.2.0-4-amd64', 'hash_type': 'sha256', 'hash_value': 'a91a35cb30b78aa625e2a1e41a1b169c290b1e224c249c461caf9c34291791df'}
```

## Example 3 - Custom ISF
Here is a Volatility3 log from an ISF created with `dwarf2json 0.7.0`, using symbols from `System.map` and types extracted from a `module.ko` file.
```shell
$ ./vol.py -vvv \
    -f ./ubuntu120464bit_3.13.0-32_test_modules.core \
    linux.pslist
Volatility 3 Framework 2.12.0
...
DEBUG    volatility3.framework.automagic.symbol_finder: Identified banner: b'Linux version 3.13.0-32-generic (buildd@phianna) (gcc version 4.6.3 (Ubuntu/Linaro 4.6.3-1ubuntu5) ) #57~precise1-Ubuntu SMP Tue Jul 15 03:51:20 UTC 2014 (Ubuntu 3.13.0-32.57~precise1-generic 3.13.11.4)\n'
DEBUG    volatility3.framework.automagic.symbol_finder: Using symbol library: file:///home/gmoreira/vol3_profiles/Ubuntu_3.13.0-32.57~precise1_3.13.0-32-generic_x64.json
DEBUG    volatility3.framework.automagic.symbol_finder: producer_name: dwarf2json, producer_version: 0.7.0
DEBUG    volatility3.framework.automagic.symbol_finder: Types:
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'dwarf', 'name': 'module.ko', 'hash_type': 'sha256', 'hash_value': 'de6c4c45a919def20b2991496b9d964f57dae212f3ba70778ca3e7f0f1a8c6f5'}
DEBUG    volatility3.framework.automagic.symbol_finder: Symbols:
DEBUG    volatility3.framework.automagic.symbol_finder:         {'kind': 'system-map', 'name': 'System.map', 'hash_type': 'sha256', 'hash_value': '0590546715deed2ee83865b3117a991373adf18e4a48ba679d8e108484c74554'}
```

# Mac
The changes include support for Mac. The Mac ISF json format is similar to Linux, so it should work seamlessly. However, I currently don't have a Mac sample on my machine, so I would greatly appreciate it if someone else could test this for me.
