### PR TITLE
Linux: Fix task parent pid in several plugins

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 12  # Number of changes that only add to the interface
+VERSION_MINOR = 13  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/plugins/linux/capabilities.py
+++ b/volatility3/framework/plugins/linux/capabilities.py
@@ -49,7 +49,7 @@ class CapabilitiesData:
 class Capabilities(plugins.PluginInterface):
     """Lists process capabilities"""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 13, 0)
     _version = (1, 1, 0)
 
     @classmethod

--- a/volatility3/framework/plugins/linux/capabilities.py
+++ b/volatility3/framework/plugins/linux/capabilities.py
@@ -50,7 +50,7 @@ class Capabilities(plugins.PluginInterface):
     """Lists process capabilities"""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 1)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -136,7 +136,7 @@ class Capabilities(plugins.PluginInterface):
             comm=utility.array_to_string(task.comm),
             pid=int(task.pid),
             tgid=int(task.tgid),
-            ppid=int(task.parent.pid),
+            ppid=int(task.get_parent_pid()),
             euid=int(task.cred.euid),
         )
 

--- a/volatility3/framework/plugins/linux/envars.py
+++ b/volatility3/framework/plugins/linux/envars.py
@@ -17,7 +17,7 @@ class Envars(plugins.PluginInterface):
     """Lists processes with their environment variables"""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 1)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls):
@@ -48,15 +48,7 @@ class Envars(plugins.PluginInterface):
 
             # get process name as string
             name = utility.array_to_string(task.comm)
-
-            # try and get task parent
-            try:
-                ppid = task.parent.pid
-            except exceptions.InvalidAddressException:
-                vollog.debug(
-                    f"Unable to read parent pid for task {pid} {name}, setting ppid to 0."
-                )
-                ppid = 0
+            ppid = task.get_parent_pid()
 
             # kernel threads never have an mm as they do not have userland mappings
             try:

--- a/volatility3/framework/plugins/linux/envars.py
+++ b/volatility3/framework/plugins/linux/envars.py
@@ -16,7 +16,7 @@ vollog = logging.getLogger(__name__)
 class Envars(plugins.PluginInterface):
     """Lists processes with their environment variables"""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 13, 0)
     _version = (1, 1, 0)
 
     @classmethod

--- a/volatility3/framework/plugins/linux/psaux.py
+++ b/volatility3/framework/plugins/linux/psaux.py
@@ -15,7 +15,7 @@ class PsAux(plugins.PluginInterface):
     """Lists processes with their command line arguments"""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 1)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls):
@@ -98,14 +98,8 @@ class PsAux(plugins.PluginInterface):
         # walk the process list and report the arguments
         for task in tasks:
             pid = task.pid
-
-            try:
-                ppid = task.parent.pid
-            except exceptions.InvalidAddressException:
-                ppid = 0
-
+            ppid = task.get_parent_pid()
             name = utility.array_to_string(task.comm)
-
             args = self._get_command_line_args(task, name)
 
             yield (0, (pid, ppid, name, args))

--- a/volatility3/framework/plugins/linux/psaux.py
+++ b/volatility3/framework/plugins/linux/psaux.py
@@ -14,7 +14,7 @@ from volatility3.plugins.linux import pslist
 class PsAux(plugins.PluginInterface):
     """Lists processes with their command line arguments"""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 13, 0)
     _version = (1, 1, 0)
 
     @classmethod

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -17,7 +17,7 @@ from volatility3.plugins.linux import elfs
 class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists the processes present in a particular linux memory image."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 13, 0)
     _version = (3, 1, 0)
 
     @classmethod

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -18,7 +18,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists the processes present in a particular linux memory image."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (3, 0, 0)
+    _version = (3, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -95,7 +95,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         """
         pid = task.tgid
         tid = task.pid
-        ppid = task.parent.tgid if task.parent else 0
+        ppid = task.get_parent_pid()
         name = utility.array_to_string(task.comm)
         start_time = task.get_create_time()
         if decorate_comm:

--- a/volatility3/framework/plugins/linux/psscan.py
+++ b/volatility3/framework/plugins/linux/psscan.py
@@ -27,7 +27,7 @@ class DescExitStateEnum(Enum):
 class PsScan(interfaces.plugins.PluginInterface):
     """Scans for processes present in a particular linux image."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 13, 0)
     _version = (1, 1, 0)
 
     @classmethod

--- a/volatility3/framework/plugins/linux/psscan.py
+++ b/volatility3/framework/plugins/linux/psscan.py
@@ -28,7 +28,7 @@ class PsScan(interfaces.plugins.PluginInterface):
     """Scans for processes present in a particular linux image."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 1)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -52,10 +52,7 @@ class PsScan(interfaces.plugins.PluginInterface):
         """
         pid = task.tgid
         tid = task.pid
-        ppid = 0
-
-        if task.parent.is_readable():
-            ppid = task.parent.tgid
+        ppid = task.get_parent_pid()
         name = utility.array_to_string(task.comm)
         exit_state = DescExitStateEnum(task.exit_state).name
 

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -13,7 +13,7 @@ class PsTree(interfaces.plugins.PluginInterface):
     ID."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 1)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls):
@@ -56,9 +56,9 @@ class PsTree(interfaces.plugins.PluginInterface):
         seen = set([pid])
         level = 0
         proc = self._tasks.get(pid)
-        while proc and proc.parent and proc.parent.pid not in seen:
+        while proc and proc.get_parent_pid() not in seen:
             if proc.is_thread_group_leader:
-                parent_pid = proc.parent.pid
+                parent_pid = proc.get_parent_pid()
             else:
                 parent_pid = proc.tgid
 

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -12,7 +12,7 @@ class PsTree(interfaces.plugins.PluginInterface):
     """Plugin for listing processes in a tree based on their parent process
     ID."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 13, 0)
     _version = (1, 1, 0)
 
     @classmethod

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -635,6 +635,20 @@ class task_struct(generic.GenericIntelProcess):
         # root time namespace, not within the task's own time namespace
         return boottime + task_start_time_timedelta
 
+    def get_parent_pid(self) -> int:
+        """Returns the parent process ID (PPID)
+
+        This method replicates the Linux kernel's `getppid` syscall behavior.
+        Avoid using `task.parent`; instead, use this function for accurate results.
+        """
+
+        if self.real_parent and self.real_parent.is_readable():
+            ppid = self.real_parent.pid
+        else:
+            ppid = 0
+
+        return ppid
+
 
 class fs_struct(objects.StructType):
     def get_root_dentry(self):


### PR DESCRIPTION
Linux plugins are using the wrong value for the parent process identifier (PPID).
Using `task.parent` can result in inaccurate results, especially in cases involving ptraced processes (refer to [PR #1288](https://github.com/volatilityfoundation/volatility3/pull/1288) for more details).

This PR introduces a new method in the task object extension that mimics the Linux kernel's [getppid](https://elixir.bootlin.com/linux/v6.12.5/source/kernel/sys.c#L984) syscall, ensuring correct and consistent retrieval of the parent PID.
