### PR TITLE
Issues/issue1629

### DIFF
--- a/volatility3/framework/plugins/windows/debugregisters.py
+++ b/volatility3/framework/plugins/windows/debugregisters.py
@@ -24,7 +24,7 @@ vollog = logging.getLogger(__name__)
 class DebugRegisters(interfaces.plugins.PluginInterface):
     # version 2.6.0 adds support for scanning for 'Ethread' structures by pool tags
     _required_framework_version = (2, 6, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List:
@@ -36,6 +36,9 @@ class DebugRegisters(interfaces.plugins.PluginInterface):
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(2, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="threads", component=threads.Threads, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="pe_symbols", component=pe_symbols.PESymbols, version=(1, 0, 0)

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -31,12 +31,6 @@ class Threads(thrdscan.ThrdScan):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.ListRequirement(
-                name="pid",
-                description="Filter on specific process IDs",
-                element_type=int,
-                optional=True,
-            ),
             requirements.PluginRequirement(
                 name="thrdscan", plugin=thrdscan.ThrdScan, version=(1, 1, 0)
             ),
@@ -74,12 +68,10 @@ class Threads(thrdscan.ThrdScan):
         layer_name = module.layer_name
         symbol_table_name = module.symbol_table_name
 
-        filter_func = pslist.PsList.create_pid_filter(context.config.get("pid", None))
-
         for proc in pslist.PsList.list_processes(
             context=context,
             layer_name=layer_name,
             symbol_table=symbol_table_name,
-            filter_func=filter_func,
+            filter_func=None,
         ):
             yield from cls.list_threads(module, proc)

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -16,7 +16,7 @@ class Threads(thrdscan.ThrdScan):
     """Lists process threads"""
 
     _required_framework_version = (2, 4, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -59,9 +59,7 @@ class Threads(thrdscan.ThrdScan):
 
     @classmethod
     def list_process_threads(
-        cls,
-        context: interfaces.context.ContextInterface,
-        module_name: str,
+        cls, context: interfaces.context.ContextInterface, module_name: str
     ) -> Iterable[interfaces.objects.ObjectInterface]:
         """Runs through all processes and lists threads for each process"""
         module = context.modules[module_name]
@@ -72,6 +70,5 @@ class Threads(thrdscan.ThrdScan):
             context=context,
             layer_name=layer_name,
             symbol_table=symbol_table_name,
-            filter_func=None,
         ):
             yield from cls.list_threads(module, proc)


### PR DESCRIPTION
Removes the pids option from threads plugin (and adds the missing dependency on debugregisters).

Closes #1629 