### PR TITLE
PEP 488 – Elimination of PYO files

### DIFF
--- a/volatility3/framework/__init__.py
+++ b/volatility3/framework/__init__.py
@@ -164,7 +164,6 @@ def _filter_files(filename: str):
     return (
         filename.endswith(".py")
         or filename.endswith(".pyc")
-        or filename.endswith(".pyo")
     ) and not filename.startswith("__")
 
 

--- a/volatility3/framework/__init__.py
+++ b/volatility3/framework/__init__.py
@@ -162,8 +162,7 @@ def import_files(base_module, ignore_errors: bool = False) -> List[str]:
 def _filter_files(filename: str):
     """Ensures that a filename traversed is an importable python file"""
     return (
-        filename.endswith(".py")
-        or filename.endswith(".pyc")
+        filename.endswith(".py") or filename.endswith(".pyc")
     ) and not filename.startswith("__")
 
 


### PR DESCRIPTION
Python 3.5 implememted PEP 488, eliminating .pyo files.