### PR TITLE
Actions: Add new workflow for generating windows EXEs with pyinstaller

### DIFF
--- a/.github/workflows/build-pyinstaller.yml
+++ b/.github/workflows/build-pyinstaller.yml
@@ -1,0 +1,50 @@
+name: build-pyinstaller
+on:
+  push:
+    branches:
+      - stable
+      - develop
+      - 'release/**'
+  pull_request:
+    branches:
+      - stable
+      - 'release/**'
+
+jobs:
+
+  exe:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller
+    
+    - name: Pyinstall executable
+      run: |
+        pyinstaller --clean -y vol.spec
+        pyinstaller --clean -y volshell.spec
+
+    - name: Move files
+      run: |
+        mv dist/vol.exe vol.exe
+        mv dist/volshell.exe volshell.exe
+
+    - name: Archive 
+      uses: actions/upload-artifact@v4
+      with:
+        name: volatility3-pyinstaller
+        path: |
+          vol.exe
+          volshell.exe
+          README.md
+          LICENSE.txt


### PR DESCRIPTION
- This PR provides an alternative to https://github.com/volatilityfoundation/volatility3/pull/1111 for generating pyinstaller executables for Windows via GithHub actions. The main difference is that this version uses a new GitHub workflow file for clearer separation.
- If this looks good, I can submit a separate PR that adds some basic testing to the generated pyinstallers