### PR TITLE
windows.threads - fix pid argument

### DIFF
--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -74,8 +74,9 @@ class Threads(thrdscan.ThrdScan):
         layer_name = module.layer_name
         symbol_table_name = module.symbol_table_name
 
-        filter_func = pslist.PsList.create_pid_filter(context.config.get("pid", None))
-
+        pid_arg = interfaces.configuration.path_join("plugins", "Threads", "pid")
+        filter_func = pslist.PsList.create_pid_filter(context.config.get(pid_arg), None)
+        
         for proc in pslist.PsList.list_processes(
             context=context,
             layer_name=layer_name,


### PR DESCRIPTION
Hello,

I found a small issue in the `windows.threads` plugin where it would not correctly grab the `pid` argument.

In `list_process_threads()`, the `pid` argument is passed through the `context` parameter and exists under `plugins.Thread.pid` instead of just `pid` as usual.

Printing `self.config` from `__init__()` will reveal it under the `pid` key as normal, but due to the inheritance, in the `list_process_threads()` it appears under the key mentioned above:

```
[...]
"plugins.Threads.kernel.symbol_table_name.symbol_mask": 0,
"plugins.Threads.pid": [
    4988
],
"plugins.Threads.thrdscan": false,
[...]
```

I don't know if this is the correct way to solve this, but I figured I would post this for future reference if somebody comes across it.
