### PR TITLE
Pdbconv: Make symbol server URL constant

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -40,6 +40,8 @@ SYMBOL_BASEPATHS = [
 ISF_EXTENSIONS = [".json", ".json.xz", ".json.gz", ".json.bz2"]
 """List of accepted extensions for ISF files"""
 
+SYMBOL_SERVER_URL = "http://msdl.microsoft.com/download/symbols"
+
 if hasattr(sys, "frozen") and sys.frozen:
     # Ensure we include the executable's directory as the base for plugins and symbols
     PLUGINS_PATH = [

--- a/volatility3/framework/symbols/windows/pdbconv.py
+++ b/volatility3/framework/symbols/windows/pdbconv.py
@@ -950,7 +950,7 @@ class PdbRetreiver:
     ) -> Optional[str]:
         vollog.info("Download PDB file...")
         file_name = ".".join(file_name.split(".")[:-1] + ["pdb"])
-        for sym_url in ["http://msdl.microsoft.com/download/symbols"]:
+        for sym_url in [constants.SYMBOL_SERVER_URL]:
             url = sym_url + f"/{file_name}/{guid}/"
 
             result = None


### PR DESCRIPTION
This removes the hard-coded symbol server URL from `PdbRetreiver.retrieve_pdb` and defines it as a constant within the `constants` module.
