### PR TITLE
Windows: Fix console potentially unbound variables

### DIFF
--- a/volatility3/framework/plugins/windows/consoles.py
+++ b/volatility3/framework/plugins/windows/consoles.py
@@ -7,7 +7,7 @@
 import logging
 import os
 import struct
-from typing import Tuple, Optional, Generator, Set, Dict, Any, Type
+from typing import Tuple, Optional, Generator, Set, Dict, Any, Type, List
 
 from volatility3.framework import interfaces, symbols, exceptions
 from volatility3.framework import renderers
@@ -372,7 +372,7 @@ class Consoles(interfaces.plugins.PluginInterface):
         Tuple[
             interfaces.objects.ObjectInterface,
             Optional[interfaces.objects.ObjectInterface],
-            list[Any],
+            List[Any],
         ],
         None,
         None,

--- a/volatility3/framework/plugins/windows/consoles.py
+++ b/volatility3/framework/plugins/windows/consoles.py
@@ -7,7 +7,7 @@
 import logging
 import os
 import struct
-from typing import Tuple, Generator, Set, Dict, Any, Type
+from typing import Tuple, Optional, Generator, Set, Dict, Any, Type
 
 from volatility3.framework import interfaces, symbols, exceptions
 from volatility3.framework import renderers
@@ -74,7 +74,7 @@ class Consoles(interfaces.plugins.PluginInterface):
     @classmethod
     def find_conhost_proc(
         cls, proc_list: Generator[interfaces.objects.ObjectInterface, None, None]
-    ) -> Tuple[interfaces.context.ContextInterface, str]:
+    ) -> Generator[Tuple[interfaces.objects.ObjectInterface, str], None, None]:
         """
         Walks the process list and returns the conhost instances.
 
@@ -87,6 +87,7 @@ class Consoles(interfaces.plugins.PluginInterface):
 
         for proc in proc_list:
             if utility.array_to_string(proc.ImageFileName).lower() == "conhost.exe":
+                proc_id = "Unknown"
                 try:
                     proc_id = proc.UniqueProcessId
                     proc_layer_name = proc.add_process_layer()
@@ -100,8 +101,8 @@ class Consoles(interfaces.plugins.PluginInterface):
 
     @classmethod
     def find_conhostexe(
-        cls, conhost_proc: interfaces.context.ContextInterface
-    ) -> Tuple[int, int]:
+        cls, conhost_proc: interfaces.objects.ObjectInterface
+    ) -> Tuple[Optional[int], Optional[int]]:
         """
         Finds the base address of conhost.exe
 
@@ -130,7 +131,7 @@ class Consoles(interfaces.plugins.PluginInterface):
         config_path: str,
         conhost_layer_name: str,
         conhost_base: int,
-    ) -> Tuple[str, Type]:
+    ) -> Tuple[Optional[str], Dict[str, Type]]:
         """Tries to determine which symbol filename to use for the image's console information. This is similar to the
         netstat plugin.
 
@@ -341,6 +342,11 @@ class Consoles(interfaces.plugins.PluginInterface):
             conhost_base,
         )
 
+        if symbol_filename is None:
+            raise ValueError(
+                "Symbol filename could not be determined for conhost version"
+            )
+
         vollog.debug(f"Using symbol file '{symbol_filename}' and types {class_types}")
 
         return intermed.IntermediateSymbolTable.create(
@@ -362,10 +368,14 @@ class Consoles(interfaces.plugins.PluginInterface):
         procs: Generator[interfaces.objects.ObjectInterface, None, None],
         max_history: Set[int],
         max_buffers: Set[int],
-    ) -> Tuple[
-        interfaces.context.ContextInterface,
-        interfaces.context.ContextInterface,
-        Dict[str, Any],
+    ) -> Generator[
+        Tuple[
+            interfaces.objects.ObjectInterface,
+            Optional[interfaces.objects.ObjectInterface],
+            list[Any],
+        ],
+        None,
+        None,
     ]:
         """Gets the Console Information structure and its related properties for each conhost process
 
@@ -401,6 +411,11 @@ class Consoles(interfaces.plugins.PluginInterface):
                     "Unable to find the location of conhost.exe. Analysis cannot proceed."
                 )
                 continue
+            if conhostexe_size is None:
+                vollog.info(
+                    "Unable to determine the size of conhost.exe.  Analysis cannot proceed."
+                )
+                continue
             vollog.debug(f"Found conhost.exe base at {conhostexe_base:#x}")
 
             proc_layer = context.layers[proc_layer_name]
@@ -420,6 +435,7 @@ class Consoles(interfaces.plugins.PluginInterface):
             )
 
             found_console_info_for_proc = False
+            console_info = None
             # scan for potential _CONSOLE_INFORMATION structures by using the CommandHistorySize
             for max_history_value in max_history:
                 max_history_bytes = struct.pack("H", max_history_value)
@@ -431,7 +447,7 @@ class Consoles(interfaces.plugins.PluginInterface):
                     scanners.BytesScanner(max_history_bytes),
                     sections=[(conhostexe_base, conhostexe_size)],
                 ):
-
+                    console_info = None
                     console_properties = []
 
                     try:


### PR DESCRIPTION
Fixes #1435.

This fixes a number of typing issues and resolves the unbound variables (potentially breaking early on failure to determine a `symbol_filename`.

There were a number of places where ContextInterface was used instead of ObjectInterface.  I presume this was a copy pasta issue as the starting variable, but I'd appreciate someone checking that my changes look good.