### PR TITLE
New plugin: linux.pagecache.recoverfs

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,7 +1,7 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 20  # Number of changes that only add to the interface
-VERSION_PATCH = 1  # Number of changes that do not change the interface
+VERSION_MINOR = 21  # Number of changes that only add to the interface
+VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 PACKAGE_VERSION = (

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -633,7 +633,8 @@ class InodePages(plugins.PluginInterface):
 class RecoverFs(plugins.PluginInterface):
     """Recovers the cached filesystem (directories, files, symlinks) into a compressed tarball.
 
-    Details: level 0 directories are named after the UUID of the parent superblock; metadata aren't replicated to extracted objects; objects modification time is set to the plugin run time.
+    Details: level 0 directories are named after the UUID of the parent superblock; metadata aren't replicated to extracted objects; objects modification time is set to the plugin run time; absolute symlinks
+    are converted to relative symlinks to prevent referencing the analyst filesystem.
     Troubleshooting: to fix extraction errors related to long paths, please consider using https://github.com/mxmlnkn/ratarmount.
     """
 

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -774,7 +774,7 @@ class RecoverFs(plugins.PluginInterface):
             follow_symlinks=False,
         )
 
-        # Prefix paths by the super_block uuid's to prevent overlaps.
+        # Prefix paths with the superblock UUID's to prevent overlaps.
         # Switch to device major and device minor for older kernels (< 2.6.39-rc1).
         uuid_as_prefix = vmlinux.get_type("super_block").has_member("s_uuid")
         if not uuid_as_prefix:

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -663,9 +663,8 @@ class RecoverFs(plugins.PluginInterface):
             ),
         ]
 
