### PR TITLE
Renderers - Fix HexBytes formatter for pretty renderer

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -51,8 +51,10 @@ def hex_bytes_as_text(value: bytes, width: int = 16) -> str:
 
     # Handle leftovers when the lenght is not mutiple of width
     if printables:
-        output += "   " * (width - len(printables))
+        padding = width - len(printables)
+        output += "   " * (padding)
         output += printables
+        output += " " * (padding)
 
     return output
 


### PR DESCRIPTION
The pretty renderer justifies each line to the right, which causes issues with the `format_hints.HexBytes` output when the last line is shorter than the maximum hex dump line size. This PR addresses and fixes those cases.

## Before 
```shell
$ python3 ./vol.py -r pretty \
    -f ./linux-sample-1.bin \
    linux.vmayarascan.VmaYaraScan \
    --pid 8600 \
    --yara-file fullvma.yar
Volatility 3 Framework 2.12.0
Formatting...
  |         Offset |  PID |                    Rule | Component |                                                            Value
* | 0x7fe78a8600a6 | 8600 | default.fullvmayarascan |       $s1 |                                                                 
  |                |      |                         |           | 5f 6e 73 73 5f 66 69 6c 65 73 5f 70 61 72 73 65 _nss_files_parse
  |                |      |                         |           |           5f 67 72 65 6e 74                               _grent
* | 0x7fe78a8683f0 | 8600 | default.fullvmayarascan |       $s2 |                                                                 
  |                |      |                         |           | 2f 6c 69 62 36 34 2f 6c 64 2d 6c 69 6e 75 78 2d /lib64/ld-linux-
  |                |      |                         |           |      78 38 36 2d 36 34 2e 73 6f 2e 32                x86-64.so.2
* | 0x7fe78a868260 | 8600 | default.fullvmayarascan |       $s3 |                                                                 
  |                |      |                         |           | 28 62 75 66 66 65 72 65 6e 64 20 2d 20 28 63 68 (bufferend - (ch
  |                |      |                         |           | 61 72 20 2a 29 20 30 29 20 25 20 73 69 7a 65 6f ar *) 0) % sizeo
  |                |      |                         |           |  66 20 28 63 68 61 72 20 2a 29 20 3d 3d 20 30    f (char *) == 0
```

## After
```shell
$ python3 ./vol.py -r pretty \
    -f ./linux-sample-1.bin \
    linux.vmayarascan.VmaYaraScan \
    --pid 8600 \
    --yara-file fullvma.yar
Volatility 3 Framework 2.12.0
Formatting...
  |         Offset |  PID |                    Rule | Component |                                                            Value
* | 0x7fe78a8600a6 | 8600 | default.fullvmayarascan |       $s1 |                                                                 
  |                |      |                         |           | 5f 6e 73 73 5f 66 69 6c 65 73 5f 70 61 72 73 65 _nss_files_parse
  |                |      |                         |           | 5f 67 72 65 6e 74                               _grent          
* | 0x7fe78a8683f0 | 8600 | default.fullvmayarascan |       $s2 |                                                                 
  |                |      |                         |           | 2f 6c 69 62 36 34 2f 6c 64 2d 6c 69 6e 75 78 2d /lib64/ld-linux-
  |                |      |                         |           | 78 38 36 2d 36 34 2e 73 6f 2e 32                x86-64.so.2     
* | 0x7fe78a868260 | 8600 | default.fullvmayarascan |       $s3 |                                                                 
  |                |      |                         |           | 28 62 75 66 66 65 72 65 6e 64 20 2d 20 28 63 68 (bufferend - (ch
  |                |      |                         |           | 61 72 20 2a 29 20 30 29 20 25 20 73 69 7a 65 6f ar *) 0) % sizeo
  |                |      |                         |           | 66 20 28 63 68 61 72 20 2a 29 20 3d 3d 20 30    f (char *) == 0 
```