### PR TITLE
Issues/issue1418

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 15  # Number of changes that only add to the interface
+VERSION_MINOR = 14  # Number of changes that only add to the interface
 VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,7 +1,7 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
 VERSION_MINOR = 12  # Number of changes that only add to the interface
-VERSION_PATCH = 0  # Number of changes that do not change the interface
+VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 PACKAGE_VERSION = (

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -11,7 +11,7 @@ without them interfering with each other.
 import functools
 import hashlib
 import logging
-from typing import Callable, Iterable, List, Optional, Set, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from volatility3.framework import constants, interfaces, symbols, exceptions
 from volatility3.framework.objects import templates
@@ -386,10 +386,9 @@ class ModuleCollection(interfaces.context.ModuleContainer):
     """Class to contain a collection of SizedModules and reason about their
     contents."""
 
-    def __init__(
-        self, modules: Optional[List[interfaces.context.ModuleInterface]] = None
-    ) -> None:
+    def __init__(self, modules: Optional[List[SizedModule]] = None) -> None:
         self._prefix_count = {}
+        self._modules: Dict[str, SizedModule] = {}
         super().__init__(modules)
 
     def deduplicate(self) -> "ModuleCollection":
@@ -402,9 +401,9 @@ class ModuleCollection(interfaces.context.ModuleContainer):
         new_modules = []
         seen: Set[str] = set()
         for mod in self._modules:
-            if mod.hash not in seen or mod.size == 0:
+            if self._modules[mod].hash not in seen or self._modules[mod].size == 0:
                 new_modules.append(mod)
-                seen.add(mod.hash)  # type: ignore # FIXME: mypy #5107
+                seen.add(self._modules[mod].hash)
         return ModuleCollection(new_modules)
 
     def free_module_name(self, prefix: str = "module") -> str:

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -11,6 +11,7 @@ without them interfering with each other.
 import functools
 import hashlib
 import logging
+import re
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from volatility3.framework import constants, interfaces, symbols, exceptions
@@ -387,7 +388,6 @@ class ModuleCollection(interfaces.context.ModuleContainer):
     contents."""
 
     def __init__(self, modules: Optional[List[SizedModule]] = None) -> None:
-        self._prefix_count = {}
         self._modules: Dict[str, SizedModule] = {}
         super().__init__(modules)
 
@@ -408,13 +408,12 @@ class ModuleCollection(interfaces.context.ModuleContainer):
 
     def free_module_name(self, prefix: str = "module") -> str:
         """Returns an unused module name"""
-        if prefix not in self._prefix_count:
-            self._prefix_count[prefix] = 1
+        existing_names = [name for name in self if re.match(rf"^{prefix}[0-9]*$", name)]
+        if not existing_names:
             return prefix
-        count = self._prefix_count[prefix]
+        count = len(existing_names)
         while prefix + str(count) in self:
             count += 1
-        self._prefix_count[prefix] = count
         return prefix + str(count)
 
     @property

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -295,6 +295,7 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
     def has_enumeration(self, name: str) -> bool:
         """Determines whether an enumeration is present in the module's symbol table."""
 
+    @property
     def symbols(self) -> List:
         """Lists the symbols contained in the symbol table for this module"""
 

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -306,6 +306,7 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
     @abstractmethod
     def symbols(self) -> List:
         """Lists the symbols contained in the symbol table for this module"""
+        raise NotImplementedError("Symbols property has not been implemented.") 
 
     @abstractmethod
     def get_symbols_by_absolute_location(self, offset: int, size: int = 0) -> List[str]:

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -306,7 +306,7 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
     @abstractmethod
     def symbols(self) -> List:
         """Lists the symbols contained in the symbol table for this module"""
-        raise NotImplementedError("Symbols property has not been implemented.") 
+        raise NotImplementedError("Symbols property has not been implemented.")
 
     @abstractmethod
     def get_symbols_by_absolute_location(self, offset: int, size: int = 0) -> List[str]:


### PR DESCRIPTION
Fixes #1418

There are still some other discrepancies (that again, don't appear to have been used, so should be fixed, and since we're bumping versions, we should do it here).  Notably, the `Module.symbols` property, is a property whereas the interface says it should be a function.  Quite tempted to change the function to a property in the interface, since I think that's what it had always been intended to be.  Technically that'd be a core bump, but since I couldn't find any uses of it anywhere (and it's in the interface, not the concrete implementation) I threw that in here too...  5:S