### PR TITLE
testing: Enable parallel execution for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ test = [
     "volatility3[dev]",
     "pytest>=8.3.3,<9",
     "yara-x>=0.10.0,<1",
+    "pytest-xdist",
 ]
 
 docs = [
@@ -73,3 +74,6 @@ ignore_missing_imports = true
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts="-n auto"


### PR DESCRIPTION
The changes introduced in this PR enable parallel execution of our test cases with `pytest`, utilizing one worker per available CPU. This enhances the speed of the testing process, both on developers' machines and on `GitHub`.

For example, on `GitHub`, it will launch 4 workers simultaneously. 

References:
- https://code.visualstudio.com/docs/python/testing#_run-tests-in-parallel
- https://pypi.org/project/pytest-xdist/