### PR TITLE
Intermed: leverage iterable hashmaps instead of lists

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 17  # Number of changes that only add to the interface
+VERSION_MINOR = 18  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,7 +1,7 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 18  # Number of changes that only add to the interface
-VERSION_PATCH = 0  # Number of changes that do not change the interface
+VERSION_MINOR = 17  # Number of changes that only add to the interface
+VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 PACKAGE_VERSION = (

--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -337,7 +337,7 @@ class Module(interfaces.context.ModuleInterface):
         )
 
     @property
-    def symbols(self):
+    def symbols(self) -> Iterable[str]:
         return self.context.symbol_space[self.symbol_table_name].symbols
 
     get_symbol = get_module_wrapper("get_symbol")

--- a/volatility3/framework/interfaces/context.py
+++ b/volatility3/framework/interfaces/context.py
@@ -303,8 +303,8 @@ class ModuleInterface(interfaces.configuration.ConfigurableInterface):
         """Determines whether an enumeration is present in the module's symbol table."""
 
     @abstractmethod
-    def symbols(self) -> List:
-        """Lists the symbols contained in the symbol table for this module"""
+    def symbols(self) -> Iterable[str]:
+        """Returns an iterable of the symbols contained in the symbol table for this module"""
 
     @abstractmethod
     def get_symbols_by_absolute_location(self, offset: int, size: int = 0) -> List[str]:

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -375,7 +375,13 @@ class NativeTableInterface(BaseSymbolTableInterface):
         )
 
     @property
-    def enumerations(self) -> Iterable[str]:
+    def enumerations(self) -> Iterable[Any]:
+        """Returns an iterable of the available enumerations."""
+        return []
+
+    @property
+    def types(self) -> Iterable[str]:
+        """Returns an iterable of the available symbol type names."""
         return []
 
 

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -122,7 +122,7 @@ class BaseSymbolTableInterface:
 
     @property
     def symbols(self) -> Iterable[str]:
-        """Returns an iterator of the Symbol names."""
+        """Returns an iterable of the available symbol names."""
         raise NotImplementedError(
             "Abstract property symbols not implemented by subclass."
         )
@@ -131,7 +131,7 @@ class BaseSymbolTableInterface:
 
     @property
     def types(self) -> Iterable[str]:
-        """Returns an iterator of the Symbol type names."""
+        """Returns an iterable of the available symbol type names."""
         raise NotImplementedError(
             "Abstract property types not implemented by subclass."
         )
@@ -149,7 +149,7 @@ class BaseSymbolTableInterface:
 
     @property
     def enumerations(self) -> Iterable[Any]:
-        """Returns an iterator of the Enumeration names."""
+        """Returns an iterable of the available enumerations names."""
         raise NotImplementedError(
             "Abstract property enumerations not implemented by subclass."
         )
@@ -366,6 +366,7 @@ class NativeTableInterface(BaseSymbolTableInterface):
 
     @property
     def symbols(self) -> Iterable[str]:
+        """Returns an iterable of the available symbol names."""
         return []
 
     def get_enumeration(self, name: str) -> objects.Template:

--- a/volatility3/framework/interfaces/symbols.py
+++ b/volatility3/framework/interfaces/symbols.py
@@ -149,7 +149,7 @@ class BaseSymbolTableInterface:
 
     @property
     def enumerations(self) -> Iterable[Any]:
-        """Returns an iterable of the available enumerations names."""
+        """Returns an iterable of the available enumerations."""
         raise NotImplementedError(
             "Abstract property enumerations not implemented by subclass."
         )

--- a/volatility3/framework/symbols/intermed.py
+++ b/volatility3/framework/symbols/intermed.py
@@ -411,18 +411,23 @@ class Version1Format(ISFormatTable):
 
     @property
     def symbols(self) -> Iterable[str]:
-        """Returns an iterator of the symbol names."""
-        return list(self._json_object.get("symbols", {}))
+        """Returns an iterable (KeysView) of the available symbol names."""
+        return self._json_object.get("symbols", {}).keys()
 
     @property
-    def enumerations(self) -> Iterable[str]:
-        """Returns an iterator of the available enumerations."""
-        return list(self._json_object.get("enums", {}))
+    def enumerations(self) -> Iterable[Any]:
+        """Returns an iterable (KeysView) of the available enumerations."""
+        return self._json_object.get("enums", {}).keys()
 
     @property
-    def types(self) -> Iterable[str]:
-        """Returns an iterator of the symbol type names."""
-        return list(self._json_object.get("user_types", {})) + list(self.natives.types)
+    def types(self):
+        """Returns an iterable (KeysView) of the available symbol type names."""
+        # self.natives.types (set) is generally very small compared to user_types,
+        # so the dict conversion overhead can be neglected
+        return {
+            **self._json_object.get("user_types", {}),
+            **dict.fromkeys(self.natives.types),
+        }.keys()
 
     def get_type_class(self, name: str) -> Type[interfaces.objects.ObjectInterface]:
         return self._overrides.get(name, objects.AggregateType)

--- a/volatility3/framework/symbols/intermed.py
+++ b/volatility3/framework/symbols/intermed.py
@@ -422,8 +422,12 @@ class Version1Format(ISFormatTable):
     @property
     def types(self) -> Iterable[str]:
         """Returns an iterable (KeysView) of the available symbol type names."""
-        # self.natives.types (set) is generally very small compared to user_types,
-        # so the dict conversion overhead can be neglected
+        # We use ** instead of
+        # `set(self._json_object.get("user_types", {}).keys()).union(self.natives.types)`
+        # because converting user_types dict to a set is costly.
+        # It is more efficient to convert the (very small) self.natives.types set to a dict.
+        # FIXME: On Python3.8 support drop, merge the two dicts using the merge operator:
+        # (self._json_object.get("user_types", {}) | dict.fromkeys(self.natives.types)).keys()
         return {
             **self._json_object.get("user_types", {}),
             **dict.fromkeys(self.natives.types),

--- a/volatility3/framework/symbols/intermed.py
+++ b/volatility3/framework/symbols/intermed.py
@@ -420,7 +420,7 @@ class Version1Format(ISFormatTable):
         return self._json_object.get("enums", {}).keys()
 
     @property
-    def types(self):
+    def types(self) -> Iterable[str]:
         """Returns an iterable (KeysView) of the available symbol type names."""
         # self.natives.types (set) is generally very small compared to user_types,
         # so the dict conversion overhead can be neglected

--- a/volatility3/framework/symbols/native.py
+++ b/volatility3/framework/symbols/native.py
@@ -30,7 +30,7 @@ class NativeTable(interfaces.symbols.NativeTableInterface):
 
     @property
     def types(self) -> Iterable[str]:
-        """Returns an iterator of the symbol type names."""
+        """Returns an iterable (set) of the available symbol type names."""
         return self._types
 
     def get_type(self, type_name: str) -> interfaces.objects.Template:


### PR DESCRIPTION
Hi, 

To perform iterable lookups in `O(1)` time instead of `O(n)` time, this PR makes use of the `.keys()` property of internal ISF APIs (symbols, types, enumerations). The required `Iterable` return type does not change, while providing a memory management and (framework/plugins) runtime improvement. 

For example, I observed a three seconds gain on a `linux.pstree` run (~13 seconds -> ~10 seconds). This is even more pronounced on heavier plugins.

I improved a few comments here and there too, and fixed a missing abstract class (NativeTableInterface.types).

Closes #1552

### Versioning

Patch bumps (**superseeded by minor bumps**): 
	- indicate the correct return type for Module.symbols (iterable, not list)
Minor bumps:
	- add missing NativeTableInterface.types abstract class