### PR TITLE
Embed additional plugin description in docstring

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -363,12 +363,13 @@ class CommandLine:
             metavar="PLUGIN",
         )
         for plugin in sorted(plugin_list):
-            # First line of a plugin docstring will be the short description for -h
-            # Following lines will be the additional description (argparse epilog)
+            # First line of a plugin docstring will be the short description for -h.
+            # Text after the first two consecutive new lines will be
+            # the additional description (argparse epilog).
             short_help = additional_help = None
             if plugin_list[plugin].__doc__ is not None:
-                doc_split = plugin_list[plugin].__doc__.strip().split("\n", 1)
-                short_help = doc_split[0]
+                doc_split = plugin_list[plugin].__doc__.split("\n\n", 1)
+                short_help = doc_split[0].strip()
                 if len(doc_split) > 1:
                     additional_help = doc_split[1].strip()
 

--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -363,11 +363,20 @@ class CommandLine:
             metavar="PLUGIN",
         )
         for plugin in sorted(plugin_list):
+            # First line of a plugin docstring will be the short description for -h
+            # Following lines will be the additional description (argparse epilog)
+            short_help = additional_help = None
+            if plugin_list[plugin].__doc__ is not None:
+                doc_split = plugin_list[plugin].__doc__.strip().split("\n", 1)
+                short_help = doc_split[0]
+                if len(doc_split) > 1:
+                    additional_help = doc_split[1].strip()
+
             plugin_parser = subparser.add_parser(
                 plugin,
-                help=plugin_list[plugin].__doc__,
-                description=plugin_list[plugin].__doc__,
-                epilog=plugin_list[plugin].additional_description,
+                help=short_help,
+                description=short_help,
+                epilog=additional_help,
             )
             self.populate_requirements_argparse(plugin_parser, plugin_list[plugin])
 

