### PR TITLE
Report the memer name and type when attributes cannot be found

### DIFF
--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -133,7 +133,7 @@ class ObjectInterface(metaclass=abc.ABCMeta):
 
     def __getattr__(self, attr: str) -> Any:
         """Method for ensuring volatility members can be returned."""
-        raise AttributeError()
+        raise AttributeError(f"Unable to find {attr} for type {self.vol.type_name}")
 
     @property
     def vol(self) -> ReadOnlyMapping:


### PR DESCRIPTION
Currently, this the last output of the backtrace when a member is accessed that does not exist:

```
 File "/home/rk/vol3commits/volatility3/framework/interfaces/objects.py", line 136, in __getattr__
    raise AttributeError()
```

Which then means you have to dig into the code to figure out what was missing. This PR makes it much nicer, such as:

```
File "/home/rk/vol3commits/volatility3/framework/interfaces/objects.py", line 136, in __getattr__
    raise AttributeError(f"Unable to find {attr} for type {self.vol.type_name}")
AttributeError: Unable to find address for type symbol_table_name1!array
```