-    @classmethod
     def _tar_add_reg_inode(
-        cls,
+        self,
         context: interfaces.context.ContextInterface,
         layer_name: str,
         tar: tarfile.TarFile,
@@ -705,9 +704,8 @@ class RecoverFs(plugins.PluginInterface):
 
         return handle_buffer_size
 
-    @classmethod
     def _tar_add_dir(
-        cls,
+        self,
         tar: tarfile.TarFile,
         directory_path: str,
         mtime: float = None,
@@ -726,9 +724,8 @@ class RecoverFs(plugins.PluginInterface):
             tar_info.mtime = mtime
         tar.addfile(tar_info)
 
-    @classmethod
     def _tar_add_lnk(
-        cls,
+        self,
         tar: tarfile.TarFile,
         symlink_source: str,
         symlink_dest: str,

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -635,7 +635,7 @@ class RecoverFs(plugins.PluginInterface):
     """Recovers the cached filesystem (directories, files, symlinks) into a compressed tarball.
 
     Details: level 0 directories are named after the UUID of the parent superblock; metadata aren't replicated to extracted objects; objects modification time is set to the plugin run time; absolute symlinks
-    are converted to relative symlinks to prevent referencing the analyst filesystem.
+    are converted to relative symlinks to prevent referencing the analyst's filesystem.
     Troubleshooting: to fix extraction errors related to long paths, please consider using https://github.com/mxmlnkn/ratarmount.
     """
 
@@ -793,7 +793,7 @@ class RecoverFs(plugins.PluginInterface):
 
             # Code is slightly duplicated here with the if-block below.
             # However this prevents unneeded tar manipulation if fifo
-            # or sock inodes comes through for example.
+            # or sock inodes come through for example.
             if not (
                 inode_in.inode.is_reg or inode_in.inode.is_dir or inode_in.inode.is_link
             ):

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -638,7 +638,7 @@ class RecoverFs(plugins.PluginInterface):
     """
 
     _version = (1, 0, 0)
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 21, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1057,11 +1057,11 @@ class super_block(objects.StructType):
         SB_LAZYTIME: "lazytime",
     }
 
-    @property
+    @functools.cached_property
     def major(self) -> int:
         return self.s_dev >> self.MINORBITS
 
-    @property
+    @functools.cached_property
     def minor(self) -> int:
         return self.s_dev & ((1 << self.MINORBITS) - 1)
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -10,6 +10,7 @@ import binascii
 import stat
 import datetime
 import socket as socket_module
+import uuid
 from typing import (
     Generator,
     Iterable,
@@ -1064,6 +1065,20 @@ class super_block(objects.StructType):
     @functools.cached_property
     def minor(self) -> int:
         return self.s_dev & ((1 << self.MINORBITS) - 1)
+
+    @functools.cached_property
+    def uuid(self) -> str:
+        if not self.has_member("s_uuid"):
+            raise AttributeError(
+                "super_block struct does not support s_uuid direct attribute access, probably indicating a kernel version < 2.6.39-rc1."
+            )
+
+        if self.s_uuid.has_member("b"):
+            uuid_as_ints = self.s_uuid.b
+        else:
+            uuid_as_ints = self.s_uuid
+
+        return str(uuid.UUID(bytes=bytes(uuid_as_ints)))
 
     def get_flags_access(self) -> str:
         return "ro" if self.s_flags & self.SB_RDONLY else "rw"


### PR DESCRIPTION
Hi,

This new plugin is a port and improvement over Volatility2's `linux_recover_filesystem` plugin, that allows to automatically extract and save the cached filesystem.

Here, it relies on a tarball instead of writing directly to the host filesystem. Doing so, Volatility3 is exempt from handling long filename errors, or "no disk space left" halfway to the end. It is also OS-agnostic, and more IO efficient as it isn't writing to disk constantly. Columns are the same as `linux.pagecache.files`, with the addition of `Recovered FileSize` at the very end:

```sh
$ python3 vol.py -f sample.bin -r pretty -o test_out/ linux.pagecache.RecoverFs > files.txt
$ cat files.txt
  | SuperblockAddr |               MountPoint | Device |   InodeNum |      InodeAddr | FileType |  InodePages | CachedPages |   FileMode |                     AccessTime |               ModificationTime |                     ChangeTime |                                                                                                                                                                         FilePath |       InodeSize | Recovered FileSize
* | 0x89388c64c800 |                        / |    8:1 |       1240 | 0x893884df0118 |      DIR |           1 |           0 | drwxr-xr-x | 2024-11-15 12:40:54.112001 UTC | 2021-07-12 10:56:03.000000 UTC | 2024-10-02 14:36:01.560177 UTC |                                                                                                                                               /etc/networkd-dispatcher/carrier.d |            4096 |                N/A
* | 0x89388c64c800 |                        / |    8:1 |        515 | 0x893884d38ee0 |      REG |           1 |           1 | -rw-r--r-- | 2024-11-15 12:40:54.668001 UTC | 2022-02-03 05:27:54.000000 UTC | 2024-10-02 14:36:01.521177 UTC |                                                                                                                                                                    /etc/gai.conf |            2584 |               2584
* | 0x89388c64c800 |                        / |    8:1 |       1304 | 0x89388ce78ee0 |      LNK |           1 |           0 | lrwxrwxrwx | 2024-11-15 12:40:54.348001 UTC | 2024-10-02 14:31:56.313182 UTC | 2024-10-02 14:36:01.564177 UTC |                                                                                                                                            /etc/vtrgb -> /etc/alternatives/vtrgb |              23 |                N/A
* | 0x89388c64c800 |                        / |    8:1 |        270 | 0x89388ce7a5d8 |      DIR |           1 |           0 | drwxr-xr-x | 2024-11-15 12:40:53.632001 UTC | 2024-10-02 14:32:21.095297 UTC | 2024-10-02 14:36:01.511177 UTC |                                                                                                                                                                      /etc/cron.d |            4096 |                N/A
* | 0x89388c64c800 |                        / |    8:1 |        271 | 0x893884d273f0 |      REG |           1 |           1 | -rw-r--r-- | 2024-11-15 12:40:53.636001 UTC | 2022-01-08 20:02:36.000000 UTC | 2024-10-02 14:36:01.511177 UTC |                                                                                                                                                          /etc/cron.d/e2scrub_all |             201 |                201
$ ls -l test_out/                
total 64992
-rw------- 1 forensics forensics 61621704 Feb 10 11:32 recovered_fs.tar.gz
```

The files don't even have to be extracted from the generated tarball, as one can leverage the `ratarmount` tool to mount the tarball locally:

```sh
$ ratarmount recovered_fs.tar.gz ./recovered_fs_mounted/
$ ls -l                     
total 64993
drwxrwxrwx 1 forensics forensics        0 Feb 10 11:39 recovered_fs_mounted
-rw------- 1 forensics forensics 61621704 Feb 10 11:32 recovered_fs.tar.gz
-rw-r--r-- 1 forensics forensics  4923392 Feb 10 11:37 recovered_fs.tar.gz.index.sqlite
$ ls -l recovered_fs_mounted/
total 10
# Notice that symlinks are patched:
lr--r--r-- 1 root root 0 Feb 10 11:30 bin -> usr/bin
drwxr-xr-x 1 root root 0 Feb 10 11:30 boot
drwxr-xr-x 1 root root 0 Feb 10 11:30 dev
drwxr-xr-x 1 root root 0 Feb 10 11:30 etc
# Inspect a recovered file content
$ cat recovered_fs_mounted/etc/issue   
Ubuntu 22.04.5 LTS \n \l

```

I hope that makes sense !

Closes #1468.