### PR TITLE
Fix broken code and APIs in Linux networking paths

### DIFF
--- a/volatility3/framework/plugins/linux/ip.py
+++ b/volatility3/framework/plugins/linux/ip.py
@@ -39,7 +39,7 @@ class Addr(plugins.PluginInterface):
         try:
             net_ns_id = net_dev.get_net_namespace_id()
         except AttributeError:
-            net_ns_id = renderers.NotAvailableValue()
+            net_ns_id = None
 
         # Interface IPv4 Addresses
         in_device = net_dev.ip_ptr.dereference().cast("in_device")
@@ -47,7 +47,7 @@ class Addr(plugins.PluginInterface):
             prefix_len = in_ifaddr.get_prefix_len()
             scope_type = in_ifaddr.get_scope_type()
             ip_addr = in_ifaddr.get_address()
-            yield net_ns_id or renderers.NotAvailableValue(), iface_ifindex, iface_name, mac_addr, promisc, ip_addr, prefix_len, scope_type, operational_state
+            yield net_ns_id, iface_ifindex, iface_name, mac_addr, promisc, ip_addr, prefix_len, scope_type, operational_state
 
         # Interface IPv6 Addresses
         inet6_dev = net_dev.ip6_ptr.dereference().cast("inet6_dev")
@@ -55,9 +55,9 @@ class Addr(plugins.PluginInterface):
             prefix_len = inet6_ifaddr.get_prefix_len()
             scope_type = inet6_ifaddr.get_scope_type()
             ip6_addr = inet6_ifaddr.get_address()
-            yield net_ns_id or renderers.NotAvailableValue(), iface_ifindex, iface_name, mac_addr, promisc, ip6_addr, prefix_len, scope_type, operational_state
+            yield net_ns_id, iface_ifindex, iface_name, mac_addr, promisc, ip6_addr, prefix_len, scope_type, operational_state
 
-    def _generator(self):
+    def _enumerate_net_namespace_list(self):
         vmlinux = self.context.modules[self.config["kernel"]]
 
         net_type_symname = vmlinux.symbol_table_name + constants.BANG + "net"
@@ -67,9 +67,32 @@ class Addr(plugins.PluginInterface):
         # 'net_namespace_list' exists from kernels >= 2.6.24
         net_namespace_list = vmlinux.object_from_symbol("net_namespace_list")
         for net_ns in net_namespace_list.to_list(net_type_symname, "list"):
-            for net_dev in net_ns.dev_base_head.to_list(net_device_symname, "dev_list"):
-                for fields in self._gather_net_dev_info(net_dev):
-                    yield 0, fields
+            yield from net_ns.dev_base_head.to_list(net_device_symname, "dev_list")
+
+    def _generator(self):
+        for net_dev in self._enumerate_net_namespace_list():
+            for (
+                net_ns_id,
+                iface_ifindex,
+                iface_name,
+                mac_addr,
+                promisc,
+                ip6_addr,
+                prefix_len,
+                scope_type,
+                operational_state,
+            ) in self._gather_net_dev_info(net_dev):
+                yield 0, (
+                    net_ns_id or renderers.NotAvailableValue(),
+                    iface_ifindex,
+                    iface_name,
+                    mac_addr,
+                    promisc,
+                    ip6_addr,
+                    prefix_len,
+                    scope_type,
+                    operational_state,
+                )
 
     def run(self):
         headers = [

--- a/volatility3/framework/plugins/linux/ip.py
+++ b/volatility3/framework/plugins/linux/ip.py
@@ -15,7 +15,7 @@ class Addr(plugins.PluginInterface):
 
     _required_framework_version = (2, 22, 0)
 
-    _version = (1, 0, 1)
+    _version = (1, 0, 2)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -47,7 +47,7 @@ class Addr(plugins.PluginInterface):
             prefix_len = in_ifaddr.get_prefix_len()
             scope_type = in_ifaddr.get_scope_type()
             ip_addr = in_ifaddr.get_address()
-            yield net_ns_id, iface_ifindex, iface_name, mac_addr, promisc, ip_addr, prefix_len, scope_type, operational_state
+            yield net_ns_id or renderers.NotAvailableValue(), iface_ifindex, iface_name, mac_addr, promisc, ip_addr, prefix_len, scope_type, operational_state
 
         # Interface IPv6 Addresses
         inet6_dev = net_dev.ip6_ptr.dereference().cast("inet6_dev")
@@ -55,7 +55,7 @@ class Addr(plugins.PluginInterface):
             prefix_len = inet6_ifaddr.get_prefix_len()
             scope_type = inet6_ifaddr.get_scope_type()
             ip6_addr = inet6_ifaddr.get_address()
-            yield net_ns_id, iface_ifindex, iface_name, mac_addr, promisc, ip6_addr, prefix_len, scope_type, operational_state
+            yield net_ns_id or renderers.NotAvailableValue(), iface_ifindex, iface_name, mac_addr, promisc, ip6_addr, prefix_len, scope_type, operational_state
 
     def _generator(self):
         vmlinux = self.context.modules[self.config["kernel"]]
@@ -127,7 +127,7 @@ class Link(plugins.PluginInterface):
         ]
         flags_str = ",".join(flags_list)
 
-        yield net_ns_id, iface_name, mac_addr, operational_state, mtu, qdisc_name, qlen, flags_str
+        yield net_ns_id or renderers.NotAvailableValue(), iface_name, mac_addr, operational_state, mtu, qdisc_name or renderers.NotAvailableValue(), qlen, flags_str
 
     def _generator(self):
         vmlinux = self.context.modules[self.config["kernel"]]


### PR DESCRIPTION
The Linux networking paths that supported the two `ip` plugins had many issues, including a `get_*` throwing a paging exception, not catching exceptions for reading names, and other issues. These caused backtraces all over in testing. These are now fixed.