### PR TITLE
Windows PEDump: Revert overwritten changes

### DIFF
--- a/volatility3/framework/plugins/windows/pedump.py
+++ b/volatility3/framework/plugins/windows/pedump.py
@@ -64,30 +64,27 @@ class PEDump(interfaces.plugins.PluginInterface):
         """
         Returns the filename of the dump file or None
         """
-        try:
-            file_handle = open_method(file_name)
+        with open_method(file_name) as file_handle:
+            try:
+                dos_header = context.object(
+                    pe_table_name + constants.BANG + "_IMAGE_DOS_HEADER",
+                    offset=base,
+                    layer_name=layer_name,
+                )
 
-            dos_header = context.object(
-                pe_table_name + constants.BANG + "_IMAGE_DOS_HEADER",
-                offset=base,
-                layer_name=layer_name,
-            )
+                for offset, data in dos_header.reconstruct():
+                    file_handle.seek(offset)
+                    file_handle.write(data)
+            except (
+                OSError,
+                exceptions.VolatilityException,
+                OverflowError,
+                ValueError,
+            ) as excp:
+                vollog.debug(f"Unable to dump PE file at offset {base}: {excp}")
+                return None
 
-            for offset, data in dos_header.reconstruct():
-                file_handle.seek(offset)
-                file_handle.write(data)
-        except (
-            OSError,
-            exceptions.VolatilityException,
-            OverflowError,
-            ValueError,
-        ) as excp:
-            vollog.debug(f"Unable to dump PE file at offset {base}: {excp}")
-            return None
-        finally:
-            file_handle.close()
-
-        return file_handle.preferred_filename
+            return file_handle.preferred_filename
 
     @classmethod
     def dump_ldr_entry(


### PR DESCRIPTION
When #1364 was merged, it may not have been rebased onto the changes
introduced in #1422, and they ended up overwritten to the old version.
This reverts those changes.
