### PR TITLE
testcases: Add basic volshell testcases for each OS image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,11 @@ jobs:
 
     - name: Testing...
       run: |
+        # VolShell
+        pytest ./test/test_volatility.py --volatility=volshell.py --image-dir=./test_images -k test_windows_volshell -v
+        pytest ./test/test_volatility.py --volatility=volshell.py --image-dir=./test_images -k test_linux_volshell -v
+
+        # Volatility
         pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k test_windows -v
         pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k test_linux -v
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,8 +47,8 @@ jobs:
         pytest ./test/test_volatility.py --volatility=volshell.py --image-dir=./test_images -k test_linux_volshell -v
 
         # Volatility
-        pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k test_windows -v
-        pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k test_linux -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k "test_windows and not test_windows_volshell" -v
+        pytest ./test/test_volatility.py --volatility=vol.py --image-dir=./test_images -k "test_linux and not test_linux_volshell" -v
 
     - name: Clean up post-test
       run: |

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -73,7 +73,7 @@ def runvolshell(img, volshell, python, volshellargs=[], globalargs=[]):
 #
 
 
-def basic_volshell_test(image, volatility, python):
+def basic_volshell_test(image, volatility, python, globalargs):
     # Basic VolShell test to verify requirements and ensure VolShell runs without crashing
 
     # FIXME: When the minimum Python version includes 3.12, replace the following with:
@@ -88,6 +88,7 @@ def basic_volshell_test(image, volatility, python):
             volshell=volatility,
             python=python,
             volshellargs=["--script", filename],
+            globalargs=globalargs,
         )
     finally:
         with contextlib.suppress(FileNotFoundError):
@@ -101,7 +102,7 @@ def basic_volshell_test(image, volatility, python):
 
 
 def test_windows_volshell(image, volatility, python):
-    basic_volshell_test(image, volatility, python)
+    basic_volshell_test(image, volatility, python, globalargs=["-w"])
 
 
 def test_windows_pslist(image, volatility, python):
@@ -376,7 +377,7 @@ def test_windows_vadyarascan_yara_string(image, volatility, python):
 
 
 def test_linux_volshell(image, volatility, python):
-    basic_volshell_test(image, volatility, python)
+    basic_volshell_test(image, volatility, python, globalargs=["-l"])
 
 
 def test_linux_pslist(image, volatility, python):
@@ -818,7 +819,7 @@ def test_linux_hidden_modules(image, volatility, python):
 
 
 def test_mac_volshell(image, volatility, python):
-    basic_volshell_test(image, volatility, python)
+    basic_volshell_test(image, volatility, python, globalargs=["-m"])
 
 
 def test_mac_pslist(image, volatility, python):

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -39,7 +39,9 @@ def runvol(args, volatility, python):
     return p.returncode, stdout, stderr
 
 
-def runvol_plugin(plugin, img, volatility, python, pluginargs=[], globalargs=[]):
+def runvol_plugin(plugin, img, volatility, python, pluginargs=None, globalargs=None):
+    pluginargs = pluginargs or []
+    globalargs = globalargs or []
     args = (
         globalargs
         + [
@@ -54,7 +56,9 @@ def runvol_plugin(plugin, img, volatility, python, pluginargs=[], globalargs=[])
     return runvol(args, volatility, python)
 
 
-def runvolshell(img, volshell, python, volshellargs=[], globalargs=[]):
+def runvolshell(img, volshell, python, volshellargs=None, globalargs=None):
+    volshellargs = volshellargs or []
+    globalargs = globalargs or []
     args = (
         globalargs
         + [


### PR DESCRIPTION
In the context of #1456, this PR adds a basic volshell testcases for each OS image.

@ikelos please verify this fails before the changes mentioned in #1456 

It runs `ps()` on each of them and verifies it gets enough processes for both Linux and Windows.
If you are interested in any other functions let me know and can add them as well. So far, it verifies:
- requirements
- ps() works.. and 
- basically, ensures that volshell runs and exits without issues

Which is already quite a bit from what we got.