### PR TITLE
Prevent yielding smeared/broken modules from the unloaded module list

### DIFF
--- a/volatility3/framework/plugins/windows/unloadedmodules.py
+++ b/volatility3/framework/plugins/windows/unloadedmodules.py
@@ -117,7 +117,18 @@ class UnloadedModules(interfaces.plugins.PluginInterface, timeliner.TimeLinerInt
         )
         unloadedmodules_array.UnloadedDrivers.count = unloaded_count
 
-        yield from unloadedmodules_array.UnloadedDrivers
+        for driver in unloadedmodules_array.UnloadedDrivers:
+            # Mass testing led to dozens of samples backtracing on this plugin when
+            # accessing members of modules coming out this list
+            # Given how often temporary drivers load and unload on Win10+, I
+            # assume the chance for smear is very high
+            try:
+                driver.StartAddress
+                driver.EndAddress
+                driver.CurrentTime
+                yield driver
+            except exceptions.InvalidAddressException:
+                continue
 
     def _generator(self):
         kernel = self.context.modules[self.config["kernel"]]


### PR DESCRIPTION
Dozens of memory samples crashed in testing from smeared/broken module entries being yielded from the list. We now ensure the three relevant members are valid before yielding a driver instance.