### PR TITLE
Testing: Enable automatic OS image selection by matching test name and image filename prefixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,10 +25,13 @@ jobs:
 
     - name: Download images
       run: |
+        mkdir test_images
+        cd test_images
         curl -sLO "https://downloads.volatilityfoundation.org/volatility3/images/linux-sample-1.bin.gz"
         gunzip linux-sample-1.bin.gz
         curl -sLO "https://downloads.volatilityfoundation.org/volatility3/images/win-xp-laptop-2005-06-25.img.gz"
         gunzip win-xp-laptop-2005-06-25.img.gz
+        cd -
 
     - name: Download and Extract symbols
       run: |
@@ -39,13 +42,12 @@ jobs:
 
     - name: Testing...
       run: |
-        pytest ./test/test_volatility.py --volatility=vol.py --image win-xp-laptop-2005-06-25.img -k test_windows -v
-        pytest ./test/test_volatility.py --volatility=vol.py --image linux-sample-1.bin -k test_linux -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k test_windows -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k test_linux -v
 
     - name: Clean up post-test
       run: |
-        rm -rf *.bin
-        rm -rf *.img
+        rm -rf test_images
         cd volatility3/symbols
         rm -rf linux
         rm -rf linux.zip


### PR DESCRIPTION
There is an issue with `pytest` in the development environment. Additionally, the current implementation does not scale well for handling multiple images per OS.

When `pytest` is executed it applies its discovery patterns, triggering the `pytest_generate_tests()` function. This function blindly adds all images to each test case, leading to incorrect behavior. For example, Linux tests end up being executed with Windows and Mac images, and vice versa, which makes many testcase-image combination to fail and it's a waste if time. 
In VSCode, for instance, the `pytest` discovery is executed during [test autodiscovery](https://code.visualstudio.com/docs/python/testing#_test-discovery). 

This PR enables `pytest` to automatically select the appropriate image to execute for each operating system.
For this functionality to work, two conditions must be respected:
1. Test case names must include the `test_[OS]_` prefix.
2. Images must have the `[OS]-` prefix.

**Both conditions are already satisfied in our current setup.**

Additionally, with this implementation, it becomes possible to execute a `pytest` command easily using a command like:
```
pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -v
```
The only drawback with this is that if test case execution is parallelized, they will finish at different times and won't be grouped or sorted by operating system. 
However, if this grouping isn't important, we could consider extending these changes (@ikelos?)