### PR TITLE
Fix ProducerMetadata class bug introduced in #1369

### DIFF
--- a/volatility3/framework/symbols/metadata.py
+++ b/volatility3/framework/symbols/metadata.py
@@ -27,7 +27,7 @@ class ProducerMetadata(interfaces.symbols.MetadataInterface):
     @property
     def version(self) -> Optional[Tuple[int]]:
         """Returns the version of the ISF file producer"""
-        version = self.version_string()
+        version = self.version_string
         if not version:
             return None
         if all(x in "0123456789." for x in version):


### PR DESCRIPTION
Since only the `hidden_modules` and `kmesg` plugins use the affected method, and there are no test cases for either, the bug wasn't triggered on my end. I'll be adding test cases for these, as well as for the remaining Linux plugins, to prevent similar issues from occurring in the future.