### PR TITLE
Linux: task.get_parent_pid() fix to mimic getppid() syscall

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -641,7 +641,7 @@ class task_struct(generic.GenericIntelProcess):
         """
 
         if self.real_parent and self.real_parent.is_readable():
-            ppid = self.real_parent.pid
+            ppid = self.real_parent.tgid
         else:
             ppid = 0
 


### PR DESCRIPTION
In the context of #1412, I missed another bug when retrieving the task parent in the initial fix. The correct value should be `task.real_parent.tgid` rather than the initial `task.parent.pid`. See https://elixir.bootlin.com/linux/v6.12.5/source/kernel/sys.c#L989