### PR TITLE
Pre linux.pagecache.recoverfs support

### DIFF
--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -473,7 +473,7 @@ class InodePages(plugins.PluginInterface):
             context: The context on which to operate
             layer_name: The name of the layer on which to operate
             inode: The inode to dump
-            stream: An IO steam to write to, typically FileHandlerInterface or BytesIO
+            stream: An IO stream to write to, typically FileHandlerInterface or BytesIO
         """
         layer = context.layers[layer_name]
         # By using truncate/seek, provided the filesystem supports it, and the

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -8,6 +8,7 @@ import datetime
 from dataclasses import dataclass, astuple
 from typing import List, Set, Type, Iterable
 
+from volatility3.framework.constants import architectures
 from volatility3.framework import renderers, interfaces
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.interfaces import plugins
@@ -112,7 +113,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.PluginRequirement(
                 name="mountinfo", plugin=mountinfo.MountInfo, version=(1, 2, 0)
@@ -397,7 +398,7 @@ class InodePages(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.PluginRequirement(
                 name="files", plugin=Files, version=(1, 0, 0)

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -112,7 +112,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 2, 0)
+    _version = (1, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -38,6 +38,11 @@ class InodeUser:
     modification_time: str
     change_time: str
     path: str
+    inode_size: int
+
+    @staticmethod
+    def format_symlink(symlink_source: str, symlink_dest: str):
+        return f"{symlink_source} -> {symlink_dest}"
 
 
 @dataclass
@@ -81,6 +86,7 @@ class InodeInternal:
         access_time_dt = self.inode.get_access_time()
         modification_time_dt = self.inode.get_modification_time()
         change_time_dt = self.inode.get_change_time()
+        inode_size = int(self.inode.i_size)
 
         inode_user = InodeUser(
             superblock_addr=superblock_addr,
@@ -96,6 +102,7 @@ class InodeInternal:
             modification_time=modification_time_dt,
             change_time=change_time_dt,
             path=self.path,
+            inode_size=inode_size,
         )
         return inode_user
 

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -220,12 +220,14 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
         cls,
         context: interfaces.context.ContextInterface,
         vmlinux_module_name: str,
+        follow_symlinks: bool = True,
     ) -> Iterable[InodeInternal]:
         """Retrieves the inodes from the superblocks
 
         Args:
             context: The context that the plugin will operate within
             vmlinux_module_name: The name of the kernel module on which to operate
+            follow_symlinks: Whether to follow symlinks or not
 
         Yields:
             An InodeInternal object
@@ -297,7 +299,9 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
                     continue
                 seen_inodes.add(file_inode_ptr)
 
