### PR TITLE
Windows: Update get_commit_charge extension to handle Core.CommitCharge case

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -269,7 +269,10 @@ class MMVAD_SHORT(objects.StructType):
             return self.u.VadFlags.CommitCharge
 
         elif self.has_member("Core"):
-            return self.Core.u1.VadFlags1.CommitCharge
+            if self.Core.has_member("CommitCharge"):
+                return self.Core.CommitCharge
+            else:
+                return self.Core.u1.VadFlags1.CommitCharge
 
         raise AttributeError("Unable to find the commit charge member")
 

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -262,7 +262,10 @@ class MMVAD_SHORT(objects.StructType):
     def get_commit_charge(self):
         """Get the VAD's commit charge (number of committed pages)"""
 
-        if self.has_member("u1") and self.u1.has_member("VadFlags1"):
+        if self.has_member("CommitCharge"):
+            return self.CommitCharge
+
+        elif self.has_member("u1") and self.u1.has_member("VadFlags1"):
             return self.u1.VadFlags1.CommitCharge
 
         elif self.has_member("u") and self.u.has_member("VadFlags"):


### PR DESCRIPTION
Hello :wave: 

This will hopefully fix https://github.com/volatilityfoundation/volatility3/issues/1400 - however I do not have a sample to test with. Please wait until @KQBTD is able to confirm. 

This changes the windows extension for get_commit_charge to handle the case where the results we're after are stored in `Core.CommitCharge` as pointed out by @atcuno.

Thanks!
:fox_face: 