### PR TITLE
Add low stub offset kernel detection

### DIFF
--- a/volatility3/framework/constants/windows/__init__.py
+++ b/volatility3/framework/constants/windows/__init__.py
@@ -10,3 +10,21 @@ KERNEL_MODULE_NAMES = ["ntkrnlmp", "ntkrnlpa", "ntkrpamp", "ntoskrnl"]
 """The list of names that kernel modules can have within the windows OS"""
 
 PE_MAX_EXTRACTION_SIZE = 1024 * 1024 * 256
+
+"""
+The following constants represent the layout of the Low Stub which exists only on x64 machines with no virtualization/emulation,
+responsible for transitioning from Real Mode(16 bit) to Protected Mode(32 bit) and Long Mode(64 bit) on boot/return from sleep.
+Contains offsets to fields and structures within the undocumented structure _PROCESSOR_START_BLOCK.
+Here's a reference: https://github.com/mic101/windows/blob/master/WRK-v1.2/base/ntos/inc/amd64.h#L3334
+"""
+# Expected signature for validation, constructed from:
+# PROCESSOR_START_BLOCK->Jmp->OpCode | PROCESSOR_START_BLOCK->Jmp->Offset | PROCESSOR_START_BLOCK->CompletionFlag
+JMP_AND_COMPLETION_SIGNATURE = 0x00000001000600E9
+
+# Address of LmTarget (Long Mode target)
+PROCESSOR_START_BLOCK_LM_TARGET_OFFSET = (
+    0x70  # PROCESSOR_START_BLOCK->LmTarget, PVOID 8 bytes
+)
+
+# CR3 register within structures describing initial processor state to be started
+PROCESSOR_START_BLOCK_CR3_OFFSET = 0xA0  # PROCESSOR_START_BLOCK->ProcessorState->SpecialRegisters->Cr3, ULONG64 8 bytes


### PR DESCRIPTION
### Summary
This PR introduces a Low-Stub based method as an additional approach to kernel offset discovery in Volatility.
When available, this method resolves the kernel offset in ~1 second, a significant improvement compared to the ~15 seconds required by the current KDBG scan for large memory dumps (e.g., 32GB).
If the Low Stub method fails (e.g., for Hyper-V .vmem files), Volatility gracefully falls back to the existing KDBG scan.

### Motivation
The KDBG scan is computationally intensive, particularly for large memory dumps, and can delay forensic investigations and incident response.
By leveraging the Low Stub, which contains the DTB and kernel base address hint, the kernel offset can be determined far more efficiently, improving overall runtime for all plugins dependent on this step.

### Testing
This hybrid approach was tested on:

- Physical memory dumps from Windows 11
- Edge cases where the Low Stub is unavailable, with successful fallback to the KDBG scan (e.g., VMs memory)

### References

- Memprocfs: Inspired the Low Stub based approach to kernel offset discovery.
- Alex Ionescu: [Recon 2017 Talk on the Low Stub][0] (starting at 43:36).

[0]: <https://www.youtube.com/watch?v=_ShCSth6dWM>


Special thanks to Ulf Frisk and Alex Ionescu for their pioneering research, which informed and inspired this contribution.

### Acknowledgment

Thank you for maintaining Volatility as an indispensable tool in the forensic community. I hope this contribution enhances its usability and performance. I welcome any feedback or suggestions for further improvement.

