### PR TITLE
Interfaces: change allow list for filenames to ensure they work safely on windows. Fixes issue #1387

### DIFF
--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -59,14 +59,14 @@ class FileHandlerInterface(io.RawIOBase):
 
     @staticmethod
     def sanitize_filename(filename: str) -> str:
-        """Sanititizes the filename to ensure only a specific whitelist of characters is allowed through"""
-        allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.- ()[]{}!$%^:#~?<>,|"
+        """Sanititizes the filename to ensure only a specific allow list of characters is allowed through"""
+        allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.- ()[]{}!$%^#~,"
         result = ""
         for char in filename:
             if char in allowed:
                 result += char
             else:
-                result += "?"
+                result += "_"  # change unwanted chars to an underscore
         return result
 
     def __enter__(self):


### PR DESCRIPTION
Hello :wave: 

This PR changes the allowed characters in filenames to ensure that they work on windows. This fixes issue #1387 

I've verified this on a windows 11 computer to check that the chars I've removed were indeed blocked by windows. 

I have had to change the replacement character from `?` to `_`. This is because `?` is not allowed on windows. 

I've not bumped any version numbers - It feels like something should be updated though? What do you think? 



Microsoft were kind enough to provide a list already of chars that are not allowed:
https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file

> Use any character in the current code page for a name, including Unicode characters and characters in the extended character set (128–255), except for the following:
> 
>     The following reserved characters:
>         < (less than)
>         > (greater than)
>         : (colon)
>         " (double quote)
>         / (forward slash)
>         \ (backslash)
>         | (vertical bar or pipe)
>         ? (question mark)
>         * (asterisk)
