### PR TITLE
Switch virtual and physical addresses to lists to support dumping mul…

### DIFF
--- a/volatility3/framework/plugins/windows/dumpfiles.py
+++ b/volatility3/framework/plugins/windows/dumpfiles.py
@@ -322,17 +322,19 @@ class DumpFiles(interfaces.plugins.PluginInterface):
         elif offsets:
             virtual_layer_name = kernel.layer_name
 
-            #FIXME - change this after standard access to physical layer
+            # FIXME - change this after standard access to physical layer
             physical_layer_name = self.context.layers[virtual_layer_name].config[
                 "memory_layer"
             ]
 
-           # Now process any offsets explicitly requested by the user.
+            # Now process any offsets explicitly requested by the user.
             for offset, is_virtual in offsets:
                 try:
                     file_obj = self.context.object(
                         kernel.symbol_table_name + constants.BANG + "_FILE_OBJECT",
-                        layer_name=virtual_layer_name if is_virtual else physical_layer_name,
+                        layer_name=(
+                            virtual_layer_name if is_virtual else physical_layer_name
+                        ),
                         native_layer_name=virtual_layer_name,
                         offset=offset,
                     )

--- a/volatility3/framework/plugins/windows/dumpfiles.py
+++ b/volatility3/framework/plugins/windows/dumpfiles.py
@@ -44,13 +44,15 @@ class DumpFiles(interfaces.plugins.PluginInterface):
                 description="Process ID to include (all other processes are excluded)",
                 optional=True,
             ),
-            requirements.IntRequirement(
+            requirements.ListRequirement(
                 name="virtaddr",
+                element_type=int,
                 description="Dump a single _FILE_OBJECT at this virtual address",
                 optional=True,
             ),
-            requirements.IntRequirement(
+            requirements.ListRequirement(
                 name="physaddr",
+                element_type=int,
                 description="Dump a single _FILE_OBJECT at this physical address",
                 optional=True,
             ),
@@ -318,6 +320,7 @@ class DumpFiles(interfaces.plugins.PluginInterface):
                         )
 
         elif offsets:
+
             # Now process any offsets explicitly requested by the user.
             for offset, is_virtual in offsets:
                 try:
@@ -355,10 +358,14 @@ class DumpFiles(interfaces.plugins.PluginInterface):
         ):
             raise ValueError("Cannot use filter flag with an address flag")
 
-        if self.config.get("virtaddr", None) is not None:
-            offsets.append((self.config["virtaddr"], True))
-        elif self.config.get("physaddr", None) is not None:
-            offsets.append((self.config["physaddr"], False))
+        if self.config.get("virtaddr"):
+            for virtaddr in self.config["virtaddr"]:
+                offsets.append((virtaddr, True))
+
+        elif self.config.get("physaddr"):
+            for physaddr in self.config["physaddr"]:
+                offsets.append((physaddr, False))
+
         else:
             filter_func = pslist.PsList.create_pid_filter(
                 [self.config.get("pid", None)]


### PR DESCRIPTION
…tiple files at once #1319

Closes #1319 

Dumpfiles only accepted one addresses at a time, which is really painful from a usability perspective. This switches it to accepting lists.

I tested this on old and new Windows version samples to test the virtual and physical list support.