### PR TITLE
fix(Windows: Handles): Unreliable SAR value on 24H2

### DIFF
--- a/volatility3/framework/plugins/windows/callbacks.py
+++ b/volatility3/framework/plugins/windows/callbacks.py
@@ -48,7 +48,7 @@ class Callbacks(interfaces.plugins.PluginInterface):
                 name="driverirp", plugin=driverirp.DriverIrp, version=(1, 0, 0)
             ),
             requirements.PluginRequirement(
-                name="handles", plugin=handles.Handles, version=(1, 0, 0)
+                name="handles", plugin=handles.Handles, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/dumpfiles.py
+++ b/volatility3/framework/plugins/windows/dumpfiles.py
@@ -69,7 +69,7 @@ class DumpFiles(interfaces.plugins.PluginInterface):
                 name="pslist", component=pslist.PsList, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="handles", component=handles.Handles, version=(1, 0, 0)
+                name="handles", component=handles.Handles, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -18,7 +18,7 @@ class Handles(interfaces.plugins.PluginInterface):
     """Lists process open handles."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 3)
+    _version = (2, 0, 0)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -21,11 +21,14 @@ except ImportError:
     has_capstone = False
 
 
+DEFAULT_SAR_VALUE = 0x10  # to be used only when decoding fails
+
+
 class Handles(interfaces.plugins.PluginInterface):
     """Lists process open handles."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 2)
+    _version = (1, 0, 3)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -118,6 +121,10 @@ class Handles(interfaces.plugins.PluginInterface):
                         )
 
                 offset = self._decode_pointer(handle_table_entry.LowValue, magic)
+                if not self.context.layers[virtual].is_valid(offset):
+                    offset = self._decode_pointer(
+                        handle_table_entry.LowValue, DEFAULT_SAR_VALUE
+                    )
             else:
                 if handle_table_entry.InfoTable == 0:
                     return None
@@ -142,7 +149,6 @@ class Handles(interfaces.plugins.PluginInterface):
         pointers in the _HANDLE_TABLE_ENTRY which allows us to find the
         associated _OBJECT_HEADER.
         """
-        DEFAULT_SAR_VALUE = 0x10  # to be used only when decoding fails
 
         if self._sar_value is None:
             if not has_capstone:

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -3,25 +3,15 @@
 #
 
 import logging
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
-from volatility3.framework import constants, exceptions, renderers, interfaces, symbols
+from volatility3.framework import constants, exceptions, interfaces, renderers, symbols
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.windows import pslist, psscan
 
 vollog = logging.getLogger(__name__)
-
-try:
-    import capstone
-
-    has_capstone = True
-except ImportError:
-    has_capstone = False
-
-
-DEFAULT_SAR_VALUE = 0x10  # to be used only when decoding fails
 
 
 class Handles(interfaces.plugins.PluginInterface):
@@ -32,7 +22,6 @@ class Handles(interfaces.plugins.PluginInterface):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._sar_value = None
         self._type_map = None
         self._cookie = None
         self._level_mask = 7
@@ -65,21 +54,6 @@ class Handles(interfaces.plugins.PluginInterface):
             ),
         ]
 
-    def _decode_pointer(self, value, magic):
-        """Windows encodes pointers to objects and decodes them on the fly
-        before using them.
-
-        This function mimics the decoding routine so we can generate the
-        proper pointer values as well.
-        """
-
-        value = value & 0xFFFFFFFFFFFFFFF8
-        value = value >> magic
-        # if (value & (1 << 47)):
-        #    value = value | 0xFFFF000000000000
-
-        return value
-
     def _get_item(self, handle_table_entry, handle_value):
         """Given  a handle table entry (_HANDLE_TABLE_ENTRY) structure from a
         process' handle table, determine where the corresponding object's
@@ -103,28 +77,11 @@ class Handles(interfaces.plugins.PluginInterface):
             )
 
             if is_64bit:
-                if handle_table_entry.LowValue == 0:
+                if handle_table_entry.ObjectPointerBits == 0:
                     return None
 
-                magic = self.find_sar_value()
+                offset = handle_table_entry.ObjectPointerBits << 4
 
-                # is this the right thing to raise here?
-                if magic is None:
-                    if has_capstone:
-                        raise AttributeError(
-                            "Unable to find the SAR value for decoding handle table pointers"
-                        )
-                    else:
-                        raise exceptions.MissingModuleException(
-                            "capstone",
-                            "Requires capstone to find the SAR value for decoding handle table pointers",
-                        )
-
-                offset = self._decode_pointer(handle_table_entry.LowValue, magic)
-                if not self.context.layers[virtual].is_valid(offset):
-                    offset = self._decode_pointer(
-                        handle_table_entry.LowValue, DEFAULT_SAR_VALUE
-                    )
             else:
                 if handle_table_entry.InfoTable == 0:
                     return None
