### PR TITLE
Layers: Fix MSF page len on a possibly uninitialized variable

### DIFF
--- a/volatility3/framework/layers/msf.py
+++ b/volatility3/framework/layers/msf.py
@@ -194,7 +194,7 @@ class PdbMSFStream(linear.LinearlyMappedLayer):
     ) -> None:
         super().__init__(context, config_path, name, metadata)
         self._base_layer = self.config["base_layer"]
-        self._pages = self.config.get("pages", None)
+        self._pages = self.config.get("pages", [])
         self._pages_len = len(self._pages)
         if not self._pages:
             raise PDBFormatException(name, "Invalid/no pages specified")


### PR DESCRIPTION
Fixes #1441

This simply default the value to an empty list rather than None all the checks, initialization and everything else should now be valid.