### PR TITLE
Make a generic DLL enumeration function that ensures the base address…

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -491,9 +491,9 @@ class FILE_OBJECT(objects.StructType, pool.ExecutiveObject):
         ].is_valid(self.FileName.Buffer)
 
     def file_name_with_device(self) -> Union[str, interfaces.renderers.BaseAbsentValue]:
-        name: Union[
-            str, interfaces.renderers.BaseAbsentValue
-        ] = renderers.UnreadableValue()
+        name: Union[str, interfaces.renderers.BaseAbsentValue] = (
+            renderers.UnreadableValue()
+        )
 
         # this pointer needs to be checked against native_layer_name because the object may
         # be instantiated from a primary (virtual) layer or a memory (physical) layer.


### PR DESCRIPTION
… is set and we return as many entries as possible #1475

This PR performs two major updates:

1) The previous code widely caught an invalid address exception, stopping processing early. This patch makes the try/except more granular so we recover much more entries

2) The previous code returned entries right on the edge of pages, so accessing a required member (DllBase) would then cause a backtrace. This broke ldrmodules in mass testing. We no longer return broken/useless entries.

Closes #1475 