### PR TITLE
Check Win10+ SlushSize member to support Windows 11 pool scanning. Re…

### DIFF
--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -205,6 +205,7 @@ class PoolScanner(plugins.PluginInterface):
                 b"AtmT",
                 type_name=symbol_table + constants.BANG + "_RTL_ATOM_TABLE",
                 size=(200, None),
+                # TODO - update this after the GUI code goes on
                 page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
             ),
             # processes on windows before windows 8
@@ -214,7 +215,7 @@ class PoolScanner(plugins.PluginInterface):
                 object_type="Process",
                 size=(600, None),
                 skip_type_test=True,
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # processes on windows starting with windows 8
             PoolConstraint(
@@ -223,7 +224,7 @@ class PoolScanner(plugins.PluginInterface):
                 object_type="Process",
                 size=(600, None),
                 skip_type_test=True,
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # threads on windows before windows8
             PoolConstraint(
@@ -232,7 +233,7 @@ class PoolScanner(plugins.PluginInterface):
                 object_type="Thread",
                 size=(600, None),  # -> 0x0258 - size of struct in win5.1
                 skip_type_test=True,
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # threads on windows starting with windows8
             PoolConstraint(
@@ -240,7 +241,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_ETHREAD",
                 object_type="Thread",
                 size=(600, None),  # -> 0x0258 - size of struct in win5.1
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # files on windows before windows 8
             PoolConstraint(
@@ -248,7 +249,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_FILE_OBJECT",
                 object_type="File",
                 size=(150, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # files on windows starting with windows 8
             PoolConstraint(
@@ -256,7 +257,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_FILE_OBJECT",
                 object_type="File",
                 size=(150, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # mutants on windows before windows 8
             PoolConstraint(
@@ -264,7 +265,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_KMUTANT",
                 object_type="Mutant",
                 size=(64, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # mutants on windows starting with windows 8
             PoolConstraint(
@@ -272,7 +273,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_KMUTANT",
                 object_type="Mutant",
                 size=(64, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # drivers on windows before windows 8
             PoolConstraint(
@@ -280,7 +281,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_DRIVER_OBJECT",
                 object_type="Driver",
                 size=(248, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
                 additional_structures=["_DRIVER_EXTENSION"],
             ),
             # drivers on windows starting with windows 8
@@ -289,14 +290,14 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_DRIVER_OBJECT",
                 object_type="Driver",
                 size=(248, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # kernel modules
             PoolConstraint(
                 b"MmLd",
                 type_name=symbol_table + constants.BANG + "_LDR_DATA_TABLE_ENTRY",
                 size=(76, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # symlinks on windows before windows 8
             PoolConstraint(
@@ -304,7 +305,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_OBJECT_SYMBOLIC_LINK",
                 object_type="SymbolicLink",
                 size=(72, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # symlinks on windows starting with windows 8
             PoolConstraint(
@@ -312,14 +313,14 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_OBJECT_SYMBOLIC_LINK",
                 object_type="SymbolicLink",
                 size=(72, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.NONPAGED | PoolType.FREE,
             ),
             # registry hives
             PoolConstraint(
                 b"CM10",
                 type_name=symbol_table + constants.BANG + "_CMHIVE",
                 size=(800, None),
-                page_type=PoolType.PAGED | PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.PAGED | PoolType.FREE,
                 skip_type_test=True,
             ),
         ]

--- a/volatility3/framework/symbols/windows/__init__.py
+++ b/volatility3/framework/symbols/windows/__init__.py
@@ -48,7 +48,9 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
 
         # This doesn't exist in very specific versions of windows
         with contextlib.suppress(ValueError):
-            if self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("PoolType") or self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("SlushSize"):
+            if self.get_type("_POOL_TRACKER_BIG_PAGES").has_member(
+                "PoolType"
+            ) or self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("SlushSize"):
                 self.set_type_class("_POOL_HEADER", pool.POOL_HEADER_VISTA)
             else:
                 self.set_type_class("_POOL_HEADER", pool.POOL_HEADER)

--- a/volatility3/framework/symbols/windows/__init__.py
+++ b/volatility3/framework/symbols/windows/__init__.py
@@ -48,7 +48,7 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
 
         # This doesn't exist in very specific versions of windows
         with contextlib.suppress(ValueError):
-            if self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("PoolType"):
+            if self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("PoolType") or self.get_type("_POOL_TRACKER_BIG_PAGES").has_member("SlushSize"):
                 self.set_type_class("_POOL_HEADER", pool.POOL_HEADER_VISTA)
             else:
                 self.set_type_class("_POOL_HEADER", pool.POOL_HEADER)


### PR DESCRIPTION
…strict the Pools that current scanners accept.

This PR fixes two major bugs in Volatility 3 that I ran into while trying to add the GUI/win32k.sys support.

1) Pool scanning on Windows 11 was completely broken as the `PoolType` member of big pools that the type check relied on is now gone (meaning it existed from Vista->later Windows 10), but does not exist on XP or Windows 11. To remedy this, I added an `or` check to also include `SlushSize` as this member was added in Windows 10 and is still present in 11. I verified scanners work again with this fix.

2) The first issue and potentially others (still investigating) were hidden by the fact that all the scanners listed that objects could come from every possible pool (paged, non paged, free) - which does not make any sense. The acceptable pool per type is now included for each type.