### PR TITLE
Windows Envars: Remove extra config check

### DIFF
--- a/volatility3/framework/plugins/windows/envars.py
+++ b/volatility3/framework/plugins/windows/envars.py
@@ -200,15 +200,13 @@ class Envars(interfaces.plugins.PluginInterface):
         return values
 
     def _generator(self, data):
-        silent_vars = []
-        if self.config.get("SILENT", None):
-            silent_vars = self._get_silent_vars()
+        silent_vars = self._get_silent_vars() if self.config.get("SILENT") else []
 
         for task in data:
             for var, val in task.environment_variables():
-                if self.config.get("silent", None):
-                    if var in silent_vars:
-                        continue
+                if var in silent_vars:
+                    continue
+
                 yield (
                     0,
                     (


### PR DESCRIPTION
Tiny bit of cleanup here - there's no need to re-check the config for `SILENT` for each variable. We can just initialize it once as either an empty list or the calculated list of silent vars depending on the config value.
