### PR TITLE
Windows: Handles - catch exception in handle iteration

### DIFF
--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -243,7 +243,12 @@ class Handles(interfaces.plugins.PluginInterface):
         layer_object = self.context.layers[virtual]
         masked_offset = offset & layer_object.maximum_address
 
-        for entry in table:
+        for i in range(len(table)):
+            try:
+                entry = table[i]
+            except exceptions.InvalidAddressException:
+                vollog.debug(f"Failed to get handle table entry at index {i}")
+                continue
             # This triggered a backtrace in many testing samples
             # in the level == 0 path
             # The code above this calls `is_valid` on the `offset`


### PR DESCRIPTION
An `InvalidAddressException` can occur inside of `__iter__` when
iterating over the handle table (the exact exception occurs when
creating the subtype in `objects.Array.__getitem__`. This changes the
handle code to do a manual iteration over the sequence using the array
length and indexes, catch the exception, log the index, and continue.

In the test sample that prompted this change, the exception occurred on
the access of the very last item in the array.

closes #1573
