### PR TITLE
Bump GitHub runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable

--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.8"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.8"]


### PR DESCRIPTION
Hi,

starting from the 1st of April 2025, GitHub runners won't support Ubuntu 20.04 anymore. There even are brownouts scheduled (one is right now) to encourage people to migrate:

https://github.com/actions/runner-images/issues/11101

edit: Sorry, commits should be read as ISO 8601 like: "2025-04-01 "