### PR TITLE
Refactor: move version `None` check to top

### DIFF
--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -529,6 +529,8 @@ class VersionRequirement(interfaces.configuration.RequirementInterface):
         component: Type[interfaces.configuration.VersionableInterface] = None,
         version: Optional[Tuple[int, ...]] = None,
     ) -> None:
+        if version is None:
+            raise TypeError("Version cannot be None")
         if description is None:
             description = f"Version {'.'.join([str(x) for x in version])} dependency on {component.__module__}.{component.__name__} unmet"
         super().__init__(
@@ -537,8 +539,6 @@ class VersionRequirement(interfaces.configuration.RequirementInterface):
         if component is None:
             raise TypeError("Component cannot be None")
         self._component: Type[interfaces.configuration.VersionableInterface] = component
-        if version is None:
-            raise TypeError("Version cannot be None")
         self._version = version
 
     def unsatisfied(


### PR DESCRIPTION
Otherwise, this will cause an error when generating the default description in the `if description is None` branch:
```
TypeError: 'NoneType' object is not iterable
```