### PR TITLE
Windows Cmdline: Clean up output

### DIFF
--- a/volatility3/framework/plugins/windows/cmdline.py
+++ b/volatility3/framework/plugins/windows/cmdline.py
@@ -70,6 +70,7 @@ class CmdLine(interfaces.plugins.PluginInterface):
         for proc in procs:
             process_name = utility.array_to_string(proc.ImageFileName)
             proc_id = "Unknown"
+            result_text = None
 
             try:
                 proc_id = proc.UniqueProcessId
@@ -78,13 +79,22 @@ class CmdLine(interfaces.plugins.PluginInterface):
                 )
 
             except exceptions.SwappedInvalidAddressException as exp:
-                result_text = f"Required memory at {exp.invalid_address:#x} is inaccessible (swapped)"
+                vollog.debug(
+                    f"Required memory at {exp.invalid_address:#x} is inaccessible (swapped)"
+                )
 
             except exceptions.PagedInvalidAddressException as exp:
-                result_text = f"Required memory at {exp.invalid_address:#x} is not valid (process exited?)"
+                vollog.debug(
+                    f"Required memory at {exp.invalid_address:#x} is not valid (process exited?)"
+                )
 
             except exceptions.InvalidAddressException as exp:
-                result_text = f"Process {proc_id}: Required memory at {exp.invalid_address:#x} is not valid (incomplete layer {exp.layer_name}?)"
+                vollog.debug(
+                    f"Process {proc_id}: Required memory at {exp.invalid_address:#x} is not valid (incomplete layer {exp.layer_name}?)"
+                )
+
+            if not result_text:
+                result_text = renderers.UnreadableValue()
 
             yield (0, (proc.UniqueProcessId, process_name, result_text))
 


### PR DESCRIPTION
The strings being used as return values here would (IMO) be better as debug statements, with the plugin returning `renderers.UnreadableValue()` for any of the `InvalidAddressException` code paths.
