### PR TITLE
Linux - Parity release harden Page Cache

### DIFF
--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -708,24 +708,25 @@ def test_linux_page_cache_inodepages(image, volatility, python):
 
     inode_address = hex(0x88001AB5C270)
     inode_dump_filename = f"inode_{inode_address}.dmp"
+
+    rc, out, _err = runvol_plugin(
+        "linux.pagecache.InodePages",
+        image,
+        volatility,
+        python,
+        pluginargs=["--inode", inode_address],
+    )
+
+    assert rc == 0
+    assert out.count(b"\n") > 4
+
+    # PageVAddr PagePAddr MappingAddr .. DumpSafe
+    assert re.search(
+        rb"0xea000054c5f8\s0x18389000\s0x88001ab5c3b0.*?True",
+        out,
+    )
+
     try:
-        rc, out, _err = runvol_plugin(
-            "linux.pagecache.InodePages",
-            image,
-            volatility,
-            python,
-            pluginargs=["--inode", inode_address],
-        )
-
-        assert rc == 0
-        assert out.count(b"\n") > 4
-
-        # PageVAddr PagePAddr MappingAddr .. DumpSafe
-        assert re.search(
-            rb"0xea000054c5f8\s0x18389000\s0x88001ab5c3b0.*?True",
-            out,
-        )
-
         rc, out, _err = runvol_plugin(
             "linux.pagecache.InodePages",
             image,
@@ -733,6 +734,10 @@ def test_linux_page_cache_inodepages(image, volatility, python):
             python,
             pluginargs=["--inode", inode_address, "--dump"],
         )
+
+        assert rc == 0
+        assert out.count(b"\n") >= 4
+
         assert os.path.exists(inode_dump_filename)
         with open(inode_dump_filename, "rb") as fp:
             inode_contents = fp.read()

--- a/test/test_volatility.py
+++ b/test/test_volatility.py
@@ -714,7 +714,7 @@ def test_linux_page_cache_inodepages(image, volatility, python):
             image,
             volatility,
             python,
-            pluginargs=["--inode", inode_address, "--dump"],
+            pluginargs=["--inode", inode_address],
         )
 
         assert rc == 0
@@ -724,6 +724,14 @@ def test_linux_page_cache_inodepages(image, volatility, python):
         assert re.search(
             rb"0xea000054c5f8\s0x18389000\s0x88001ab5c3b0.*?True",
             out,
+        )
+
+        rc, out, _err = runvol_plugin(
+            "linux.pagecache.InodePages",
+            image,
+            volatility,
+            python,
+            pluginargs=["--inode", inode_address, "--dump"],
         )
         assert os.path.exists(inode_dump_filename)
         with open(inode_dump_filename, "rb") as fp:

--- a/volatility3/framework/exceptions.py
+++ b/volatility3/framework/exceptions.py
@@ -130,3 +130,7 @@ class OfflineException(VolatilityException):
 
 class RenderException(VolatilityException):
     """Thrown if there is an error during rendering"""
+
+
+class LinuxPageCacheException(VolatilityException):
+    """Thrown if there is an error during Linux Page Cache processing"""

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -520,7 +520,11 @@ class InodePages(plugins.PluginInterface):
             page_mapping_addr = page_obj.mapping
             page_index = int(page_obj.index)
             page_file_offset = page_index * vmlinux_layer.page_size
-            dump_safe = page_file_offset < inode_size
+            dump_safe = (
+                page_file_offset < inode_size
+                and page_mapping_addr
+                and page_mapping_addr.is_readable()
+            )
             page_flags_list = page_obj.get_flags_list()
             page_flags = ",".join([x.replace("PG_", "") for x in page_flags_list])
             fields = (

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -104,7 +104,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 1)
+    _version = (1, 0, 2)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -253,6 +253,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             if not root_inode.is_valid():
                 continue
 
+            if not (root_inode.i_mapping and root_inode.i_mapping.is_readable()):
+                # Retrieving data from the page cache requires a valid address space
+                continue
+
             # Inode already processed?
             if root_inode_ptr in seen_inodes:
                 continue
