### PR TITLE
chore(ci): pin ruff

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -13,3 +13,4 @@ jobs:
         with:
           args: check
           src: "."
+          version: 0.9.3


### PR DESCRIPTION
pin ruff in ci, so that new ruff releases don't cause previously passing checks to fail