### PR TITLE
Linux: Differentiate yara/yara-x in vmayarascan

### DIFF
--- a/volatility3/framework/plugins/linux/vmayarascan.py
+++ b/volatility3/framework/plugins/linux/vmayarascan.py
@@ -67,12 +67,32 @@ class VmaYaraScan(interfaces.plugins.PluginInterface):
             proc_layer = self.context.layers[proc_layer_name]
 
             for start, end in self.get_vma_maps(task):
-                for match in rules.match(
-                    data=proc_layer.read(start, end - start, True)
-                ):
-                    if yarascan.YaraScan.yara_returns_instances():
-                        for match_string in match.strings:
-                            for instance in match_string.instances:
+                data = proc_layer.read(start, end - start, True)
+                if not yarascan.YaraScan._yara_x:
+                    for match in rules.match(data=data):
+                        if yarascan.YaraScan.yara_returns_instances():
+                            for match_string in match.strings:
+                                for instance in match_string.instances:
+                                    yield 0, (
+                                        format_hints.Hex(instance.offset + start),
+                                        task.UniqueProcessId,
+                                        match.rule,
+                                        match_string.identifier,
+                                        instance.matched_data,
+                                    )
+                        else:
+                            for offset, name, value in match.strings:
+                                yield 0, (
+                                    format_hints.Hex(offset + start),
+                                    task.tgid,
+                                    match.rule,
+                                    name,
+                                    value,
+                                )
+                else:
+                    for match in rules.scan(data=data).matching_rules:
+                        for match_string in match.patterns:
+                            for instance in match_string.matches:
                                 yield 0, (
                                     format_hints.Hex(instance.offset + start),
                                     task.UniqueProcessId,
@@ -80,15 +100,6 @@ class VmaYaraScan(interfaces.plugins.PluginInterface):
                                     match_string.identifier,
                                     instance.matched_data,
                                 )
-                    else:
-                        for offset, name, value in match.strings:
-                            yield 0, (
-                                format_hints.Hex(offset + start),
-                                task.tgid,
-                                match.rule,
-                                name,
-                                value,
-                            )
 
     @staticmethod
     def get_vma_maps(


### PR DESCRIPTION
Adds in code to compensate for the differences in yara and yara-x...  5:\  Really wish there were a generic interface between the two, we can't have plugins needing to know about specific implementations of yara, but I'll file a separate bug for that.  We could *probably* just force the specific scanners to have larger blocks, but failing that I'll write a shim that'll take in either yara and create a consistent interface...

I don't get the expected output (I get no results), but I don't get the exceptions any more either.

Fixes #1367