-                file_path = cls._follow_symlink(file_inode_ptr, file_path)
+                if follow_symlinks:
+                    file_path = cls._follow_symlink(file_inode_ptr, file_path)
+
                 inode_in = InodeInternal(
                     superblock=superblock,
                     mountpoint=mountpoint,

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -112,7 +112,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (1, 0, 1)
+    _version = (1, 2, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -402,7 +402,7 @@ class InodePages(plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (2, 1, 0)
+    _version = (3, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -468,7 +468,7 @@ class InodePages(plugins.PluginInterface):
 
         Args:
             inode: The inode to dump
-            stream: A IO steam to write to, typically FileHandlerInterface or BytesIO
+            stream: An IO steam to write to, typically FileHandlerInterface or BytesIO
             vmlinux_layer: The kernel layer to obtain the page size
         """
 

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -389,6 +389,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             ("ModificationTime", datetime.datetime),
             ("ChangeTime", datetime.datetime),
             ("FilePath", str),
+            ("InodeSize", int),
         ]
 
         return renderers.TreeGrid(

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -41,7 +41,7 @@ class InodeUser:
     inode_size: int
 
     @staticmethod
-    def format_symlink(symlink_source: str, symlink_dest: str):
+    def format_symlink(symlink_source: str, symlink_dest: str) -> str:
         return f"{symlink_source} -> {symlink_dest}"
 
 

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -402,7 +402,7 @@ class InodePages(plugins.PluginInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (2, 0, 0)
+    _version = (2, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -156,10 +156,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
         """
         # i_link (fast symlinks) were introduced in 4.2
         if inode and inode.is_link and inode.has_member("i_link") and inode.i_link:
-            i_link_str = inode.i_link.dereference().cast(
+            symlink_dest = inode.i_link.dereference().cast(
                 "string", max_length=255, encoding="utf-8", errors="replace"
             )
-            symlink_path = f"{symlink_path} -> {i_link_str}"
+            symlink_path = InodeUser.format_symlink(symlink_path, symlink_dest)
 
         return symlink_path
 


### PR DESCRIPTION
Hi, 

To prepare for the new `linux.pagecache.recoverfs` plugin, I figured it would be better to split changes non directly related to it in a separate PR. 

A few readability tweaks were operated, as well as splitting the `inode` content extraction and writing process to allow for better flexibility. 
The `InodeSize` column was added to `Files` output, as I think it is a valuable piece of information. It will also complement very well `linux.pagecache.RecoverFs` `Recovered FileSize` column, as the following snippet demonstrates (scroll right to the last columns) :

```bash
$ python3 vol.py -f sample.bin -r pretty linux.pagecache.RecoverFs
  | SuperblockAddr |               MountPoint | Device |   InodeNum |      InodeAddr | FileType |  InodePages | CachedPages |   FileMode |                     AccessTime |               ModificationTime |                     ChangeTime |                                                                                                                                                                         FilePath |       InodeSize | Recovered FileSize
* | 0x89388c64c800 |                        / |    8:1 |      72981 | 0x89388cd19378 |      REG |          51 |          24 | -rw-r----- | 2024-11-15 12:40:53.900001 UTC | 2024-11-15 14:59:14.121585 UTC | 2024-11-15 14:59:14.121585 UTC |                                                                                                                                                                  /var/log/syslog |          207810 |             207810
* | 0x89388c64c800 |                        / |    8:1 |      72605 | 0x89388cd185b0 |      REG |           2 |           2 | -rw-rw-r-- | 2024-10-02 14:31:24.629028 UTC | 2024-11-15 14:58:43.880001 UTC | 2024-11-15 14:58:43.880001 UTC |                                                                                                                                                                    /var/log/wtmp |            6144 |               6144
* | 0x89388c64c800 |                        / |    8:1 |      72606 | 0x89388cd18118 |      REG |           0 |           0 | -rw-rw---- | 2024-10-02 14:31:24.629028 UTC | 2024-10-02 14:33:48.019670 UTC | 2024-10-02 14:36:11.362212 UTC |                                                                                                                                                                    /var/log/btmp |               0 |                  0
* | 0x89388c64c800 |                        / |    8:1 |      80281 | 0x89388cdeeac0 |      DIR |           1 |           0 | drwx------ | 2024-11-15 12:40:45.328000 UTC | 2024-11-15 12:40:45.328000 UTC | 2024-11-15 12:40:45.328000 UTC |                                                                                                                                                                 /var/log/private |            4096 |                N/A
* | 0x89388c64c800 |                        / |    8:1 |      80249 | 0x89388cd04a98 |      DIR |           1 |           0 | drwxr-sr-x | 2024-11-15 12:40:58.716001 UTC | 2024-11-15 12:40:44.876000 UTC | 2024-11-15 12:40:44.876000 UTC |                                                                                                                                                                 /var/log/journal |            4096 |                N/A
* | 0x89388c64c800 |                        / |    8:1 |      80275 | 0x89388cd033a0 |      DIR |           1 |           0 | drwxr-sr-x | 2024-11-15 12:40:58.716001 UTC | 2024-11-15 12:40:55.952001 UTC | 2024-11-15 12:40:55.952001 UTC |                                                                                                                                /var/log/journal/c602156d161745d29b98f977eb66a96d |            4096 |                N/A
* | 0x89388c64c800 |                        / |    8:1 |      72930 | 0x89388cd073f0 |      REG |        2048 |         292 | -rw-r----- | 2024-11-15 14:58:37.228001 UTC | 2024-11-15 14:58:42.764001 UTC | 2024-11-15 14:58:42.764001 UTC |                                                                                                              /var/log/journal/c602156d161745d29b98f977eb66a96d/user-1000.journal |         8388608 |            1196032
* | 0x89388c64c800 |                        / |    8:1 |      72437 | 0x89388cd00118 |      REG |        2048 |         732 | -rw-r----- | 2024-11-15 14:58:37.228001 UTC | 2024-11-15 14:59:14.401585 UTC | 2024-11-15 14:59:14.401585 UTC |                                                                                                                 /var/log/journal/c602156d161745d29b98f977eb66a96d/system.journal |         8388608 |            2998272
```

As you can see, this will provide easy lookups to compare the recovered file size to the announced size. It also arguments the choice of placing `InodeSize` at the very end. Happy to discuss it however !

### Versioning

#### linux.pagecache.Files

- Minor bump:
	- get_inodes: add "follow_symlinks" argument
	- rendering: add "InodeSize" column

#### linux.pagecache.InodePages

- Minor bump:
	- add "write_inode_content_to_stream" method