### PR TITLE
Speedup page class attributes accesses with shared lru_cache

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2525,7 +2525,28 @@ class address_space(objects.StructType):
 
 
 class page(objects.StructType):
-    @functools.cached_property
+    def __eq__(self, other):
+        """Share @property's in a "vmlinux->[*pages]" lru_cache,
+        as thousands of page objects can be instantiated in
+        a single plugin run. Observed benchmarks noted
+        30x faster _intel_vmemmap_start accesses after first call.
+        The properties are in fact kernel-wide constants, and do not need
+        to be re-calculated on each instantiation.
+        Doc: https://stackoverflow.com/a/69780424
+
+        Use functools.cached_property to ignore this behaviour, as it was
+        observed to not call __hash__ and __eq__.
+        """
+        return isinstance(other, page) and self.__hash__() == other.__hash__()
+
+    # Use the vmlinux to identify cache pools.
+    def __hash__(self):
+        return linux.LinuxUtilities.get_module_from_volobj_type(
+            self._context, self
+        ).__hash__()
+
+    @property
+    @functools.lru_cache
     def pageflags_enum(self) -> Dict:
         """Returns 'pageflags' enumeration key/values
 
@@ -2545,7 +2566,8 @@ class page(objects.StructType):
 
         return pageflags_enum
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache
     def _intel_vmemmap_start(self) -> int:
         """Determine the start of the struct page array, for Intel systems.
 


### PR DESCRIPTION
Hi, 

While working on new capabilities involving the instantiation of thousands of `page` objects, I noticed that `_intel_vmemmap_start` was a severe bottleneck in `get_contents` call: 

```sh
# Nice tool to trace execution and spot functions execution time
$ viztracer --log_func_exec "get_contents" -- vol.py -f sample.bin linux.pagecache.DumpFs
```

- `get_contents` time: ~31 ms
	- `_intel_vmemmap_start`: ~30ms 

While we were currently using `functools.cached_property`, it was only efficient for a `page` instance, which was not relevant as most of the time we only dump its content before discarding it. To enhance the design, I tied each `page` object `hash` to its `vmlinux` hash, which is verified by `functools` to hit the cache or not. This prevents overlaps between multiple vmlinux in a same sample, and only applies to the needed attributes. 

After this patch, `get_contents` execution time dropped to ~1ms (on cache hits after first call).