--- a/volatility3/framework/interfaces/plugins.py
+++ b/volatility3/framework/interfaces/plugins.py
@@ -112,8 +112,6 @@ class PluginInterface(
     # Be careful with inheritance around this (We default to requiring a version which doesn't exist, so it must be set)
     _required_framework_version: Tuple[int, int, int] = (0, 0, 0)
     """The _version variable is a quick way for plugins to define their current interface, it should follow SemVer rules"""
-    additional_description: str = None
-    """Display additional description of the plugin after the description of the arguments. See: https://docs.python.org/3/library/argparse.html#epilog"""
 
     def __init__(
         self,

--- a/volatility3/framework/plugins/configwriter.py
+++ b/volatility3/framework/plugins/configwriter.py
@@ -14,8 +14,8 @@ vollog = logging.getLogger(__name__)
 
 
 class ConfigWriter(plugins.PluginInterface):
-    """Runs the automagics and both prints and outputs configuration in the
-    output directory."""
+    """Runs the automagics and both prints and outputs configuration in the \
+output directory."""
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/linux/modxview.py
+++ b/volatility3/framework/plugins/linux/modxview.py
@@ -15,8 +15,8 @@ vollog = logging.getLogger(__name__)
 
 
 class Modxview(interfaces.plugins.PluginInterface):
-    """Centralize lsmod, check_modules and hidden_modules results to efficiently
-    spot modules presence and taints."""
+    """Centralize lsmod, check_modules and hidden_modules results to efficiently \
+spot modules presence and taints."""
 
     _version = (1, 0, 0)
     _required_framework_version = (2, 17, 0)

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -9,8 +9,7 @@ from volatility3.plugins.linux import pslist
 
 
 class PsTree(interfaces.plugins.PluginInterface):
-    """Plugin for listing processes in a tree based on their parent process
-    ID."""
+    """Plugin for listing processes in a tree based on their parent process ID."""
 
     _required_framework_version = (2, 13, 0)
     _version = (1, 1, 1)

--- a/volatility3/framework/plugins/mac/mount.py
+++ b/volatility3/framework/plugins/mac/mount.py
@@ -11,8 +11,8 @@ from volatility3.framework.symbols import mac
 
 
 class Mount(plugins.PluginInterface):
-    """A module containing a collection of plugins that produce data typically
-    found in Mac's mount command"""
+    """A module containing a collection of plugins that produce data typically \
+found in Mac's mount command"""
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/mac/pstree.py
+++ b/volatility3/framework/plugins/mac/pstree.py
@@ -10,8 +10,7 @@ from volatility3.plugins.mac import pslist
 
 
 class PsTree(plugins.PluginInterface):
-    """Plugin for listing processes in a tree based on their parent process
-    ID."""
+    """Plugin for listing processes in a tree based on their parent process ID."""
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -41,8 +41,8 @@ class TimeLinerInterface(metaclass=abc.ABCMeta):
 
 
 class Timeliner(interfaces.plugins.PluginInterface):
-    """Runs all relevant plugins that provide time related information and
-    orders the results by time."""
+    """Runs all relevant plugins that provide time related information and \
+orders the results by time."""
 
     _required_framework_version = (2, 0, 0)
     _version = (1, 1, 0)

--- a/volatility3/framework/plugins/windows/pstree.py
+++ b/volatility3/framework/plugins/windows/pstree.py
@@ -14,8 +14,7 @@ vollog = logging.getLogger(__name__)
 
 
 class PsTree(interfaces.plugins.PluginInterface):
-    """Plugin for listing processes in a tree based on their parent process
-    ID."""
+    """Plugin for listing processes in a tree based on their parent process ID."""
 
     _required_framework_version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/windows/psxview.py
+++ b/volatility3/framework/plugins/windows/psxview.py
@@ -21,9 +21,10 @@ vollog = logging.getLogger(__name__)
 
 
 class PsXView(plugins.PluginInterface):
-    """Lists all processes found via four of the methods described in \"The Art of Memory Forensics,\" which may help
-    identify processes that are trying to hide themselves. I recommend using -r pretty if you are looking at this
-    plugin's output in a terminal."""
+    """Lists all processes found via four of the methods described in \"The Art of Memory Forensics\" which may help \
+identify processes that are trying to hide themselves.
+
+We recommend using -r pretty if you are looking at this plugin's output in a terminal."""
 
     # I've omitted the desktop thread scanning method because Volatility3 doesn't appear to have the functionality
     # which the original plugin used to do it.

--- a/volatility3/framework/plugins/windows/registry/hivescan.py
+++ b/volatility3/framework/plugins/windows/registry/hivescan.py
@@ -12,8 +12,7 @@ from volatility3.plugins.windows import poolscanner, bigpools
 
 
 class HiveScan(interfaces.plugins.PluginInterface):
-    """Scans for registry hives present in a particular windows memory
-    image."""
+    """Scans for registry hives present in a particular windows memory image."""
 
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)

--- a/volatility3/framework/plugins/windows/scheduled_tasks.py
+++ b/volatility3/framework/plugins/windows/scheduled_tasks.py
@@ -1099,9 +1099,8 @@ class DynamicInfo:
 
 
 class ScheduledTasks(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
-    """Decodes scheduled task information from the Windows registry, including
-    information about triggers, actions, run times, and creation times.
-    """
+    """Decodes scheduled task information from the Windows registry, including \
+information about triggers, actions, run times, and creation times."""
 
     _required_framework_version = (2, 11, 0)
     _version = (1, 0, 0)


### PR DESCRIPTION
Hi,

This PR introduces a new way to provide an additional plugin description, by relying exclusively on its docstring.

The first line of the docstring will be used as the short help (`vol.py -h`), while the following lines will be printed at the bottom of the plugin full help (`vol.py myplugin -h`). This only directly impacts `windows.psxview` for now, given its current description (see the diff for more info). New result:

```sh
$ python3 vol.py windows.psxview -h         
Volatility 3 Framework 2.19.0
usage: vol.py windows.psxview.PsXView [-h] [--physical-offsets]

Lists all processes found via four of the methods described in "The Art of Memory Forensics" which may help identify processes that are trying to hide themselves.

options:
  -h, --help          show this help message and exit
  --physical-offsets  List processes with physical offsets instead of virtual offsets.

We recommend using -r pretty if you are looking at this plugin's output in a terminal.
```

Superseeds and reverts #1538. This might be worth adding this information to the plugin development guidelines, or the general coding style ?