### PR TITLE
Add mnt_parent check to kernel version validation

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1574,7 +1574,7 @@ class vfsmount(objects.StructType):
             'True' if the kernel lacks the 'mount' struct, typically indicating kernel < 3.3.
         """
 
-        return not self._context.symbol_space.has_type("mount")
+        return (not self._context.symbol_space.has_type("mount")) and self.has_member("mnt_parent")
 
     def is_equal(self, vfsmount_ptr) -> bool:
         """Helper to make sure it is comparing two pointers to 'vfsmount'.

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1574,7 +1574,9 @@ class vfsmount(objects.StructType):
             'True' if the kernel lacks the 'mount' struct, typically indicating kernel < 3.3.
         """
 
-        return (not self._context.symbol_space.has_type("mount")) and self.has_member("mnt_parent")
+        return (not self._context.symbol_space.has_type("mount")) and self.has_member(
+            "mnt_parent"
+        )
 
     def is_equal(self, vfsmount_ptr) -> bool:
         """Helper to make sure it is comparing two pointers to 'vfsmount'.


### PR DESCRIPTION
@gcmoreira I ran into the following backtrace when testing the latest develop version with the Linux updates. The code is breaking as mnt_parent isn't in the structure.

I then saw the check about this member was recently removed (changed?):

https://github.com/volatilityfoundation/volatility3/commit/74a834b6de089a0ba8cca62d9e86314996faa9fb

So I then changed to what you see in the PR and file descriptors are again returned correctly.

The kernel version for the sample is:

```
Platform: Ubuntu 22.04 LTS (Jammy Jellyfish) version 5.15.0-33-generic (buildd@lcy02-amd64-037) (gcc (Ubuntu 11.2.0-19ubuntu1) 11.2.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #34-Ubuntu SMP Wed May 18 13:34:26 UTC 2022
```

Is my PR accurate or do you want another fix?

```
Traceback (most recent call last):
  File "/home/ub/volatility3/vol.py", line 11, in <module>
    volatility3.cli.main()
  File "/home/ub/volatility3/volatility3/cli/__init__.py", line 924, in main
    CommandLine().run()
  File "/home/ub/volatility3/volatility3/cli/__init__.py", line 512, in run
    renderer.render(grid)
  File "/home/ub/volatility3/volatility3/cli/text_renderer.py", line 232, in render
    grid.populate(visitor, outfd)
  File "/home/ub/volatility3/volatility3/framework/renderers/__init__.py", line 240, in populate
    for level, item in self._generator:
  File "/home/ub/volatility3/volatility3/framework/plugins/linux/lsof.py", line 173, in _generator
    for fd_internal in self.list_fds(
  File "/home/ub/volatility3/volatility3/framework/plugins/linux/lsof.py", line 168, in list_fds
    for fd_fields in fd_generator:
  File "/home/ub/volatility3/volatility3/framework/symbols/linux/__init__.py", line 361, in files_descriptors_for_process
    full_path = LinuxUtilities.path_for_file(context, task, filp)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/symbols/linux/__init__.py", line 328, in path_for_file
    ret = LinuxUtilities._get_path_file(task, filp)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/symbols/linux/__init__.py", line 115, in _get_path_file
    return cls.do_get_path(rdentry, rmnt, dentry, vfsmnt)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/symbols/linux/__init__.py", line 175, in do_get_path
    if not vfsmnt.has_parent():
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/symbols/linux/extensions/__init__.py", line 1689, in has_parent
    return self.mnt_parent != self.vol.offset
           ^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/objects/__init__.py", line 970, in __getattr__
    raise AttributeError(
AttributeError: StructType has no attribute: symbol_table_name1!vfsmount.mnt_parent. Did you mean: 'has_parent'?
```