### PR TITLE
Correctly use decode with replace to avoid backtraces on partially sm…

### DIFF
--- a/volatility3/framework/plugins/linux/envars.py
+++ b/volatility3/framework/plugins/linux/envars.py
@@ -95,7 +95,9 @@ class Envars(plugins.PluginInterface):
         envar_data = envar_data.rstrip(b"\x00")
         for envar_pair in envar_data.split(b"\x00"):
             try:
-                env_key, env_value = envar_pair.decode().split("=", 1)
+                env_key, env_value = envar_pair.decode(
+                    encoding="utf8", errors="replace"
+                ).split("=", 1)
             except ValueError:
                 # Some legitimate programs, like 'avahi-daemon', avoid reallocating the args
                 # and instead exploit the fact that the environment variables area is contiguous

--- a/volatility3/framework/plugins/linux/psaux.py
+++ b/volatility3/framework/plugins/linux/psaux.py
@@ -78,7 +78,7 @@ class PsAux(plugins.PluginInterface):
                 return renderers.UnreadableValue()
 
             # the arguments are null byte terminated, replace the nulls with spaces
-            s = argv.decode().split("\x00")
+            s = argv.decode(encoding="utf8", errors="replace").split("\x00")
             args = " ".join(s)
         else:
             # kernel thread


### PR DESCRIPTION
…eared strings