### PR TITLE
Linux - Fix dentry type support for kernels pre 3.19

### DIFF
--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -632,6 +632,26 @@ def test_linux_vmayarascan_yara_string(image, volatility, python):
     assert rc == 0
 
 
+def test_linux_page_cache_files(image, volatility, python):
+    rc, out, _err = runvol_plugin(
+        "linux.pagecache.Files",
+        image,
+        volatility,
+        python,
+        pluginargs=["--find", "/etc/passwd"],
+    )
+    out = out.lower()
+
+    assert out.count(b"\n") > 4
+
+    # inode_num inode_addr ... file_path
+    assert re.search(
+        rb"146829\s0x88001ab5c270.*?/etc/passwd",
+        out,
+    )
+    assert rc == 0
+
+
 # MAC
 
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1107,8 +1107,15 @@ class dentry(objects.StructType):
             walk_member = "d_sib"
             list_head_member = self.d_children
         elif self.has_member("d_child") and self.has_member("d_subdirs"):
-            # 2.5.0 <= kernels < 6.8
+            # 3.19.0 <= kernels < 6.8
             walk_member = "d_child"
+            list_head_member = self.d_subdirs
+        elif self.has_member("d_u") and self.has_member("d_subdirs"):
+            # kernels < 3.19
+
+            # Actually, 'd_u.d_child' but to_list() doesn't support something like that.
+            # Since, it's an union, everything is at the same offset than 'd_u'.
+            walk_member = "d_u"
             list_head_member = self.d_subdirs
         else:
             raise exceptions.VolatilityException("Unsupported dentry type")


### PR DESCRIPTION
This PR addresses an issue in the dentry type, which lacked support for kernels earlier than 3.19. Since the dentry function is exclusively used by the Page Cache plugins, this limitation caused them to fail.

```shell
./vol.py -vvv \
    -f ./linux-sample-1.bin \
    linux.pagecache.Files
...
DEBUG    volatility3.cli: Traceback (most recent call last):
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/cli/__init__.py", line 505, in run
    renderer.render(grid)
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/cli/text_renderer.py", line 232, in render
    grid.populate(visitor, outfd)
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/framework/renderers/__init__.py", line 245, in populate
    for level, item in self._generator:
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/framework/plugins/linux/pagecache.py", line 350, in format_fields_with_headers
    for level, fields in generator:
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/framework/plugins/linux/pagecache.py", line 312, in _generator
    for inode_in in inodes_iter:
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/framework/plugins/linux/pagecache.py", line 272, in get_inodes
    for file_path, file_dentry in cls._walk_dentry(
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/framework/plugins/linux/pagecache.py", line 177, in _walk_dentry
    for dentry in root_dentry.get_subdirs():
  File "/home/user/vol3_fix_issue_dentry_d_u/volatility3/framework/symbols/linux/extensions/__init__.py", line 1121, in get_subdirs
    raise exceptions.VolatilityException("Unsupported dentry type")
volatility3.framework.exceptions.VolatilityException: Unsupported dentry type
```

Since the sample used for the GitHub test cases corresponds to kernel version 3.2.0 (<3.19), it allows us to validate this fix. Therefore, this PR also includes a test case for the `linux.pagecache.Files` plugin to confirm that it works as intended.

After the fix:

```shell
./vol.py -vvv \
    -f ./linux-sample-1.bin \
    linux.pagecache.Files
Volatility 3 Framework 2.12.0   Stacking attempts finished                 

SuperblockAddr  MountPoint      Device  InodeNum        InodeAddr       FileType        InodePages      CachedPages     FileMode        AccessTime      ModificationTime        ChangeTime      FilePath

0x88001f904800  /       0:1     1       0x88001e801b18  DIR     0       0       drwxr-xr-x      2014-06-24 10:22:35.580000 UTC  2014-06-24 10:22:35.580000 UTC  2014-06-24 10:22:35.580000 UTC  /
0x88001f904800  /       0:1     1666    0x88001e928278  DIR     0       0       drwx------      2014-06-05 06:14:45.000000 UTC  2014-06-05 06:14:45.000000 UTC  2014-06-24 10:22:33.340019 UTC  /root
0x88001b5c8c00  /sys    0:13    1       0x88001ea2e8f0  DIR     0       0       drwxr-xr-x      2014-06-24 10:22:34.500000 UTC  2014-06-24 10:22:34.500000 UTC  2014-06-24 10:22:34.500000 UTC  /sys
0x88001b5c8c00  /sys    0:13    96      0x88001aa5a278  DIR     0       0       drwxr-xr-x      2014-06-24 10:22:40.788797 UTC  2014-06-24 10:22:40.788797 UTC  2014-06-24 10:22:40.788797 UTC  /sys/power
...
```