### PR TITLE
Exception handling in registry-related code

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 14  # Number of changes that only add to the interface
+VERSION_MINOR = 15  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/layers/registry.py
+++ b/volatility3/framework/layers/registry.py
@@ -140,7 +140,14 @@ class RegistryHive(linear.LinearlyMappedLayer):
         """Returns the appropriate Node, interpreted from the Cell based on its
         Signature."""
         cell = self.get_cell(cell_offset)
-        signature = cell.cast("string", max_length=2, encoding="latin-1")
+        try:
+            signature = cell.cast("string", max_length=2, encoding="latin-1")
+        except exceptions.InvalidAddressException:
+            vollog.debug(
+                f"Unable to read cell signature for cell at {cell.vol.offset:x}"
+            )
+            return cell
+
         if signature == "nk":
             return cell.u.KeyNode
         elif signature == "sk":

--- a/volatility3/framework/plugins/windows/amcache.py
+++ b/volatility3/framework/plugins/windows/amcache.py
@@ -543,7 +543,7 @@ class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                     amcache.get_key("Root\\InventoryDriverBinary")  # type: ignore
                 )
             )
-        except KeyError:
+        except (KeyError, registry.RegistryFormatException):
             # Registry key not found
             pass
 
@@ -554,7 +554,7 @@ class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                     amcache.get_key("Root\\Programs")
                 )  # type: ignore
             }
-        except KeyError:
+        except (KeyError, registry.RegistryFormatException):
             programs = {}
 
         try:
@@ -564,7 +564,7 @@ class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 ),
                 key=_entry_sort_key,
             )
-        except KeyError:
+        except (KeyError, registry.RegistryFormatException):
             files = []
 
         for program_id, file_entries in itertools.groupby(
@@ -593,7 +593,7 @@ class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                     amcache.get_key("Root\\InventoryApplication")  # type: ignore
                 )
             )
-        except KeyError:
+        except (KeyError, registry.RegistryFormatException):
             programs = {}
 
         try:
@@ -603,7 +603,7 @@ class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 ),
                 key=_entry_sort_key,
             )
