### PR TITLE
Linux: Fix copy-pasted module docstrings

### DIFF
--- a/volatility3/framework/plugins/linux/bash.py
+++ b/volatility3/framework/plugins/linux/bash.py
@@ -1,8 +1,8 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-"""A module containing a collection of plugins that produce data typically
-found in Linux's /proc file system."""
+"""A module containing a plugin that recovers bash command history
+from bash process memory."""
 
 import datetime
 import struct

--- a/volatility3/framework/plugins/linux/check_afinfo.py
+++ b/volatility3/framework/plugins/linux/check_afinfo.py
@@ -1,8 +1,8 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-"""A module containing a collection of plugins that produce data typically
-found in Linux's /proc file system."""
+"""A module containing a plugin that verifies the operation function
+pointers of network protocols."""
 import logging
 from typing import List
 

--- a/volatility3/framework/plugins/linux/check_syscall.py
+++ b/volatility3/framework/plugins/linux/check_syscall.py
@@ -1,8 +1,7 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-"""A module containing a collection of plugins that produce data typically
-found in Linux's /proc file system."""
+"""A module containing a plugin that checks the system call table for hooks."""
 import contextlib
 import logging
 from typing import List

--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -1,8 +1,8 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-"""A module containing a collection of plugins that produce data typically
-found in Linux's /proc file system."""
+"""A module containing a plugin for enumerating memory-mapped
+ELF files across all processes."""
 
 import logging
 from typing import List, Optional, Type

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -1,8 +1,7 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-"""A module containing a collection of plugins that produce data typically
-found in Linux's /proc file system."""
+"""A module containing a plugin that lists loaded kernel modules."""
 
 import logging
 from typing import List, Iterable


### PR DESCRIPTION
This updates the module docstrings for five modules that duplicate the
docstring from the `proc` module. This was presumably the result of using
the `proc` module as a template for the others.
