### PR TITLE
Fix: Error early if no inodes are found in linux.pagecache.InodePages plugin

### DIFF
--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -483,6 +483,9 @@ class InodePages(plugins.PluginInterface):
                 if inode_in.path == self.config["find"]:
                     inode = inode_in.inode
                     break  # Only the first match
+            else:
+                vollog.error("Unable to find inode with path %s", self.config["find"])
+                return None
 
         elif self.config["inode"]:
             inode = vmlinux.object("inode", self.config["inode"], absolute=True)


### PR DESCRIPTION
If not, this will cause an error 5 lines down when running `if not inode.is_valid()`:
```
UnboundLocalError: cannot access local variable 'inode' where it is not associated with a value
```