-        except KeyError:
+        except (KeyError, registry.RegistryFormatException):
             files = []
 
         for program_id, file_entries in itertools.groupby(

--- a/volatility3/framework/plugins/windows/cachedump.py
+++ b/volatility3/framework/plugins/windows/cachedump.py
@@ -8,7 +8,7 @@ from typing import Tuple
 from Crypto.Cipher import ARC4, AES
 from Crypto.Hash import HMAC
 
-from volatility3.framework import interfaces, renderers
+from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import registry
 from volatility3.framework.symbols.windows import versions
@@ -140,9 +140,14 @@ class Cachedump(interfaces.plugins.PluginInterface):
             if cache_item.Name == "NL$Control":
                 continue
 
-            data = sechive.read(cache_item.Data + 4, cache_item.DataLength)
-            if data is None:
+            try:
+                data = sechive.read(cache_item.Data + 4, cache_item.DataLength)
+            except exceptions.InvalidAddressException:
                 continue
+
+            if not data:
+                continue
+
             (
                 uname_len,
                 domain_len,

--- a/volatility3/framework/plugins/windows/hashdump.py
+++ b/volatility3/framework/plugins/windows/hashdump.py
@@ -332,7 +332,7 @@ class Hashdump(interfaces.plugins.PluginInterface):
         try:
             if hive:
                 result = hive.get_key(key)
-        except KeyError:
+        except (KeyError, registry.RegistryFormatException):
             vollog.info(
                 f"Unable to load the required registry key {hive.get_name()}\\{key} from this memory image"
             )

--- a/volatility3/framework/plugins/windows/lsadump.py
+++ b/volatility3/framework/plugins/windows/lsadump.py
@@ -8,7 +8,7 @@ from typing import Optional
 from Crypto.Cipher import ARC4, DES, AES
 from Crypto.Hash import MD5, SHA256
 
-from volatility3.framework import interfaces, renderers
+from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import registry
 from volatility3.framework.symbols.windows import versions
@@ -81,7 +81,10 @@ class Lsadump(interfaces.plugins.PluginInterface):
         if not enc_reg_value:
             return None
 
-        obf_lsa_key = sechive.read(enc_reg_value.Data + 4, enc_reg_value.DataLength)
+        try:
+            obf_lsa_key = sechive.read(enc_reg_value.Data + 4, enc_reg_value.DataLength)
+        except exceptions.InvalidAddressException:
+            return None
 
         if not obf_lsa_key:
             return None

--- a/volatility3/framework/symbols/windows/extensions/registry.py
+++ b/volatility3/framework/symbols/windows/extensions/registry.py
@@ -159,6 +159,11 @@ class CM_KEY_NODE(objects.StructType):
     """Extension to allow traversal of registry keys."""
 
     def get_volatile(self) -> bool:
+        """
+        Returns a bool indicating whether or not the key is volatile.
+
+        Raises ValueError if the key was not instantiated on a RegistryHive layer
+        """
         if not isinstance(self._context.layers[self.vol.layer_name], RegistryHive):
             raise ValueError(
                 "Cannot determine volatility of registry key without an offset in a RegistryHive layer"
@@ -166,7 +171,10 @@ class CM_KEY_NODE(objects.StructType):
         return bool(self.vol.offset & 0x80000000)
 
     def get_subkeys(self) -> Iterator["CM_KEY_NODE"]:
-        """Returns a list of the key nodes."""
+        """Returns a list of the key nodes.
+
+        Raises TypeError if the key was not instantiated on a RegistryHive layer
+        """
         hive = self._context.layers[self.vol.layer_name]
         if not isinstance(hive, RegistryHive):
             raise TypeError("CM_KEY_NODE was not instantiated on a RegistryHive layer")
@@ -222,7 +230,10 @@ class CM_KEY_NODE(objects.StructType):
                     yield from self._get_subkeys_recursive(hive, subnode)
 
     def get_values(self) -> Iterator["CM_KEY_VALUE"]:
-        """Returns a list of the Value nodes for a key."""
+        """Returns a list of the Value nodes for a key.
+
+        Raises TypeError if the key was not instantiated on a RegistryHive layer
+        """
         hive = self._context.layers[self.vol.layer_name]
         if not isinstance(hive, RegistryHive):
             raise TypeError("CM_KEY_NODE was not instantiated on a RegistryHive layer")
@@ -251,6 +262,11 @@ class CM_KEY_NODE(objects.StructType):
         return self.Name.cast("string", max_length=namelength, encoding="latin-1")
 
     def get_key_path(self) -> str:
+        """
+        Returns the full path to this registry key.
+
+        Raises TypeError if the key was not instantiated on a RegistryHive layer
+        """
         reg = self._context.layers[self.vol.layer_name]
         if not isinstance(reg, RegistryHive):
             raise TypeError("Key was not instantiated on a RegistryHive layer")

--- a/volatility3/framework/symbols/windows/extensions/registry.py
+++ b/volatility3/framework/symbols/windows/extensions/registry.py
@@ -162,12 +162,10 @@ class CM_KEY_NODE(objects.StructType):
         """
         Returns a bool indicating whether or not the key is volatile.
 
-        Raises ValueError if the key was not instantiated on a RegistryHive layer
+        Raises TypeError if the key was not instantiated on a RegistryHive layer
         """
         if not isinstance(self._context.layers[self.vol.layer_name], RegistryHive):
-            raise ValueError(
-                "Cannot determine volatility of registry key without an offset in a RegistryHive layer"
-            )
+            raise TypeError("CM_KEY_NODE was not instantiated on a RegistryHive layer")
         return bool(self.vol.offset & 0x80000000)
 
     def get_subkeys(self) -> Iterator["CM_KEY_NODE"]:


### PR DESCRIPTION
This adds exception handling in a number of places where `InvalidAddressException`s were not being caught before.

Notably, `CM_KEY_VALUE.decode_data()` was missing exception handling for calls to `read` that can raise these exceptions. The new behavior is that a debug message will be logged, and null bytes of the same length will be returned in place of the actual data. This will allow partial data to be returned when reading large binary blobs from binary registry values.

It also adds exception handling in the amcache and hashdump plugins where the exceptions raise by `get_key` were not being caught exhaustively. 