### PR TITLE
Fix dependency conflicts in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ more details.
 
 ## Installing
 
-Volatility 3 requires Python 3.10.0 or later and is published on the [PyPi registry](https://pypi.org/project/volatility3).
+Volatility 3 requires Python 3.8.0 or later and is published on the [PyPi registry](https://pypi.org/project/volatility3).
 
 ```shell
 pip install volatility3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ more details.
 
 ## Installing
 
-Volatility 3 requires Python 3.8.0 or later and is published on the [PyPi registry](https://pypi.org/project/volatility3).
+Volatility 3 requires Python 3.10.0 or later and is published on the [PyPi registry](https://pypi.org/project/volatility3).
 
 ```shell
 pip install volatility3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Volatility Foundation", email = "volatility@volatilityfoundation.org" },
 ]
-requires-python = ">=3.10.0"
+requires-python = ">=3.8.0"
 license = { text = "VSL" }
 dynamic = ["version"]
 
@@ -48,8 +48,8 @@ test = [
 
 docs = [
     "volatility3[dev]",
-    "sphinx==8.0.2",
-    "sphinx-autodoc-typehints>=2.5.0,<3",
+    "sphinx>=7,<=7.1.2",
+    "sphinx-autodoc-typehints==2.0.1",
     "sphinx-rtd-theme>=3.0.1,<4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ readme = "README.md"
 authors = [
     { name = "Volatility Foundation", email = "volatility@volatilityfoundation.org" },
 ]
-requires-python = ">=3.8.0"
+requires-python = ">=3.10.0"
 license = { text = "VSL" }
 dynamic = ["version"]
 
 dependencies = [
-    "pefile>=2024.8.26",
+    "pefile>=2023.2.7",
 ]
 
 [project.optional-dependencies]
@@ -48,7 +48,7 @@ test = [
 
 docs = [
     "volatility3[dev]",
-    "sphinx>=8.0.0,<7",
+    "sphinx==8.0.2",
     "sphinx-autodoc-typehints>=2.5.0,<3",
     "sphinx-rtd-theme>=3.0.1,<4",
 ]


### PR DESCRIPTION
Closes #1546 

This makes three changes to fix dependency resolution
- Fixes a bug where the sphinx version is unresolvable, and pins it to
  8.0.2 (the minimum version required by the minimum version of
  sphinx-autodoc-typehints)
- Lowers the required version of `pefile` in order to allow us to use
  the `pyinstaller` version specified in the `dev` dependencies
- Bumps the python version to 3.10 in order to support sphinx 8.0.2

I know bumping the minimum Python version is not desirable, but I wasn't sure which `sphinx`/`sphinx-autodoc-typehints` versions would be acceptable due to my unfamiliarity with our doc requirements. We can lower those if an acceptable version can be found that supports python 3.8. There isn't a way to specify different required Python versions for different sets of dependencies within `pyproject.toml`.
