### PR TITLE
Vma enumeration issues

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -872,9 +872,10 @@ class mm_struct(objects.StructType):
 
         with contextlib.suppress(exceptions.InvalidAddressException):
             for vma in self._do_get_vma_iter():
-                    # this catches invalid instances returned by the internal interator functions
-                    vma.vm_start
-                    yield vma
+                # this catches invalid instances returned by the internal interator functions
+                vma.vm_start
+                yield vma
+
 
 class super_block(objects.StructType):
     # include/linux/kdev_t.h

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -3,6 +3,7 @@
 #
 
 import abc
+import contextlib
 import collections.abc
 import logging
 import functools
@@ -856,7 +857,7 @@ class mm_struct(objects.StructType):
             )
             yield vma
 
-    def get_vma_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
+    def _do_get_vma_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
         """Returns an iterator for the VMAs in an mm_struct. Automatically choosing the mmap or mm_mt as required."""
 
         if self.has_member("mmap"):
@@ -866,6 +867,14 @@ class mm_struct(objects.StructType):
         else:
             raise AttributeError("Unable to find mmap or mm_mt in mm_struct")
 
+    def get_vma_iter(self) -> Iterable[interfaces.objects.ObjectInterface]:
+        """Returns an iterator for the VMAs in an mm_struct. Automatically choosing the mmap or mm_mt as required."""
+
+        with contextlib.suppress(exceptions.InvalidAddressException):
+            for vma in self._do_get_vma_iter():
+                    # this catches invalid instances returned by the internal interator functions
+                    vma.vm_start
+                    yield vma
 
 class super_block(objects.StructType):
     # include/linux/kdev_t.h


### PR DESCRIPTION
These enumeration functions threw many backtraces and returned bad instances.

Thankfully, they are on a per-process basis anyway so the current code will cleanly bail out when smear/broken instances are found.

I plan to re-use this pattern in some other problematic places in Windows and Linux.