### PR TITLE
Fix broken socket retrieval that causes backtrace

### DIFF
--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -541,11 +541,11 @@ class Sockstat(plugins.PluginInterface):
             try:
                 sock_type = sock.get_type()
                 family = sock.get_family()
+                sock_handler = SockHandlers(vmlinux, task)
+                sock_fields = sock_handler.process_sock(sock)
             except exceptions.InvalidAddressException:
                 continue
 
-            sock_handler = SockHandlers(vmlinux, task)
-            sock_fields = sock_handler.process_sock(sock)
             if not sock_fields:
                 continue
 

--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -538,8 +538,11 @@ class Sockstat(plugins.PluginInterface):
                 continue
             sock = socket.sk.dereference()
 
-            sock_type = sock.get_type()
-            family = sock.get_family()
+            try:
+                sock_type = sock.get_type()
+                family = sock.get_family()
+            except exceptions.InvalidAddressException:
+                continue
 
             sock_handler = SockHandlers(vmlinux, task)
             sock_fields = sock_handler.process_sock(sock)


### PR DESCRIPTION
Sample: browser_mem_20231201165747_linux

```
25-01-31 19:15:33 volatility3.cli DEBUG    Traceback (most recent call last):
  File "/home/ub/volatility3/volatility3/cli/__init__.py", line 512, in run
    renderer.render(grid)
  File "/home/ub/volatility3/volatility3/cli/text_renderer.py", line 232, in render
    grid.populate(visitor, outfd)
  File "/home/ub/volatility3/volatility3/framework/renderers/__init__.py", line 240, in populate
    for level, item in self._generator:
  File "/home/ub/volatility3/volatility3/framework/plugins/linux/sockstat.py", line 604, in _generator
    for (
  File "/home/ub/volatility3/volatility3/framework/plugins/linux/sockstat.py", line 545, in list_sockets
    sock_fields = sock_handler.process_sock(sock)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/plugins/linux/sockstat.py", line 96, in process_sock
    unix_sock, sock_stat = sock_handler(sock)
                           ^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/plugins/linux/sockstat.py", line 195, in _unix_sock
    state = unix_sock.get_state()
            ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/symbols/linux/extensions/__init__.py", line 1875, in get_state
    return self.sk.sk_socket.get_state()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/symbols/linux/extensions/__init__.py", line 1825, in get_state
    socket_state_idx = self.state
                       ^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/objects/__init__.py", line 962, in __getattr__
    member = template(context=self._context, object_info=object_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/objects/templates.py", line 96, in __call__
    return self.vol.object_class(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/objects/__init__.py", line 566, in __new__
    value = base_type(context=context, object_info=object_info)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/objects/templates.py", line 96, in __call__
    return self.vol.object_class(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/objects/__init__.py", line 168, in __new__
    value = cls._unmarshall(context, data_format, object_info)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/objects/__init__.py", line 202, in _unmarshall
    data = context.layers.read(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/interfaces/layers.py", line 635, in read
    return self[layer].read(offset, length, pad)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/layers/linear.py", line 45, in read
    for offset, _, mapped_offset, mapped_length, layer in self.mapping(
  File "/home/ub/volatility3/volatility3/framework/layers/intel.py", line 326, in mapping
    for offset, size, mapped_offset, mapped_size, map_layer in self._mapping(
  File "/home/ub/volatility3/volatility3/framework/layers/intel.py", line 382, in _mapping
    chunk_offset, page_size, layer_name = self._translate(offset)
                                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/layers/intel.py", line 162, in _translate
    entry, position = self._translate_entry(offset)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/layers/intel.py", line 197, in _translate_entry
    return self._translate_page(page_address)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ub/volatility3/volatility3/framework/layers/intel.py", line 237, in _translate_page
    raise exceptions.PagedInvalidAddressException(
volatility3.framework.exceptions.PagedInvalidAddressException: Page Fault at entry 0x0 in table page directory pointer
```