### PR TITLE
Change the type information reported for missing attributes

### DIFF
--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -133,7 +133,7 @@ class ObjectInterface(metaclass=abc.ABCMeta):
 
     def __getattr__(self, attr: str) -> Any:
         """Method for ensuring volatility members can be returned."""
-        raise AttributeError(f"Unable to find {attr} for type {self.vol.type_name}")
+        raise AttributeError(f"Unable to find {attr} for type {type(self)}")
 
     @property
     def vol(self) -> ReadOnlyMapping:


### PR DESCRIPTION
This triggered an issue today when I was testing Windows:

https://github.com/volatilityfoundation/volatility3/pull/1657

The problem is that Pointers and Void objects can end up through there, which do not have the vol.type_name set. From debugging with many print statements, including inside of Python itself, it seems many paths cross there in Volatility. At least getting the attribute name and type should help much more than before when it didn't report anything specifc.

This was very hard to debug and I had to add a bunch of print statements inside of the Python core libraries, which made my VMs quite unhappy :| 