### PR TITLE
Linux: Add support for Intel 32bit with PAE

### DIFF
--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -71,10 +71,9 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
                 elif "init_level4_pgt" in table.symbols:
                     layer_class = intel.LinuxIntel32e
                     dtb_symbol_name = "init_level4_pgt"
-                elif (
-                    "pkmap_count" in table.symbols
-                    and table.get_symbol("pkmap_count").type.count == 512
-                ):
+                elif "pkmap_count" in table.symbols and table.get_symbol(
+                    "pkmap_count"
+                ).type.count in (512, 2048):
                     layer_class = intel.LinuxIntelPAE
                     dtb_symbol_name = "swapper_pg_dir"
                 else:

--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -71,6 +71,12 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
                 elif "init_level4_pgt" in table.symbols:
                     layer_class = intel.LinuxIntel32e
                     dtb_symbol_name = "init_level4_pgt"
+                elif (
+                    "pkmap_count" in table.symbols
+                    and table.get_symbol("pkmap_count").type.count == 512
+                ):
+                    layer_class = intel.LinuxIntelPAE
+                    dtb_symbol_name = "swapper_pg_dir"
                 else:
                     layer_class = intel.LinuxIntel
                     dtb_symbol_name = "swapper_pg_dir"


### PR DESCRIPTION
In the [vmcoreinfo PR](https://github.com/volatilityfoundation/volatility3/pull/1332), we added support for Intel 32-bit PAE, however, this feature was still missing in the original `LinuxIntelStacker` layer.

The changes in this PR are based on the size of the `pkmap_count` variable, which varies depending on whether PAE is enabled. From [2.3.27](https://elixir.bootlin.com/linux/2.3.27/source/mm/highmem.c#L95) to [2.3.28](https://elixir.bootlin.com/linux/2.3.28/source/mm/highmem.c#L96) the `LAST_PKMAP` macro value for PAE was **2048**. Starting from [2.3.29](https://elixir.bootlin.com/linux/2.3.29/source/include/asm-i386/highmem.h#L47), it was reduced to **512**. See also the latest kernel [6.13-rc3](https://elixir.bootlin.com/linux/v6.13-rc3/source/arch/x86/include/asm/pgtable_32_areas.h#L22)
```c
#ifdef CONFIG_X86_PAE
#define LAST_PKMAP 512
#else
#define LAST_PKMAP 1024
#endif

static int pkmap_count[LAST_PKMAP];
```