### PR TITLE
Fix up vmayarascan and vadyarascan to use yarascan properly

### DIFF
--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -14,6 +14,7 @@ import tempfile
 import hashlib
 import ntpath
 import json
+import contextlib
 
 #
 # HELPER FUNCTIONS
@@ -377,6 +378,42 @@ def test_linux_library_list(image, volatility, python):
 
     assert out.count(b"\n") >= 2677
     assert rc == 0
+
+def test_linux_vmayarascan_yara_rule(image, volatility, python):
+    yara_rule_01 = r"""
+        rule fullvmayarascan
+        {
+            strings:
+                $s1 = "_nss_files_parse_grent"
+                $s2 = "/lib64/ld-linux-x86-64.so.2"
+                $s3 = "(bufferend - (char *) 0) % sizeof (char *) == 0"
+            condition:
+                all of them
+        }
+    """
+
+    # FIXME: When the minimum Python version includes 3.12, replace the following with:
+    # with tempfile.NamedTemporaryFile(delete_on_close=False) as fd: ...
+    fd, filename = tempfile.mkstemp(suffix=".yar")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(yara_rule_01)
+
+        rc, out, _err = runvol_plugin(
+            "linux.vmayarascan.VmaYaraScan",
+            image,
+            volatility,
+            python,
+            pluginargs=["--pid", "8600", "--yara-file", filename],
+        )
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(filename)
+
+    out = out.lower()
+    assert out.count(b"\n") > 4
+    assert rc == 0
+
 
 
 # MAC


### PR DESCRIPTION
This gets vmayarascan and vadyarascan to use the scanning framework properly, but hands in chunks that are the size of the complete vad.

This resolves issues around plugins needing to know about the version of vad whilst keeping the fix that led to the divergence...

Supercedes #1370.
Closes #1367 