### PR TITLE
Fix get_name API, fix malfind

### DIFF
--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -177,7 +177,7 @@ class Elfs(plugins.PluginInterface):
                         name,
                         format_hints.Hex(vma.vm_start),
                         format_hints.Hex(vma.vm_end),
-                        path,
+                        path or renderers.NotAvailableValue(),
                         file_output,
                     ),
                 )

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -2,7 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
-from typing import List
+from typing import List, Tuple, Optional
 import logging
 from volatility3.framework import interfaces
 from volatility3.framework import renderers, symbols
@@ -39,7 +39,7 @@ class Malfind(interfaces.plugins.PluginInterface):
             ),
         ]
 
-    def _list_injections(self, task):
+    def _list_injections(self, task) -> Tuple[interfaces.objects.ObjectInterface, Optional[str], bytes]:
         """Generate memory regions for a process that may contain injected
         code."""
 

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -56,10 +56,10 @@ class Malfind(interfaces.plugins.PluginInterface):
             )
             if (
                 vma.is_suspicious(proc_layer)
-                and vma.get_name(self.context, task) != "[vdso]"
+                and vma_name != "[vdso]"
             ):
                 data = proc_layer.read(vma.vm_start, 64, pad=True)
-                yield vma, data
+                yield vma, vma_name, data
 
     def _generator(self, tasks):
         # determine if we're on a 32 or 64 bit kernel
@@ -71,7 +71,7 @@ class Malfind(interfaces.plugins.PluginInterface):
         for task in tasks:
             process_name = utility.array_to_string(task.comm)
 
-            for vma, data in self._list_injections(task):
+            for vma, vma_name, data in self._list_injections(task):
                 if is_32bit_arch:
                     architecture = "intel"
                 else:
@@ -88,6 +88,7 @@ class Malfind(interfaces.plugins.PluginInterface):
                         process_name,
                         format_hints.Hex(vma.vm_start),
                         format_hints.Hex(vma.vm_end),
+                        vma_name or renderers.NotAvailableValue(),
                         vma.get_protection(),
                         format_hints.HexBytes(data),
                         disasm,
@@ -103,6 +104,7 @@ class Malfind(interfaces.plugins.PluginInterface):
                 ("Process", str),
                 ("Start", format_hints.Hex),
                 ("End", format_hints.Hex),
+                ("Path", str),
                 ("Protection", str),
                 ("Hexdump", format_hints.HexBytes),
                 ("Disasm", interfaces.renderers.Disassembly),

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -39,7 +39,9 @@ class Malfind(interfaces.plugins.PluginInterface):
             ),
         ]
 
-    def _list_injections(self, task) -> Tuple[interfaces.objects.ObjectInterface, Optional[str], bytes]:
+    def _list_injections(
+        self, task
+    ) -> Tuple[interfaces.objects.ObjectInterface, Optional[str], bytes]:
         """Generate memory regions for a process that may contain injected
         code."""
 

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -54,10 +54,7 @@ class Malfind(interfaces.plugins.PluginInterface):
             vollog.debug(
                 f"Injections : processing PID {task.pid} : VMA {vma_name} : {hex(vma.vm_start)}-{hex(vma.vm_end)}"
             )
-            if (
-                vma.is_suspicious(proc_layer)
-                and vma_name != "[vdso]"
-            ):
+            if vma.is_suspicious(proc_layer) and vma_name != "[vdso]":
                 data = proc_layer.read(vma.vm_start, 64, pad=True)
                 yield vma, vma_name, data
 

--- a/volatility3/framework/plugins/linux/proc.py
+++ b/volatility3/framework/plugins/linux/proc.py
@@ -246,7 +246,7 @@ class Maps(plugins.PluginInterface):
                         major,
                         minor,
                         inode_num,
-                        path,
+                        path or renderers.NotAvailableValue(),
                         file_output,
                     ),
                 )

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1056,7 +1056,7 @@ class vm_area_struct(objects.StructType):
         parent_layer = self._context.layers[self.vol.layer_name]
         return self.vm_pgoff << parent_layer.page_shift
 
-    def get_name(self, context, task):
+    def _do_get_name(self, context, task) -> str:
         if self.vm_file != 0:
             fname = linux.LinuxUtilities.path_for_file(context, task, self.vm_file)
         elif self.vm_start <= task.mm.start_brk and self.vm_end >= task.mm.brk:
@@ -1071,6 +1071,12 @@ class vm_area_struct(objects.StructType):
         else:
             fname = "Anonymous Mapping"
         return fname
+
+    def get_name(self, context, task) -> Optional[str]:
+        try:
+            return self._do_get_name(context, task)
+        except exceptions.InvalidAddressException:
+            return None
 
     # used by malfind
     def is_suspicious(self, proclayer=None):


### PR DESCRIPTION
The `get_name` API of vm_area_struct instances could (and did in testing) throw invalid address exception, which doesn't match how other `get_*` APIs work and really defeats the purpose of them.  So I fixed the API to properly return None on these errors and updated the typing to reflect that (it was missing before). I also changed the callers of this API to properly display a renderer value when the name isn't found.

malfind for vol3 was also strange in that it didn't show the path of code injection regions, which is a key artifact. Given that malfind uses `get_name`, I added the path fixes for it in along with its API fixing.

Sample: ggmemday1