### PR TITLE
Linux: Update inode pagecache plugin to conform to framework dumping convention

### DIFF
--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -520,7 +520,6 @@ class InodePages(plugins.PluginInterface):
             yield 0, fields
 
         if self.config["dump"]:
-            filename = self.config["dump"]
             open_method = self.open
             inode_address = inode.vol.offset
             filename = open_method.sanitize_filename(f"inode_0x{inode_address:x}.dmp")


### PR DESCRIPTION
This PR addresses #1392 issue

```shell
$ mkdir output_dir
$ ./vol.py \
    --output output_dir \
    -f ./data.lime \
    linux.pagecache.InodePages \
    --inode 0x9d9a457753e0 \
    --dump 
Volatility 3 Framework 2.12.0
PageVAddr       PagePAddr       MappingAddr     Index   DumpSafe        Flags

0xdd8747f885c0  0x1fe217000     0x9d9a45775558  0       True    dirty,lru,referenced,savepinned,swapbacked,uptodate
0xdd8747f87e80  0x1fe1fa000     0x9d9a45775558  1       True    dirty,lru,referenced,savepinned,swapbacked,uptodate
0xdd8747f87f40  0x1fe1fd000     0x9d9a45775558  2       True    dirty,lru,referenced,savepinned,swapbacked,uptodate

$ sha1sum output_dir/inode_0x9d9a457753e0.dmp 
f17f82631f0ace010884ff58cbd8c90ddd89a782  output_dir/inode_0x9d9a457753e0.dmp
```