### PR TITLE
Issues/issue1408 - Delete partial cache downloads

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -120,6 +120,9 @@ OFFLINE = False
 REMOTE_ISF_URL = None  # 'http://localhost:8000/banners.json'
 """Remote URL to query for a list of ISF addresses"""
 
+DOWNLOAD_TIMEOUT = 30
+"""Length of time (in seconds) to wait for another process to download a resource before using it"""
+
 ###
 # DEPRECATED VALUES
 ###

--- a/volatility3/framework/layers/resources.py
+++ b/volatility3/framework/layers/resources.py
@@ -178,42 +178,39 @@ class ResourceAccessor:
                     + ".cache",
                 )
 
+                try:
+                    content_length = int(fp.info().get("Content-Length", -1))
+                except (AttributeError, ValueError):
+                    # If our fp doesn't have an info member, carry on gracefully
+                    content_length = -1
+
                 if not os.path.exists(temp_filename):
                     vollog.debug(f"Caching file at: {temp_filename}")
+                    cache_file_size = -1
 
                     try:
-                        content_length = fp.info().get("Content-Length", -1)
-                    except AttributeError:
-                        # If our fp doesn't have an info member, carry on gracefully
-                        content_length = -1
-                    with open(temp_filename, "wb") as cache_file:
-                        count = 0
-                        block = fp.read(block_size)
-                        while block:
-                            count += len(block)
-                            if self._progress_callback:
-                                self._progress_callback(
-                                    count * 100 / max(count, int(content_length)),
-                                    f"Reading file {url}",
-                                )
-                            cache_file.write(block)
+                        with open(temp_filename, "wb") as cache_file:
+                            count = 0
                             block = fp.read(block_size)
+                            while block:
+                                count += len(block)
+                                if self._progress_callback:
+                                    self._progress_callback(
+                                        count * 100 / max(count, int(content_length)),
+                                        f"Reading file {url}",
+                                    )
+                                cache_file.write(block)
+                                block = fp.read(block_size)
+                            cache_file.seek(0, os.SEEK_END)
+                            cache_file_size = cache_file.tell()
+                    finally:
+                        if cache_file_size < content_length:
+                            os.remove(temp_filename)
+                            raise ValueError("Cached file did not download completely")
                 else:
                     vollog.debug(
                         f"Trying to use already cached file at: {temp_filename}"
                     )
-                    count = 0
-                    fp.seek(0, os.SEEK_END)
-                    expected_filesize = fp.tell()
-                    stop = False
-                    while count < constants.DOWNLAOD_TIMEOUT and not stop:
-                        time.sleep(1)
-                        if os.stat(temp_filename).st_size == expected_filesize:
-                            stop = True
-                    if not stop:
-                        raise ValueError(
-                            f"Cached file existed, but was not the correct filesize, even after {constants.DOWNLOAD_TIMEOUT} seconds"
-                        )
 
                 # Re-open the cache with a different mode
                 # Since we don't want people thinking they're able to save to the cache file,

--- a/volatility3/framework/layers/resources.py
+++ b/volatility3/framework/layers/resources.py
@@ -204,6 +204,8 @@ class ResourceAccessor:
                 # open it in read mode only and allow breakages to happen if they wanted to write
                 curfile = open(temp_filename, mode="rb")
 
+        # Validate the hash or delete the temp_filename and report an error
+
         # Determine whether the file is a particular type of file, and if so, open it as such
         IMPORTED_MAGIC = False
         if HAS_MAGIC:

--- a/volatility3/framework/layers/resources.py
+++ b/volatility3/framework/layers/resources.py
@@ -2,7 +2,6 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
-import time
 import bz2
 import contextlib
 import gzip


### PR DESCRIPTION
This should ensure partial downloads are deleted rather than causing future failures.

Caveats:
 * We don't try to continue partial downloads
 * If the server being downloaded from doesn't respond with the content-length field, the file is always cached
 * This does nothing to prevent bad files living in the cache, since the framework is effectively unaware of the caching and the caching is unaware of the filetype, there isn't easily a way to delete the cached file, if it's found (by the framework) to be invalid.

So this is a stop-gap that should alleviate the primary symptoms, but still isn't ideal by a fair way.  Ideally someone would sit and work through the opener and rewrite it (so that automatic decompression and caching all still work correctly, but with better control over intermediate files).