### PR TITLE
Core: Scanning only splits up the layer

### DIFF
--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -551,29 +551,41 @@ class TranslationLayerInterface(DataLayerInterface, metaclass=ABCMeta):
         assumed to have no holes
         """
         for section_start, section_length in sections:
-            output: List[Tuple[str, int, int]] = []
-
             # For each section, find out which bits of its exists and where they map to
             # This is faster than cutting the entire space into scan_chunk sized blocks and then
             # finding out what exists (particularly if most of the space isn't mapped)
 
+            chunk_start = chunk_position = section_start
+
             for mapped in self.mapping(
                 section_start, section_length, ignore_errors=True
             ):
+                # coallesce adjacent sections
                 offset, sublength, mapped_offset, mapped_length, layer_name = mapped
 
-                for block_start in range(
-                    offset, offset + sublength, scanner.chunk_size
-                ):
-                    block_end = min(
-                        offset + sublength,
-                        block_start + scanner.chunk_size + scanner.overlap,
-                    )
-                    output += [(self.name, block_start, block_end - block_start)]
+                if chunk_start == chunk_position and chunk_start != offset:
+                    chunk_start = chunk_position = offset
 
-                # Ship anything that might be left
-                if output:
-                    yield output, offset
+                if chunk_position < offset:
+                    # New chunk, output the old chunk
+                    yield [
+                        (self.name, chunk_start, chunk_position - chunk_start)
+                    ], chunk_start
+                    chunk_start = offset
+
+                if offset + sublength - chunk_start > scanner.chunk_size:
+                    for block_start in range(
+                        offset, offset + sublength, scanner.chunk_size
+                    ):
+                        yield [
+                            (self.name, chunk_start, chunk_position - chunk_start)
+                        ], chunk_start
+                        chunk_start = chunk_position = block_start
+
+                chunk_position = offset + sublength
+
+            # Ship anything that might be left
+            yield [(self.name, chunk_start, chunk_position - chunk_start)], chunk_start
 
 
 class LayerContainer(collections.abc.Mapping):

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -570,7 +570,7 @@ class TranslationLayerInterface(DataLayerInterface, metaclass=ABCMeta):
                     # New chunk, output the old chunk
                     yield [
                         (self.name, chunk_start, chunk_position - chunk_start)
-                    ], chunk_start
+                    ], chunk_position
                     chunk_start = offset
 
                 if offset + sublength - chunk_start > scanner.chunk_size:
@@ -579,13 +579,15 @@ class TranslationLayerInterface(DataLayerInterface, metaclass=ABCMeta):
                     ):
                         yield [
                             (self.name, chunk_start, chunk_position - chunk_start)
-                        ], chunk_start
+                        ], chunk_position
                         chunk_start = chunk_position = block_start
 
                 chunk_position = offset + sublength
 
             # Ship anything that might be left
-            yield [(self.name, chunk_start, chunk_position - chunk_start)], chunk_start
+            yield [
+                (self.name, chunk_start, chunk_position - chunk_start)
+            ], chunk_position
 
 
 class LayerContainer(collections.abc.Mapping):

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -564,55 +564,18 @@ class TranslationLayerInterface(DataLayerInterface, metaclass=ABCMeta):
             ):
                 offset, sublength, mapped_offset, mapped_length, layer_name = mapped
 
-                # Setup the variables for this block
-                block_start = offset
-                block_end = offset + sublength
-
-                # Setup the necessary bits for non-linear mappings
-                # For linear we give one layer down and mapped offsets (therefore the conversion)
-                # This saves an tiny amount of time not have to redo lookups we've already done
-                # For non-linear layers, we give the layer name and the offset in the layer name
-                # so that the read/conversion occurs properly
-                conversion = mapped_offset - offset if linear else 0
-                return_name = layer_name if linear else self.name
-
-                # If this isn't contiguous, start a new chunk
-                if chunk_position < block_start:
-                    yield output, chunk_position
-                    output = []
-                    chunk_start = chunk_position = block_start
-
-                # Halfway through a chunk, finish the chunk, then take more
-                if chunk_position != chunk_start:
-                    chunk_size = min(
-                        chunk_position - chunk_start,
-                        scanner.chunk_size + scanner.overlap,
+                for block_start in range(
+                    mapped_offset, mapped_offset + mapped_length, scanner.chunk_size
+                ):
+                    block_end = min(
+                        mapped_offset + mapped_length,
+                        block_start + scanner.chunk_size + scanner.overlap,
                     )
-                    output += [(return_name, chunk_position + conversion, chunk_size)]
-                    chunk_start = chunk_position + chunk_size
-                    chunk_position = chunk_start
+                    output += [(self.name, block_start, block_end)]
 
-                # Pack chunks, if we're enter the loop (starting a new chunk) and there's already chunk there, ship it
-                for chunk_start in range(chunk_position, block_end, scanner.chunk_size):
-                    if output:
-                        yield output, chunk_position
-                        output = []
-                        chunk_position = chunk_start
-                    # Take from chunk_position as far as the block can go,
-                    # or as much left of a scanner chunk as we can
-                    chunk_size = min(
-                        block_end - chunk_position,
-                        scanner.chunk_size
-                        + scanner.overlap
-                        - (chunk_position - chunk_start),
-                    )
-                    output += [(return_name, chunk_position + conversion, chunk_size)]
-                    chunk_start = chunk_position + chunk_size
-                    chunk_position = chunk_start
-
-            # Ship anything that might be left
-            if output:
-                yield output, chunk_position
+                # Ship anything that might be left
+                if output:
+                    yield output, mapped_offset
 
 
 class LayerContainer(collections.abc.Mapping):

--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -553,29 +553,27 @@ class TranslationLayerInterface(DataLayerInterface, metaclass=ABCMeta):
         for section_start, section_length in sections:
             output: List[Tuple[str, int, int]] = []
 
-            # Hold the offsets of each chunk (including how much has been filled)
-            chunk_start = chunk_position = 0
-
             # For each section, find out which bits of its exists and where they map to
             # This is faster than cutting the entire space into scan_chunk sized blocks and then
             # finding out what exists (particularly if most of the space isn't mapped)
+
             for mapped in self.mapping(
                 section_start, section_length, ignore_errors=True
             ):
                 offset, sublength, mapped_offset, mapped_length, layer_name = mapped
 
                 for block_start in range(
-                    mapped_offset, mapped_offset + mapped_length, scanner.chunk_size
+                    offset, offset + sublength, scanner.chunk_size
                 ):
                     block_end = min(
-                        mapped_offset + mapped_length,
+                        offset + sublength,
                         block_start + scanner.chunk_size + scanner.overlap,
                     )
-                    output += [(self.name, block_start, block_end)]
+                    output += [(self.name, block_start, block_end - block_start)]
 
                 # Ship anything that might be left
                 if output:
-                    yield output, mapped_offset
+                    yield output, offset
 
 
 class LayerContainer(collections.abc.Mapping):

--- a/volatility3/framework/layers/scanners/__init__.py
+++ b/volatility3/framework/layers/scanners/__init__.py
@@ -20,6 +20,7 @@ class BytesScanner(layers.ScannerInterface):
     def __call__(self, data: bytes, data_offset: int) -> Generator[int, None, None]:
         """Runs through the data looking for the needle, and yields all offsets
         where the needle is found."""
+
         find_pos = data.find(self.needle)
         while find_pos >= 0:
             # Ensure that if we're in the overlap, we don't report it


### PR DESCRIPTION
Scanning had been rigged to chop up a layer's readable bits into the chunks that make it up from the lower layer.  Unfortunately it did this on chunks in the lower layer, rather than chunks readable in the higher layer.  This meant chunks in Intel were already read in page sized blocks.  This vastly simplifies the reading of data and brings non-linear layer searching in sync with linear layer searching (because there's no good reason they should be different).

This doesn't directly help with the yarascanning issue that spawned its investigation, but it will vastly simplify things.  The big question is whether it speeds things up or slows them down...

Since this is core functionality I'd like all eyes on it before it lands please...