### PR TITLE
Issues/issue1546

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ test = [
 
 docs = [
     "volatility3[dev]",
-    "sphinx>=8.0.0,<9",
+    "sphinx>=4.0.0,<9",
     "sphinx-autodoc-typehints>=2.0.0,<3",
     "sphinx-rtd-theme>=3.0.1,<4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
 docs = [
     "volatility3[dev]",
     "sphinx>=8.0.0,<9",
-    "sphinx-autodoc-typehints>=2.5.0,<3",
+    "sphinx-autodoc-typehints>=2.0.0,<3",
     "sphinx-rtd-theme>=3.0.1,<4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ cloud = [
 dev = [
     "volatility3[full,cloud]",
     "jsonschema>=4.23.0,<5",
-    "pyinstaller>=6.11.0,<7",
+    "pyinstaller>=6.5.0,<7",
     "pyinstaller-hooks-contrib>=2024.9",
     "types-jsonschema>=4.23.0,<5",
 ]
@@ -48,7 +48,7 @@ test = [
 
 docs = [
     "volatility3[dev]",
-    "sphinx>=8.0.0,<7",
+    "sphinx>=8.0.0,<9",
     "sphinx-autodoc-typehints>=2.5.0,<3",
     "sphinx-rtd-theme>=3.0.1,<4",
 ]


### PR DESCRIPTION
This is designed to supercede #1548.  It should allow older versions of pyinstaller without the requirement on an older pefile.  It also fixes the sphinx requirements to relax the older version numbers, given we haven't found reason to disallow the older versions.

Fixes #1546.