### PR TITLE
linux: Ensure task listing functions yield only valid tasks

### DIFF
--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -34,7 +34,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists the processes present in a particular linux memory image."""
 
     _required_framework_version = (2, 13, 0)
-    _version = (4, 0, 0)
+    _version = (4, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -250,6 +250,9 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
         # Note that the init_task itself is not yielded, since "ps" also never shows it.
         for task in init_task.tasks:
+            if not task.is_valid():
+                continue
+
             if filter_func(task):
                 continue
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -307,6 +307,36 @@ class module(generic.GenericIntelProcess):
 
 
 class task_struct(generic.GenericIntelProcess):
+    def is_valid(self) -> bool:
+        layer = self._context.layers[self.vol.layer_name]
+        # Make sure the entire task content is readable
+        if not layer.is_valid(self.vol.offset, self.vol.size):
+            return False
+
+        if self.pid < 0:
+            return False
+
+        if not (self.signal and self.signal.is_readable()):
+            return False
+
+        if not (self.nsproxy and self.nsproxy.is_readable()):
+            return False
+
+        if not (self.real_parent and self.real_parent.is_readable()):
+            return False
+
+        if self.active_mm and not self.active_mm.is_readable():
+            return False
+
+        if self.mm:
+            if not self.mm.is_readable():
+                return False
+
+            if self.mm != self.active_mm:
+                return False
+
+        return True
+
     def add_process_layer(
         self, config_prefix: Optional[str] = None, preferred_name: Optional[str] = None
     ) -> Optional[str]:
@@ -401,6 +431,8 @@ class task_struct(generic.GenericIntelProcess):
         tasks_iterable = self._get_tasks_iterable()
         threads_seen = set([self.vol.offset])
         for task in tasks_iterable:
+            if not task.is_valid():
+                continue
             if task.vol.offset not in threads_seen:
                 threads_seen.add(task.vol.offset)
                 yield task

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -316,16 +316,26 @@ class task_struct(generic.GenericIntelProcess):
         if self.pid < 0:
             return False
 
-        if not (self.signal and self.signal.is_readable()):
+        if self.has_member("signal") and not (
+            self.signal and self.signal.is_readable()
+        ):
             return False
 
-        if not (self.nsproxy and self.nsproxy.is_readable()):
+        if self.has_member("nsproxy") and not (
+            self.nsproxy and self.nsproxy.is_readable()
+        ):
             return False
 
-        if not (self.real_parent and self.real_parent.is_readable()):
+        if self.has_member("real_parent") and not (
+            self.real_parent and self.real_parent.is_readable()
+        ):
             return False
 
-        if self.active_mm and not self.active_mm.is_readable():
+        if (
+            self.has_member("active_mm")
+            and self.active_mm
+            and not self.active_mm.is_readable()
+        ):
             return False
 
         if self.mm:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -313,7 +313,7 @@ class task_struct(generic.GenericIntelProcess):
         if not layer.is_valid(self.vol.offset, self.vol.size):
             return False
 
-        if self.pid < 0:
+        if self.pid < 0 or self.tgid < 0:
             return False
 
         if self.has_member("signal") and not (


### PR DESCRIPTION
In the context of #1516 and related issues, we noticed that core functions responsible for yielding tasks sometimes include entries that are either dead or invalid. 

This pull request addresses these scenarios to improve task handling and ensure robust functionality.

close: #1518
fix: #1523, #1524