### PR TITLE
Issues/improve jsonschema speed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,9 @@ cloud = [
 
 dev = [
     "volatility3[full,cloud]",
-    "jsonschema>=4.23.0,<5",
+    "fastjsonschema>=2.21.1,<3",
     "pyinstaller>=6.11.0,<7",
     "pyinstaller-hooks-contrib>=2024.9",
-    "types-jsonschema>=4.23.0,<5",
 ]
 
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,15 @@
 [project]
 name = "volatility3"
 description = "Memory forensics framework"
-keywords = ["volatility", "memory", "forensics", "framework", "windows", "linux", "volshell"]
+keywords = [
+    "volatility",
+    "memory",
+    "forensics",
+    "framework",
+    "windows",
+    "linux",
+    "volshell",
+]
 readme = "README.md"
 authors = [
     { name = "Volatility Foundation", email = "volatility@volatilityfoundation.org" },
@@ -10,9 +18,7 @@ requires-python = ">=3.8.0"
 license = { text = "VSL" }
 dynamic = ["version"]
 
-dependencies = [
-    "pefile>=2024.8.26",
-]
+dependencies = ["pefile>=2024.8.26"]
 
 [project.optional-dependencies]
 full = [
@@ -26,16 +32,14 @@ full = [
     "pillow>=10.0.0,<11.0.0",
 ]
 
-cloud = [
-    "gcsfs>=2024.10.0",
-    "s3fs>=2024.10.0",
-]
+cloud = ["gcsfs>=2024.10.0", "s3fs>=2024.10.0"]
 
 dev = [
     "volatility3[full,cloud]",
-    "fastjsonschema>=2.21.1,<3",
+    "jsonschema>=4.23.0,<5",
     "pyinstaller>=6.11.0,<7",
     "pyinstaller-hooks-contrib>=2024.9",
+    "types-jsonschema>=4.23.0,<5",
 ]
 
 test = [
@@ -78,16 +82,16 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = [
-	"F",       # pyflakes
-	"E",       # pycodestyle errors
-	"W",       # pycodestyle warnings
-	"G",       # flake8-logging-format
-	"PIE",     # flake8-pie
-	"UP",      # pyupgrade
+    "F",   # pyflakes
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "G",   # flake8-logging-format
+    "PIE", # flake8-pie
+    "UP",  # pyupgrade
 ]
 
 ignore = [
-    "E501",    # ignore due to conflict with formatter
+    "E501", # ignore due to conflict with formatter
 ]
 
 [build-system]

--- a/volatility3/framework/plugins/isfinfo.py
+++ b/volatility3/framework/plugins/isfinfo.py
@@ -97,7 +97,7 @@ class IsfInfo(plugins.PluginInterface):
                     if filter_item in isf_file:
                         filtered_list.append(isf_file)
 
-        if find_spec("jsonschema") and self.config["validate"]:
+        if find_spec("fastjsonschema") and self.config["validate"]:
 
             def check_valid(data):
                 return "True" if schemas.validate(data, True) else "False"

--- a/volatility3/framework/plugins/isfinfo.py
+++ b/volatility3/framework/plugins/isfinfo.py
@@ -97,7 +97,7 @@ class IsfInfo(plugins.PluginInterface):
                     if filter_item in isf_file:
                         filtered_list.append(isf_file)
 
-        if find_spec("fastjsonschema") and self.config["validate"]:
+        if find_spec("jsonschema") and self.config["validate"]:
 
             def check_valid(data):
                 return "True" if schemas.validate(data, True) else "False"

--- a/volatility3/schemas/__init__.py
+++ b/volatility3/schemas/__init__.py
@@ -112,7 +112,7 @@ def valid(
         validators[schema_key].validate(input)
         cached_validations.add(input_hash)
         vollog.debug("JSON validated against schema (result cached)")
-    except fastjsonschema.JsonSchemaValueException:
+    except jsonschema.exceptions.SchemaError:
         vollog.debug("Schema validation error", exc_info=True)
         return False
 


### PR DESCRIPTION
This precompiles the schema file for jsonschema, meaning that (for some reason) it's already faster than the old combined method, but also if many json files are verified against the same schema there'll be a several second win each additional time (due to not having to recompile the schema).

I tried using fastjsonschema but the error messages are less descriptive and it fails validation for most of our existing handcoded and generated files, because the timestamps they generate don't include the timezone offset at the end (+XX:XX) finding all datetimes within a json file would be a pig (and slow) so better to change the validator somehow (still investigating) and/or figure out why jsonschema allows the old times and fastjsonschema does not...

Anyway, lemme know what you think and if the changes speed-up your testing workflow much?