### PR TITLE
Add proper exception handling in file descriptor enumeration

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,7 +1,7 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
 VERSION_MINOR = 20  # Number of changes that only add to the interface
-VERSION_PATCH = 0  # Number of changes that do not change the interface
+VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 PACKAGE_VERSION = (

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -342,13 +342,12 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         try:
             files = task.files
             fd_table = files.get_fds()
+            if fd_table == 0:
+                return None
+
+            max_fds = files.get_max_fds()
         except exceptions.InvalidAddressException:
             return None
-
-        if fd_table == 0:
-            return None
-
-        max_fds = files.get_max_fds()
 
         # corruption check
         if max_fds > 500000:

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -341,13 +341,6 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
     ):
         try:
             files = task.files
-        except exceptions.InvalidAddressException:
-            return None
-
-        if not files.is_readable():
-            return None
-
-        try:
             fd_table = files.get_fds()
         except exceptions.InvalidAddressException:
             return None

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -339,15 +339,23 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         symbol_table: str,
         task: interfaces.objects.ObjectInterface,
     ):
-        # task.files can be null
-        if not (task.files and task.files.is_readable()):
+        try:
+            files = task.files
+        except exceptions.InvalidAddressException:
             return None
 
-        fd_table = task.files.get_fds()
+        if not files.is_readable():
+            return None
+
+        try:
+            fd_table = files.get_fds()
+        except exceptions.InvalidAddressException:
+            return None
+
         if fd_table == 0:
             return None
 
-        max_fds = task.files.get_max_fds()
+        max_fds = files.get_max_fds()
 
         # corruption check
         if max_fds > 500000:


### PR DESCRIPTION
The lack of exception handling caused backtraces in multiple plugins over 50+ samples. These cleans up those missing checks.