### PR TITLE
xen_coredump_layer: fix potential uninitialized variable issue 

### DIFF
--- a/volatility3/framework/layers/xen.py
+++ b/volatility3/framework/layers/xen.py
@@ -54,6 +54,7 @@ class XenCoreDumpLayer(elf.Elf64Layer):
 
         segments = []
         self._segment_headers = []
+        segment_names = None
 
         for sindex in range(ehdr.e_shnum):
             shdr = self.context.object(


### PR DESCRIPTION
This PR addresses #1434