### PR TITLE
linux: pslist: fix task credentials rendering

### DIFF
--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -179,6 +179,10 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 file_output = "VMA start matching task start_code not found"
         return file_output
 
+    @staticmethod
+    def _format_cred(cred):
+        return renderers.NotAvailableValue() if cred is None else cred
+
     def _generator(
         self,
         pid_filter: Callable[[Any], bool],
@@ -212,16 +216,21 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
             task_fields = self.get_task_fields(task, decorate_comm)
 
+            task_uid = self._format_cred(task_fields.uid)
+            task_gid = self._format_cred(task_fields.gid)
+            task_euid = self._format_cred(task_fields.euid)
+            task_egid = self._format_cred(task_fields.egid)
+
             yield 0, (
                 format_hints.Hex(task_fields.offset),
                 task_fields.user_pid,
                 task_fields.user_tid,
                 task_fields.user_ppid,
                 task_fields.name,
-                task_fields.uid or renderers.NotAvailableValue(),
-                task_fields.gid or renderers.NotAvailableValue(),
-                task_fields.euid or renderers.NotAvailableValue(),
-                task_fields.egid or renderers.NotAvailableValue(),
+                task_uid,
+                task_gid,
+                task_euid,
+                task_egid,
                 task_fields.creation_time or renderers.NotAvailableValue(),
                 file_output,
             )


### PR DESCRIPTION
Currently, when the user id is zero, typically root, we are incorrectly using the `BaseAbsentValue`  resulting in a Hyphen `-` being displayed in each ID column.

This PR fixes this issue. New output:
```shell
$ ./vol.py -r pretty \
    -f ./linux-sample-1.bin \
    linux.pslist 
Volatility 3 Framework 2.16.0
  |     OFFSET (V) |  PID |  TID | PPID |            COMM |  UID |   GID | EUID |  EGID |                  CREATION TIME | File output
* | 0x88001f994740 |    1 |    1 |    0 |            init |    0 |     0 |    0 |     0 | 2014-06-24 10:22:33.016001 UTC |    Disabled
* | 0x88001f994040 |    2 |    2 |    0 |        kthreadd |    0 |     0 |    0 |     0 | 2014-06-24 10:22:33.016001 UTC |    Disabled
...
* | 0x88001d5ed080 | 2157 | 2157 |    1 |           acpid |    0 |     0 |    0 |     0 | 2014-06-24 10:22:38.517995 UTC |    Disabled
* | 0x88001be1e8c0 | 2178 | 2178 |    1 |     dbus-daemon |  101 |   105 |  101 |   105 | 2014-06-24 10:22:38.554893 UTC |    Disabled
* | 0x88001c278080 | 2254 | 2254 |    1 |         apache2 |    0 |     0 |    0 |     0 | 2014-06-24 10:22:38.683805 UTC |    Disabled
* | 0x88001aca0080 | 2344 | 2344 |    1 |             atd |    0 |     0 |    1 |     1 | 2014-06-24 10:22:38.729819 UTC |    Disabled
* | 0x88001ac987c0 | 2363 | 2363 |    1 |  NetworkManager |    0 |     0 |    0 |     0 | 2014-06-24 10:22:38.761895 UTC |    Disabled
* | 0x88001c86a040 | 2388 | 2388 |    1 |    avahi-daemon |  106 |   114 |  106 |   114 | 2014-06-24 10:22:38.802027 UTC |    Disabled
* | 0x88001ac980c0 | 2390 | 2390 | 2388 |    avahi-daemon |  106 |   114 |  106 |   114 | 2014-06-24 10:22:38.804543 UTC |    Disabled
...
```