### PR TITLE
Introduce customizable plugin arparse epilog

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -367,9 +367,7 @@ class CommandLine:
                 plugin,
                 help=plugin_list[plugin].__doc__,
                 description=plugin_list[plugin].__doc__,
-            )
-            plugin_parser.epilog = getattr(
-                plugin_list[plugin], "_argparse_epilog", None
+                epilog=getattr(plugin_list[plugin], "_argparse_epilog", None),
             )
             self.populate_requirements_argparse(plugin_parser, plugin_list[plugin])
 

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -368,9 +368,9 @@ class CommandLine:
                 help=plugin_list[plugin].__doc__,
                 description=plugin_list[plugin].__doc__,
             )
-            epilog = getattr(plugin_list[plugin], "_argparse_epilog", None)
-            if epilog is not None:
-                plugin_parser.epilog = epilog
+            plugin_parser.epilog = getattr(
+                plugin_list[plugin], "_argparse_epilog", None
+            )
             self.populate_requirements_argparse(plugin_parser, plugin_list[plugin])
 
         ###

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -367,7 +367,7 @@ class CommandLine:
                 plugin,
                 help=plugin_list[plugin].__doc__,
                 description=plugin_list[plugin].__doc__,
-                epilog=getattr(plugin_list[plugin], "_argparse_epilog", None),
+                epilog=plugin_list[plugin].additional_description,
             )
             self.populate_requirements_argparse(plugin_parser, plugin_list[plugin])
 

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -368,6 +368,9 @@ class CommandLine:
                 help=plugin_list[plugin].__doc__,
                 description=plugin_list[plugin].__doc__,
             )
+            epilog = getattr(plugin_list[plugin], "_argparse_epilog", None)
+            if epilog is not None:
+                plugin_parser.epilog = epilog
             self.populate_requirements_argparse(plugin_parser, plugin_list[plugin])
 
         ###

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 15  # Number of changes that only add to the interface
+VERSION_MINOR = 16  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -112,7 +112,7 @@ class PluginInterface(
     # Be careful with inheritance around this (We default to requiring a version which doesn't exist, so it must be set)
     _required_framework_version: Tuple[int, int, int] = (0, 0, 0)
     """The _version variable is a quick way for plugins to define their current interface, it should follow SemVer rules"""
-    _argparse_epilog: str = None
+    additional_description: str = None
     """Display additional description of the plugin after the description of the arguments. See: https://docs.python.org/3/library/argparse.html#epilog"""
 
     def __init__(

--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -112,6 +112,8 @@ class PluginInterface(
     # Be careful with inheritance around this (We default to requiring a version which doesn't exist, so it must be set)
     _required_framework_version: Tuple[int, int, int] = (0, 0, 0)
     """The _version variable is a quick way for plugins to define their current interface, it should follow SemVer rules"""
+    _argparse_epilog: str = None
+    """Display additional description of the plugin after the description of the arguments. See: https://docs.python.org/3/library/argparse.html#epilog"""
 
     def __init__(
         self,


### PR DESCRIPTION
Hi 👋, 

This PR introduces a feature to specify an argparse epilog for plugins, allowing to extend a plugin description easily, without modifying the short description.  Sample from https://docs.python.org/3/library/argparse.html#epilog:

```python
parser = argparse.ArgumentParser(
    description='A foo that bars',
    epilog="And that's how you'd foo a bar")
parser.print_help()

usage: argparse.py [-h]

A foo that bars

options:
 -h, --help  show this help message and exit

And that's how you'd foo a bar
```