### PR TITLE
Windows Extensions: Fix potential AttributeErrors

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/network.py
+++ b/volatility3/framework/symbols/windows/extensions/network.py
@@ -4,7 +4,7 @@
 
 import logging
 import socket
-from typing import Dict, Tuple, List, Union
+from typing import Dict, Tuple, List, Union, Optional
 
 from volatility3.framework import exceptions
 from volatility3.framework import objects, interfaces
@@ -86,19 +86,29 @@ class _TCP_LISTENER(objects.StructType):
         except exceptions.InvalidAddressException:
             return None
 
-    def get_owner_pid(self):
-        if self.get_owner().is_valid():
-            if self.get_owner().has_valid_member("UniqueProcessId"):
-                return self.get_owner().UniqueProcessId
+    def get_owner_pid(self) -> Optional[int]:
+        owner = self.get_owner()
+
+        if owner is None:
+            return None
+
+        if owner.is_valid():
+            if owner.has_valid_member("UniqueProcessId"):
+                return owner.UniqueProcessId
 
         return None
 
-    def get_owner_procname(self):
-        if self.get_owner().is_valid():
-            if self.get_owner().has_valid_member("ImageFileName"):
-                return self.get_owner().ImageFileName.cast(
+    def get_owner_procname(self) -> Optional[str]:
+        owner = self.get_owner()
+
+        if owner is None:
+            return None
+
+        if owner.is_valid():
+            if owner.has_valid_member("ImageFileName"):
+                return owner.ImageFileName.cast(
                     "string",
-                    max_length=self.get_owner().ImageFileName.vol.count,
+                    max_length=owner.ImageFileName.vol.count,
                     errors="replace",
                 )
 


### PR DESCRIPTION
If `self.get_owner()` returns `None`, and the chained call to
`is_valid()` is executed, an `AttributeError` will occur. This fixes two
instances of this bug by intializing a local variable with the result of
the `get_owner()` call, checking for `None`, and returning if that's the
case.

Also adds type-hints for these methods.