@@ -282,6 +286,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
                 file_inode = file_inode_ptr.dereference()
                 if not file_inode.is_valid():
+                    continue
+
+                if not (file_inode.i_mapping and file_inode.i_mapping.is_readable()):
+                    # Retrieving data from the page cache requires a valid address space
                     continue
 
                 # Inode already processed?
@@ -316,10 +324,12 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             if self.config["find"]:
                 if inode_in.path == self.config["find"]:
                     inode_out = inode_in.to_user(vmlinux_layer)
+
                     yield (0, astuple(inode_out))
                     break  # Only the first match
             else:
                 inode_out = inode_in.to_user(vmlinux_layer)
+
                 yield (0, astuple(inode_out))
 
     def generate_timeline(self):
@@ -389,7 +399,7 @@ class InodePages(plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (2, 0, 0)
+    _version = (2, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -511,7 +511,7 @@ class InodePages(plugins.PluginInterface):
                 page_vaddr = page_obj.vol.offset
                 page_paddr = page_obj.to_paddr()
                 page_mapping_addr = page_obj.mapping
-                page_index = int(page_obj.index)
+                page_index = page_obj.index
                 page_file_offset = page_index * vmlinux_layer.page_size
                 dump_safe = (
                     page_file_offset < inode_size

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -147,7 +147,13 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             Otherwise, it returns the same symlink_path
         """
         # i_link (fast symlinks) were introduced in 4.2
-        if inode and inode.is_link and inode.has_member("i_link") and inode.i_link:
+        if (
+            inode
+            and inode.is_link
+            and inode.has_member("i_link")
+            and inode.i_link
+            and inode.i_link.is_readable()
+        ):
             i_link_str = inode.i_link.dereference().cast(
                 "string", max_length=255, encoding="utf-8", errors="replace"
             )

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -469,6 +469,8 @@ class InodePages(plugins.PluginInterface):
                             inode_size,
                             page_idx,
                         )
+                        continue
+
                     f.seek(current_fp)
                     f.write(page_bytes)
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -3,6 +3,7 @@
 #
 import math
 import contextlib
+import logging
 from abc import ABC, abstractmethod
 from typing import Iterator, List, Tuple, Optional, Union
 
@@ -11,6 +12,8 @@ from volatility3.framework import constants, exceptions, interfaces, objects
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.linux import extensions
+
+vollog = logging.getLogger(__name__)
 
 
 class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
@@ -612,7 +615,7 @@ class IDStorage(ABC):
         raise NotImplementedError
 
     def nodep_to_node(self, nodep) -> interfaces.objects.ObjectInterface:
-        """Instanciates a tree node from its pointer
+        """Instantiates a tree node from its pointer
 
         Args:
             nodep: Pointer to the XArray/RadixTree node
@@ -846,4 +849,11 @@ class PageCache:
             if not layer.is_valid(page_addr):
                 continue
 
-            yield self.vmlinux.object("page", offset=page_addr, absolute=True)
+            page = self.vmlinux.object("page", offset=page_addr, absolute=True)
+            if not page.is_valid():
+                vollog.error(
+                    f"Invalid cached page at {page.vol.offset:#x}, aborting",
+                )
+                break
+
+            yield page

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -861,17 +861,15 @@ class PageCache:
         """
         layer = self.vmlinux.context.layers[self.vmlinux.layer_name]
         for page_addr in self._idstorage.get_entries(self._page_cache.i_pages):
-            if not page_addr:
-                continue
-
             if not layer.is_valid(page_addr):
-                continue
+                error_msg = f"Invalid cached page address at {page_addr:#x}, aborting"
+                vollog.error(error_msg)
+                raise exceptions.LinuxPageCacheException(error_msg)
 
             page = self.vmlinux.object("page", offset=page_addr, absolute=True)
             if not page.is_valid():
-                vollog.error(
-                    f"Invalid cached page at {page.vol.offset:#x}, aborting",
-                )
-                break
+                error_msg = f"Invalid cached page at {page_addr:#x}, aborting"
+                vollog.error(error_msg)
+                raise exceptions.LinuxPageCacheException(error_msg)
 
             yield page

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -3,6 +3,7 @@
 #
 import math
 import contextlib
+import functools
 import logging
 from abc import ABC, abstractmethod
 from typing import Iterator, List, Tuple, Optional, Union
@@ -662,7 +663,7 @@ class IDStorage(ABC):
         height = self.get_tree_height(root.vol.offset)
 
         nodep = self.get_head_node(root)
-        if not nodep:
+        if not (nodep and nodep.is_readable()):
             return
 
         # Keep the internal flag before untagging it
@@ -697,7 +698,7 @@ class XArray(IDStorage):
 
     def get_node_height(self, nodep) -> int:
         node = self.nodep_to_node(nodep)
-        return (node.shift / self.CHUNK_SHIFT) + 1
+        return (node.shift // self.CHUNK_SHIFT) + 1
 
     def get_head_node(self, tree) -> int:
         return tree.xa_head
@@ -720,6 +721,7 @@ class RadixTree(IDStorage):
     RADIX_TREE_INTERNAL_NODE = 1
     RADIX_TREE_EXCEPTIONAL_ENTRY = 2
     RADIX_TREE_ENTRY_MASK = 3
+    RADIX_TREE_MAP_SHIFT = 6  # CONFIG_BASE_FULL
 
     # Dynamic values. These will be initialized later
     RADIX_TREE_INDEX_BITS = None
@@ -756,42 +758,56 @@ class RadixTree(IDStorage):
     def get_tree_height(self, treep) -> int:
         with contextlib.suppress(exceptions.SymbolError):
             if self.vmlinux.get_type("radix_tree_root").has_member("height"):
-                # kernels < 4.7.10
+                # kernels < 4.7 d0891265bbc988dc91ed8580b38eb3dac128581b
                 radix_tree_root = self.vmlinux.object(
                     "radix_tree_root", offset=treep, absolute=True
                 )
                 return radix_tree_root.height
 
-        # kernels >= 4.7.10
+        # kernels >= 4.7
         return 0
+
+    @functools.cached_property
+    def _max_height_array(self):
+        if self.vmlinux.has_symbol("height_to_maxindex"):
+            # 2.6.24 26fb1589cb0aaec3a0b4418c54f30c1a2b1781f6 <= Kernels < 4.7 d0891265bbc988dc91ed8580b38eb3dac128581b
+            return self.vmlinux.object_from_symbol("height_to_maxindex")
+        elif self.vmlinux.has_symbol("height_to_maxnodes"):
+            # 4.8 c78c66d1ddfdbd2353f3fcfeba0268524537b096 <= kernels < 4.20 8cf2f98411e3a0865026a1061af637161b16d32b
+            return self.vmlinux.object_from_symbol("height_to_maxnodes")
+
+        return None
 
     def _radix_tree_maxindex(self, node, height) -> int:
         """Return the maximum key which can be store into a radix tree with this height."""
 
-        if not self.vmlinux.has_symbol("height_to_maxindex"):
-            # Kernels >= 4.7
-            return (self.CHUNK_SIZE << node.shift) - 1
+        if self._max_height_array:
+            # 2.6.24 <= kernels <= 4.20 See _max_height_array()
+            return self._max_height_array[height]
         else:
-            # Kernels < 4.7
-            height_to_maxindex_array = self.vmlinux.object_from_symbol(
-                "height_to_maxindex"
-            )
-            maxindex = height_to_maxindex_array[height]
-            return maxindex
+            # Kernels >= 4.20
+            return (self.CHUNK_SIZE << node.shift) - 1
 
     def get_node_height(self, nodep) -> int:
         node = self.nodep_to_node(nodep)
         if hasattr(node, "shift"):
             # 4.7 <= Kernels < 4.20
-            return (node.shift / self.CHUNK_SHIFT) + 1
+            height = (node.shift // self.CHUNK_SHIFT) + 1
         elif hasattr(node, "path"):
             # 3.15 <= Kernels < 4.7
-            return node.path & self.RADIX_TREE_HEIGHT_MASK
+            height = node.path & self.RADIX_TREE_HEIGHT_MASK
         elif hasattr(node, "height"):
             # Kernels < 3.15
-            return node.height
+            height = node.height
         else:
             raise exceptions.VolatilityException("Cannot find radix-tree node height")
+
+        if self._max_height_array and not (0 <= height < self._max_height_array.count):
+            error_msg = f"Radix Tree node {node.vol.offset:#x} height {height} exceeds max height of {self._max_height_array.count}"
+            vollog.error(error_msg)
+            raise exceptions.LinuxPageCacheException(error_msg)
+
+        return height
 
     def get_head_node(self, tree) -> int:
         return tree.rnode
@@ -805,14 +821,16 @@ class RadixTree(IDStorage):
     def untag_node(self, nodep) -> int:
         return nodep & (~self.RADIX_TREE_ENTRY_MASK)
 
-    def is_valid_node(self, nodep) -> bool:
+    def _is_exceptional_node(self, nodep) -> bool:
         # In kernels 4.20, exceptional nodes were removed and internal entries took their bitmask
-        if self.vmlinux.has_type("radix_tree_root"):
-            return (
-                nodep & self.RADIX_TREE_ENTRY_MASK
-            ) != self.RADIX_TREE_EXCEPTIONAL_ENTRY
+        return (
+            self.vmlinux.has_type("radix_tree_root")
+            and (nodep & self.RADIX_TREE_ENTRY_MASK)
+            == self.RADIX_TREE_EXCEPTIONAL_ENTRY
+        )
 
-        return True
+    def is_valid_node(self, nodep) -> bool:
+        return not self._is_exceptional_node(nodep)
 
 
 class PageCache:

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -838,11 +838,12 @@ class PageCache:
         Yields:
             Page objects
         """
-
+        layer = self.vmlinux.context.layers[self.vmlinux.layer_name]
         for page_addr in self._idstorage.get_entries(self._page_cache.i_pages):
             if not page_addr:
                 continue
 
-            page = self.vmlinux.object("page", offset=page_addr, absolute=True)
-            if page:
-                yield page
+            if not layer.is_valid(page_addr):
+                continue
+
+            yield self.vmlinux.object("page", offset=page_addr, absolute=True)

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2534,6 +2534,15 @@ class address_space(objects.StructType):
 
 
 class page(objects.StructType):
+    def is_valid(self) -> bool:
+        if self.mapping and not self.mapping.is_readable():
+            return False
+
+        if self.to_paddr() < 0:
+            return False
+
+        return True
+
     @functools.cached_property
     def pageflags_enum(self) -> Dict:
         """Returns 'pageflags' enumeration key/values

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2513,6 +2513,11 @@ class inode(objects.StructType):
             page_content (bytes): The page content
         """
         for page_obj in self.get_pages():
+            if page_obj.mapping != self.i_mapping:
+                vollog.warning(
+                    f"Cached page at {page_obj.vol.offset:#x} has a mismatched address space with the inode. Skipping page"
+                )
+                continue
             page_index = int(page_obj.index)
             page_content = page_obj.get_content()
             if page_content:
@@ -2524,7 +2529,7 @@ class address_space(objects.StructType):
     def i_pages(self):
         """Returns the appropriate member containing the page cache tree"""
         if self.has_member("i_pages"):
-            # Kernel >= 4.17
+            # Kernel >= 4.17 b93b016313b3ba8003c3b8bb71f569af91f19fc7
             return self.member("i_pages")
         elif self.has_member("page_tree"):
             # Kernel < 4.17


### PR DESCRIPTION
In the context of https://github.com/volatilityfoundation/volatility3/pull/1516 and related issues, this PR addresses several bugs in the Page Cache API code and its associated functions. 

### NOTE1: This requires the fixes from #1543 (linked list object extensions) and #1545 (mountinfo). Please DO NOT test the samples below using only the changes from this branch!

**NOTE2: From now on, the `linux.pagecache.InodePages` plugin will no longer display inode page details when using the `--dump` argument. This change helps prevent redundant scanning of the inode page cache, significantly improving processing time, especially when dealing with large files, such as those mentioned in the related issues.**

fix: #1526 ,  #1527

# Issue 1526

## Sample: broken_rhel_load_as_2.lime 
```shell
$ time ./vol.py -f ./broken_rhel_load_as_2.lime linux.pagecache.Files 2>/tmp/broken_rhel_load_as_2.err | wc -l
23920

real    1m19.729s
...
$ wc -l /tmp/broken_rhel_load_as_2.err 
0 /tmp/broken_rhel_load_as_2.err
```

## Sample: Ubuntu_Server_x64_22.04_Auth.zip.lime

```shell
$ time ./vol.py -f ./Ubuntu_Server_x64_22.04_Auth.lime linux.pagecache.Files 2>/tmp/Ubuntu_Server_x64_22.04_Auth.err | wc -l
82978

real    4m31.273s

$ wc -l /tmp/Ubuntu_Server_x64_22.04_Auth.err
0 /tmp/Ubuntu_Server_x64_22.04_Auth.err
```

# Issue 1527
## 1 - Page out of the bounds issue
Fixes the issue reported by @atcuno in #1527 related to handling page out-of-bounds scenarios.

## 2 - Sample: unshared_fds_network_connection.zip.lime

I'm not sure how the `/proc/kcore` file ended up being written in that case. It's likely due to all these recent changes, however, in my tests the inode for the `/proc/kcore` file in that sample shows zero cached pages, meaning that using `--dump` doesn't result in any file being written.
```shell
$ ./vol.py -f ../unshared_fds_network_connection.lime linux.pagecache.Files | grep 9ec482a94e30
SuperblockAddr  MountPoint      Device  InodeNum        InodeAddr       FileType        InodePages      CachedPages     FileMode        AccessTime      ModificationTime      ChangeTime       FilePath
...
0x9ec482298000  /proc   0:21    4026532026      0x9ec482a94e30  REG     34359734275     0       -r--------      2024-08-20 18:57:13.620000 UTC  2024-08-20 18:57:13.620000 UTC2024-08-20 18:57:13.620000 UTC   /proc/kcore
```

Regarding the dump size limit: I can add an argument to restrict the file size in a future PR. However, this shouldn't be an issue in most cases since the output is a sparse file, which is supported by most modern filesystems across all major operating systems.
 - Linux: Ext2/3/4, XFS, JFS, ReiserFS, Btrfs, ZFS and even NTFS-3G
 - Windows: NTFS, exFAT and ReFS.
 - MAC: APFS, HFS+ and exFAT
 
The `actual` file size (not the `apparent` / `sparsed` size reported by the OS) will only include the pages found in memory. 
Even if we dump all existing inodes from the entire Page Cache, the total `actual` occupied size, by definition, cannot exceed the system RAM size. Even in the hypothetical (and absurd) scenario where 100% of RAM is used by the Page Cache, the resulting sizes are still too small to `break` a filesystem. 
Naturally, if you have just 100MB of available space and the `actual` written size is 16GB, you'll run into issues. 
However, this can happen with any command in the operating system, i.e.: `cp /some/big/file /some/small/fs/`. 
Curiously, `cp` does not have an option to limit the size of the data being written.

Additionally, `ls` will report only the apparent/sparsed size, not the actual size. You can even have a sparse file larger than the space available on disk. For instance:
```shell
$ df -h .
Filesystem               Size  Used Avail Use% Mounted on
/dev/nvme1n1p1           469G   93G  353G  21% /mnt/other_disk
``` 
There's 353GB available, let's create a 512GB sparse file:
```shell
$ truncate -s 512G file.img
$ ls -la file.img 
-rw-rw-r-- 1 gmoreira gmoreira 549755813888 Jan 14 19:46 file.img
```
Is the filesystem full or broken? 
```shell
$ df -h
Filesystem               Size  Used Avail Use% Mounted on
/dev/nvme1n1p1           469G   93G  353G  21% /mnt/other_disk
``` 
It doesn't take up any space. To read the `actual` file size, you can use `du`.
```
$ du -hs file.img 
0 file.img
```

On the other hand, files like `/proc/kcore` will never report pages available in the Page Cache since it's not a normal file backed on disk blocks but a special file in the proc filesystem. It directly represents in-memory content, so caching is unnecessary and irrelevant to its purpose.

Having said that, I've added lazy initialization for the output sparse file. This ensures that if the `linux.pagecache.InodePages` plugin cannot to find any valid pages to dump, it will still generate the file, however, in such cases, the file will be created but remain empty with 0 actual bytes and not truncated to the inode size.

## 3 - Sample: 20220822195350.zip

Effectively, the file contains 55007 pages which is approx ~215MB.

```shell
$ ./vol.py -f ../20220822195350_data.lime linux.pagecache.Files | grep 888223baee58
0x88822de2b000.0/       259:1   4822135g0x888223baee58  REG     55006   55007   -rw-r--r--      2022-08-16 20:31:07.000000 UTC  2022-08-16 20:31:07.000000 UTC  2022-08-22 19:06:06.114498 UTC /var/cache/yum/x86_64/2/amzn2-core/gen/primary_db.sqlite
```
It's odd it reports more pages available than the actual file size. I've already debugged and verified this, see my notes later.

```shell
$ time ./vol.py -f ./20220822195350_data.lime linux.pagecache.Inode --inode 0x888223baee58 --dump 
...
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x888223baee58, inode size 225304576, page index 55006

real    9m48.316s
```

Did it work as expected?
```shell
$ file inode_0x888223baee58.dmp
inode_0x888223baee58.dmp: SQLite 3.x database, last written using SQLite version 3039002, file counter 19, database pages 55006, cookie 0x11, schema 4, UTF-8, version-valid-for 19
```

```shell
$ sqlite3 ./inode_0x888223baee58.dmp
SQLite version 3.45.1 2024-01-30 16:01:20
Enter ".help" for usage hints.
sqlite> .tables
conflicts  db_info    files      obsoletes  packages   provides   requires 

sqlite> select * from files limit 10;
/usr/bin/filan|file|10
/usr/bin/procan|file|10
/usr/bin/socat|file|10
/usr/bin/jose|file|19
/usr/bin/im-chooser|file|23
/usr/bin/db_archive|file|26
/usr/bin/db_checkpoint|file|26
/usr/bin/db_deadlock|file|26
/usr/bin/db_dump|file|26
/usr/bin/db_dump185|file|26
```
### Is the number of available pages vs the inode pages a bug?
Using the respective debug symbols for that kernel, I debugged it using GDB:
```shell
gdb> p ((struct inode*)0xffff888223baee58)->i_mapping.nrpages
$3 = 55007
gdb> p ((struct inode*)0xffff888223baee58)->i_size
$4 = 225304576
...
>>> 225304576/4096.0
55006.0
```
So, it's not a bug. 

## 4 - Sample: 4_4_0-176_206-4_4_0-176-generic.lime
```
$ time ./vol.py -f ./4_4_0-176_206-4_4_0-176-generic.lime.raw linux.pagecache.Inode --inode 0x880035826958 --dump 
PageVAddr       PagePAddr       MappingAddr     Index   DumpSafe        Flags

real    0m12.048s
...
```

Did it work as expected?

```shell
$ file inode_0x880035826958.dmp
inode_0x880035826958.dmp: Journal file, Mon Mar 30 17:17:01 2020, online, compressed, header size 0xf0, entries 0x17b
```

```shell
$ journalctl --file=inode_0x880035826958.dmp --list-boots
IDX BOOT ID                          FIRST ENTRY                  LAST ENTRY                  
  0 9bf6e4bbdfe243b29e948903f7613c24 Tue 2020-03-31 04:17:01 AEDT Tue 2020-03-31 12:17:01 AEDT
```

```shell
$ journalctl --file=inode_0x880035826958.dmp 
Mar 31 04:17:01 ubuntu-16-04-xenserver65-x64-patched CRON[18822]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
Mar 31 04:17:01 ubuntu-16-04-xenserver65-x64-patched CRON[18821]: pam_unix(cron:session): session closed for user root
Mar 31 05:17:01 ubuntu-16-04-xenserver65-x64-patched CRON[18825]: pam_unix(cron:session): session opened for user root by (uid=0)
Mar 31 05:17:01 ubuntu-16-04-xenserver65-x64-patched CRON[18826]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
Mar 31 05:17:01 ubuntu-16-04-xenserver65-x64-patched CRON[18825]: pam_unix(cron:session): session closed for user root
...
```

## 5 - Sample: blackhat_2022_linux_poc_logkey.lime

```shell
$ ./vol.py -f ./blackhat_2022_linux_poc_logkey.lime linux.pagecache.Files | grep 9a590549a728 
0x9a591ef48800.0/       8:1     941200ng0x9a590549a728  REG     20638   18328   -r--r-----      2022-03-31 14:38:42.696390 UTC  2022-03-31 14:38:42.888389 UTC  2022-03-31 14:38:42.888389 UTC    /home/rk/debrkdev/20220331093842/memory/data.lime
```
Ok.. this is a memory dump.

```shell
$ ./vol.py -f ./blackhat_2022_linux_poc_logkey.lime linux.pagecache.Inode --inode 0x9a590549a728 2>/dev/null | wc -l
3275

$ time ./vol.py -f ./blackhat_2022_linux_poc_logkey.lime linux.pagecache.Inode --inode 0x9a590549a728 --dump 2>/tmp/blackhat_2022_linux_poc_logkey.err

real    0m52.983s
...
```

However, this sample and inode has many errors.
```shell
$ wc -l /tmp/blackhat_2022_linux_poc_logkey.err
3459 /tmp/blackhat_2022_linux_poc_logkey.err

$ head /tmp/blackhat_2022_linux_poc_logkey.err 
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87427
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87428
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 89805
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87429
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87430
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87431
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87432
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87433
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87434
ERROR    volatility3.plugins.linux.pagecache: Page out of file bounds: inode 0x9a590549a728, inode size 84529216, page index 87435
```


## 6 - Sample: blackhat_2022_poc_ssh_keylogger_test.lime

```shell
$ ./vol.py ./blackhat_2022_poc_ssh_keylogger_test.lime linux.pagecache.Files | grep 9a591cbfd1a8 
0x9a591ef48800  /       8:1     944566  0x9a591cbfd1a8  REG     116894  52105   -r--r-----      2022-03-31 15:53:38.761565 UTC  2022-03-31 15:53:39.953558 UTC  2022-03-31 15:53:39.953558 UTC       /home/rk/debrkdev/20220331105338/memory/data.lime
```
Another memory dump.

Again, this inode have a lot of issues with the page cache.
```shell
$ time ./vol.py ./blackhat_2022_poc_ssh_keylogger_test.lime linux.pagecache.Inode --inode 0x9a591cbfd1a8 --dump 2>/tmp/blackhat_2022_poc_ssh_keylogger_test.err

real    1m44.042s
```

```shell
$  wc -l /tmp/blackhat_2022_poc_ssh_keylogger_test.err
2130 /tmp/blackhat_2022_poc_ssh_keylogger_test.err

$ tail /tmp/blackhat_2022_poc_ssh_keylogger_test.err
WARNING  volatility3.framework.symbols.linux.extensions: Cached page at 0xe5dbc05a1040 has a mismatched address space with the inode. Skipping page
WARNING  volatility3.framework.symbols.linux.extensions: Cached page at 0xe5dbc05a1080 has a mismatched address space with the inode. Skipping page
WARNING  volatility3.framework.symbols.linux.extensions: Cached page at 0xe5dbc05a10c0 has a mismatched address space with the inode. Skipping page
WARNING  volatility3.framework.symbols.linux.extensions: Cached page at 0xe5dbc05a1100 has a mismatched address space with the inode. Skipping page
WARNING  volatility3.framework.symbols.linux.extensions: Cached page at 0xe5dbc05a1140 has a mismatched address space with the inode. Skipping page
WARNING  volatility3.framework.symbols.linux.extensions: Cached page at 0xe5dbc05a1180 has a mismatched address space with the inode. Skipping page
WARNING  volatility3.framework.symbols.linux.extensions: Cached page at 0xe5dbc05a11c0 has a mismatched address space with the inode. Skipping page
ERROR    volatility3.framework.symbols.linux: Invalid cached page at 0x9a59064deda0, aborting
WARNING  volatility3.framework.interfaces.plugins: File inode_0x9a591cbfd1a8.dmp could not be written: Invalid cached page at 0x9a59064deda0, aborting
ERROR    volatility3.plugins.linux.pagecache: Error dumping cached pages for inode at 0x9a591cbfd1a8
```

To ensure everything is correct, I debugged the issue using the `crash utility`. As you can see, it triggers the exact same error for that inode, causing the listing to abort
```shell
crash> files -p 0xffff9a591cbfd1a8
     INODE        NRPAGES
ffff9a591cbfd1a8    52105

      PAGE       PHYSICAL      MAPPING       INDEX CNT FLAGS
ffffe5dbc015f5c0  57d7000 ffff9a591cbfd320    1c6b3  2 ffffc000001028 uptodate,lru,private
...
ffffe5dbc0092c80  24b2000 ffff9a591cbfd320    13eb6  2 ffffc000001028 uptodate,lru,private
files: do_radix_tree: callback operation failed: entry: 7040  item: ffff9a59064deda0
crash> 
```

Anyway, it still partially recovered the file from memory.
```
$ strings inode_0x9a591cbfd1a8.dmp | wc -l
98272

$ strings inode_0x9a591cbfd1a8.dmp | grep "^Linux version"
Linux version 4.19.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 8.3.0 (Debian 8.3.0-6)) #1 SMP Debian 4.19.118-2+deb10u1 (2020-06-07)
```

## 7 - Sample: downloads_memory_20220701103641.lime

```shell
$ ./vol.py -f ./downloads_memory_20220701103641.lime linux.pagecache.Files | grep 9fa87bf1b1a8 
0x9fa836498000  /       254:1   261475  0x9fa87bf1b1a8  REG     438272  320321  -r--r-----      2022-07-01 14:36:41.535180 UTC  2022-07-01 14:36:53.315186 UTC  2022-07-01 14:36:53.315186 UTC       /home/redacted/downloads/20220701103641.zip
```

```shell
$ time ./vol.py -f ./downloads_memory_20220701103641.lime  linux.pagecache.Inode --inode 0x9fa87bf1b1a8  --dump 2>/tmp/downloads_memory_20220701103641.err

real    0m9.445s
```

```shell
$ cat /tmp/downloads_memory_20220701103641.err
ERROR    volatility3.framework.symbols.linux: Radix Tree node 0x9fa803033240 height 41 exceeds max height of 12
WARNING  volatility3.framework.interfaces.plugins: File inode_0x9fa87bf1b1a8.dmp could not be written: Radix Tree node 0x9fa803033240 height 41 exceeds max height of 12
ERROR    volatility3.plugins.linux.pagecache: Error dumping cached pages for inode at 0x9fa87bf1b1a8
```

But an empty output file.
```shell
$ ls -la inode_0x9fa87bf1b1a8.dmp
-rw------- 1 gmoreira gmoreira 0 Jan 16 20:55 inode_0x9fa87bf1b1a8.dmp
```
Let's use the `crash tool` to check if this is a bug in our code.
```shell
crash> files -p 0xffff9fa87bf1b1a8
     INODE        NRPAGES
ffff9fa87bf1b1a8   320321

radix_tree_node at ffff9fa87bf1b330
...
files: height 41 is greater than maximum radix tree height index 12
```