### PR TITLE
Windows Handles: Fix remaining tracebacks

### DIFF
--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -68,7 +68,12 @@ class Handles(interfaces.plugins.PluginInterface):
             if not self.context.layers[virtual].is_valid(handle_table_entry.Object):
                 return None
             fast_ref = handle_table_entry.Object.cast("_EX_FAST_REF")
-            object_header = fast_ref.dereference().cast("_OBJECT_HEADER")
+
+            try:
+                object_header = fast_ref.dereference().cast("_OBJECT_HEADER")
+            except exceptions.InvalidAddressException:
+                return None
+
             object_header.GrantedAccess = handle_table_entry.GrantedAccess
         except AttributeError:
             # starting with windows 8
@@ -77,16 +82,26 @@ class Handles(interfaces.plugins.PluginInterface):
             )
 
             if is_64bit:
-                if handle_table_entry.ObjectPointerBits == 0:
+                try:
+                    pointer_bits = handle_table_entry.ObjectPointerBits
+                except exceptions.InvalidAddressException:
                     return None
 
-                offset = handle_table_entry.ObjectPointerBits << 4
+                if pointer_bits == 0:
+                    return None
+
+                offset = pointer_bits << 4
 
             else:
-                if handle_table_entry.InfoTable == 0:
+                try:
+                    info_table = handle_table_entry.InfoTable
+                except exceptions.InvalidAddressException:
                     return None
 
-                offset = handle_table_entry.InfoTable & ~7
+                if info_table == 0:
+                    return None
+
+                offset = info_table & ~7
 
             # print("LowValue: {0:#x} Magic: {1:#x} Offset: {2:#x}".format(handle_table_entry.InfoTable, magic, offset))
             object_header = self.context.object(
@@ -94,7 +109,10 @@ class Handles(interfaces.plugins.PluginInterface):
                 virtual,
                 offset=offset,
             )
-            object_header.GrantedAccess = handle_table_entry.GrantedAccessBits
+            try:
+                object_header.GrantedAccess = handle_table_entry.GrantedAccessBits
+            except exceptions.InvalidAddressException:
+                return None
 
         object_header.HandleValue = handle_value
         return object_header

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -178,7 +178,7 @@ class Handles(interfaces.plugins.PluginInterface):
             except exceptions.InvalidAddressException:
                 vollog.log(
                     constants.LOGLEVEL_VVV,
-                    f"Cannot access _OBJECT_HEADER Name at {objt.vol.offset:#x}",
+                    f"Cannot access _OBJECT_HEADER Name at {ptr.vol.offset:#x}",
                 )
                 continue
 

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -226,6 +226,14 @@ class Handles(interfaces.plugins.PluginInterface):
         masked_offset = offset & layer_object.maximum_address
 
         for entry in table:
+            # This triggered a backtrace in many testing samples
+            # in the level == 0 path
+            # The code above this calls `is_valid` on the `offset`
+            # It is sent but then does not validate `entry` before
+            # sending it to `_get_item`
+            if not self.context.layers[virtual].is_valid(entry.vol.offset):
+                continue
+
             if level > 0:
                 yield from self._make_handle_array(entry, level - 1, depth)
                 depth += 1

--- a/volatility3/framework/symbols/windows/extensions/pool.py
+++ b/volatility3/framework/symbols/windows/extensions/pool.py
@@ -376,7 +376,16 @@ class OBJECT_HEADER(objects.StructType):
 
         try:
             # vista and earlier have a Type member
-            self._vol["object_header_object_type"] = self.Type.Name.String
+            length = self.Type.member("Name").Length
+            if length == 0 or length > 128:
+                string = None
+            else:
+                string = self.Type.Name.String
+                if len(string) == 0 or len(string) > 128:
+                    string = None
+
+            self._vol["object_header_object_type"] = string
+
         except AttributeError:
             # windows 7 and later have a TypeIndex, but windows 10
             # further encodes the index value with nt1!ObHeaderCookie


### PR DESCRIPTION
refs #1493 

This fixes the remaining bugs in handle enumeration that can occur when accessing struct members. Apparently, just checking the base address of a `_HANDLE_TABLE_ENTRY` is not sufficient to prevent `InvalidAddressException`s, so `try/except` blocks have been added around the problematic member accesses and pointer dereferences as well.

This also includes a patch as requested by @atcuno  that cleans up some problematic object header object type name parsing.