### PR TITLE
Make ETHREAD year check dynamic

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -519,7 +519,8 @@ class ETHREAD(objects.StructType, pool.ExecutiveObject):
                 if not isinstance(ctime, datetime.datetime):
                     return False
 
-                if not (1998 < ctime.year < 2030):
+                current_year = datetime.datetime.now().year
+                if not (1998 < ctime.year < current_year + 10):
                     return False
 
         except exceptions.InvalidAddressException:


### PR DESCRIPTION
Change upper bound year check of ETHREAD to be a decade from now. Makes consistent with EPROCESS.