@@ -141,77 +98,6 @@ class Handles(interfaces.plugins.PluginInterface):
 
         object_header.HandleValue = handle_value
         return object_header
-
-    def find_sar_value(self):
-        """Locate ObpCaptureHandleInformationEx if it exists in the sample.
-
-        Once found, parse it for the SAR value that we need to decode
-        pointers in the _HANDLE_TABLE_ENTRY which allows us to find the
-        associated _OBJECT_HEADER.
-        """
-
-        if self._sar_value is None:
-            if not has_capstone:
-                vollog.debug(
-                    "capstone module is missing, unable to create disassembly of ObpCaptureHandleInformationEx"
-                )
-                return None
-            kernel = self.context.modules[self.config["kernel"]]
-
-            virtual_layer_name = kernel.layer_name
-            kvo = self.context.layers[virtual_layer_name].config[
-                "kernel_virtual_offset"
-            ]
-            ntkrnlmp = self.context.module(
-                kernel.symbol_table_name, layer_name=virtual_layer_name, offset=kvo
-            )
-
-            try:
-                func_addr = ntkrnlmp.get_symbol("ObpCaptureHandleInformationEx").address
-            except exceptions.SymbolError:
-                vollog.debug("Unable to locate ObpCaptureHandleInformationEx symbol")
-                return None
-
-            try:
-                func_addr_to_read = kvo + func_addr
-                num_bytes_to_read = 0x200
-                vollog.debug(
-                    f"ObpCaptureHandleInformationEx symbol located at {hex(func_addr_to_read)}"
-                )
-                data = self.context.layers.read(
-                    virtual_layer_name, func_addr_to_read, num_bytes_to_read
-                )
-            except exceptions.InvalidAddressException:
-                vollog.warning(
-                    f"Failed to read {hex(num_bytes_to_read)} bytes at symbol {hex(func_addr_to_read)}. Unable to decode SAR value. Failing back to a common value of {hex(DEFAULT_SAR_VALUE)}"
-                )
-                self._sar_value = DEFAULT_SAR_VALUE
-                return self._sar_value
-
-            md = capstone.Cs(capstone.CS_ARCH_X86, capstone.CS_MODE_64)
-
-            instruction_count = 0
-            for address, size, mnemonic, op_str in md.disasm_lite(
-                data, kvo + func_addr
-            ):
-                # print("{} {} {} {}".format(address, size, mnemonic, op_str))
-                instruction_count += 1
-                if mnemonic.startswith("sar"):
-                    # if we don't want to parse op strings, we can disasm the
-                    # single sar instruction again, but we use disasm_lite for speed
-                    self._sar_value = int(op_str.split(",")[1].strip(), 16)
-                    vollog.debug(
-                        f"SAR located at {hex(address)} with value of {hex(self._sar_value)}"
-                    )
-                    break
-
-            if self._sar_value is None:
-                vollog.warning(
-                    f"Failed to to locate SAR value having parsed {instruction_count} instructions, failing back to a common value of {hex(DEFAULT_SAR_VALUE)}"
-                )
-                self._sar_value = DEFAULT_SAR_VALUE
-
-        return self._sar_value
 
     @classmethod
     def get_type_map(

--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -139,7 +139,7 @@ class PoolScanner(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="handles", plugin=handles.Handles, version=(1, 0, 0)
+                name="handles", plugin=handles.Handles, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/psxview.py
+++ b/volatility3/framework/plugins/windows/psxview.py
@@ -62,7 +62,7 @@ class PsXView(plugins.PluginInterface):
                 name="thrdscan", component=thrdscan.ThrdScan, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="handles", component=handles.Handles, version=(1, 0, 0)
+                name="handles", component=handles.Handles, version=(2, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="physical-offsets",


### PR DESCRIPTION
Handles are not being decoded in 24H2+ samples. This is because the
`Handles._decode_pointer` method grabs the SAR shift value from the
disassembled function, but in these samples this value (`0x11`) is
incorrect. Adding a fallback to the default SAR value of `0x10` if the
obtained pointer is not valid in the kernel address space  resolves the
issue.

This is similar to #1214, but in this case the _correct_ constant pulled from the
disassembly via capstone is _incorrect_ for pointer decoding, so after decoding the
value, we need to check the validity of the pointer, and if it's
invalid, fall back to a pointer decoding with a default SAR value of
0x10. I've confirmed that this fixes the issue on 24H2 while not
breaking things on older samples.
