### PR TITLE
Windows: Handle missing _MM_SESSION_SPACE

### DIFF
--- a/volatility3/framework/plugins/windows/modules.py
+++ b/volatility3/framework/plugins/windows/modules.py
@@ -165,13 +165,33 @@ class Modules(interfaces.plugins.PluginInterface):
 
                 # create the session space object in the process' own layer.
                 # not all processes have a valid session pointer.
-                session_space = context.object(
-                    symbol_table + constants.BANG + "_MM_SESSION_SPACE",
-                    layer_name=layer_name,
-                    offset=proc.Session,
-                )
+                try:
+                    session_space = context.object(
+                        symbol_table + constants.BANG + "_MM_SESSION_SPACE",
+                        layer_name=layer_name,
+                        offset=proc.Session,
+                    )
+                    session_id = session_space.SessionId
 
-                if session_space.SessionId in seen_ids:
+                except exceptions.SymbolError:
+                    # In Windows 11 24H2, the _MM_SESSION_SPACE type was
+                    # replaced with _PSP_SESSION_SPACE, and the kernel PDB
+                    # doesn't contain information about its members (otherwise,
+                    # we would just fall back to the new type). However, it
+                    # appears to be, for our purposes, functionally identical
+                    # to the _MM_SESSION_SPACE. Because _MM_SESSION_SPACE
+                    # stores its session ID at offset 8 as an unsigned long, we
+                    # create an unsigned long at that offset and use that
+                    # instead.
+                    session_id = int(
+                        context.object(
+                            layer_name=layer_name,
+                            object_type=symbol_table + constants.BANG + "unsigned long",
+                            offset=proc.Session + 8,
+                        )
+                    )
+
+                if session_id in seen_ids:
                     continue
 
             except exceptions.InvalidAddressException:
@@ -184,7 +204,7 @@ class Modules(interfaces.plugins.PluginInterface):
                 continue
 
             # save the layer if we haven't seen the session yet
-            seen_ids.append(session_space.SessionId)
+            seen_ids.append(session_id)
             yield proc_layer_name
 
     @classmethod

--- a/volatility3/framework/plugins/windows/modules.py
+++ b/volatility3/framework/plugins/windows/modules.py
@@ -2,14 +2,14 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from typing import List, Iterable, Generator
+from typing import Generator, Iterable, List
 
-from volatility3.framework import exceptions, interfaces, constants, renderers
+from volatility3.framework import constants, exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.windows.extensions import pe
-from volatility3.plugins.windows import pslist, pedump
+from volatility3.plugins.windows import pedump, pslist
 
 vollog = logging.getLogger(__name__)
 
@@ -183,12 +183,10 @@ class Modules(interfaces.plugins.PluginInterface):
                     # stores its session ID at offset 8 as an unsigned long, we
                     # create an unsigned long at that offset and use that
                     # instead.
-                    session_id = int(
-                        context.object(
-                            layer_name=layer_name,
-                            object_type=symbol_table + constants.BANG + "unsigned long",
-                            offset=proc.Session + 8,
-                        )
+                    session_id = context.object(
+                        layer_name=layer_name,
+                        object_type=symbol_table + constants.BANG + "unsigned long",
+                        offset=proc.Session + 8,
                     )
 
                 if session_id in seen_ids:

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -797,7 +797,7 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
 
         return renderers.UnreadableValue()
 
-    def get_session_id(self):
+    def get_session_id(self) -> Union[int, interfaces.renderers.BaseAbsentValue]:
         try:
             if self.has_member("Session"):
                 if self.Session == 0:
@@ -836,7 +836,7 @@ class EPROCESS(generic.GenericIntelProcess, pool.ExecutiveObject):
                         offset=self.Session + 8,
                         absolute=True,
                     )
-                    return int(session_id)
+                    return session_id
 
         except exceptions.InvalidAddressException:
             vollog.log(


### PR DESCRIPTION
refs #1385

As of Windows 11 24H2, the `_MM_SESSION_SPACE` type no longer appears in the kernel PDB. Instead, the `_EPROCESS.Session` member refers to a new, opaque type, `_PSP_SESSION_SPACE`. However, experimentation has shown that this new structure is functionally identical to the old structure - the `ProcessList` and `SessionId` members still appear to be at their old offsets. In order to account for this when analyzing these newer Windows versions, this catches the `SymbolError` and instantiates an `unsigned long` at the offset (8) where the `SessionId` member would normally be defined within an `_MM_SESSION_SPACE` structure.

This fixes plugins that rely on this member, including `windows.pslist` and `windows.verinfo`

@ikelos I considered adding a new symbol table with this `_PSP_SESSION_SPACE` structure, but this was the quick and easy solution - let me know if you'd prefer an approach like that instead.