### PR TITLE
windows.lsadump: Improve secret readability

### DIFF
--- a/volatility3/framework/plugins/windows/lsadump.py
+++ b/volatility3/framework/plugins/windows/lsadump.py
@@ -204,7 +204,7 @@ class Lsadump(interfaces.plugins.PluginInterface):
             else:
                 secret = self.decrypt_aes(enc_secret, lsakey)
 
-            yield (0, (key.get_name(), secret.decode("latin1"), secret))
+            yield (0, (key.get_name(), str(secret), secret))
 
     def run(self):
         offset = self.config.get("offset", None)

--- a/volatility3/framework/plugins/windows/lsadump.py
+++ b/volatility3/framework/plugins/windows/lsadump.py
@@ -14,6 +14,7 @@ from volatility3.framework.layers import registry
 from volatility3.framework.symbols.windows import versions
 from volatility3.plugins.windows import hashdump
 from volatility3.plugins.windows.registry import hivelist
+from volatility3.framework.renderers import format_hints
 
 vollog = logging.getLogger(__name__)
 
@@ -204,7 +205,7 @@ class Lsadump(interfaces.plugins.PluginInterface):
             else:
                 secret = self.decrypt_aes(enc_secret, lsakey)
 
-            yield (0, (key.get_name(), str(secret), secret))
+            yield (0, (key.get_name(), format_hints.HexBytes(secret), secret))
 
     def run(self):
         offset = self.config.get("offset", None)
@@ -224,6 +225,6 @@ class Lsadump(interfaces.plugins.PluginInterface):
                 sechive = hive
 
         return renderers.TreeGrid(
-            [("Key", str), ("Secret", str), ("Hex", bytes)],
+            [("Key", str), ("Secret", format_hints.HexBytes), ("Hex", bytes)],
             self._generator(syshive, sechive),
         )

--- a/volatility3/framework/plugins/windows/lsadump.py
+++ b/volatility3/framework/plugins/windows/lsadump.py
@@ -22,7 +22,7 @@ class Lsadump(interfaces.plugins.PluginInterface):
     """Dumps lsa secrets from memory"""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls):


### PR DESCRIPTION
Hi,

The current `windows.ldsadump` plugin outputs secrets both as decoded and hex-encoded format. However, the output is generally very messy (source is `win-xp-laptop-2005-06-25.img`): 

<img width="946" alt="image" src="https://github.com/user-attachments/assets/0b20bf2b-a0da-4609-84fb-b75cf6d63bb4" />

This can be circumvented by using the "-r json" renderer, but I've encountered a lot of confusion amongst analysts that think the plugin is broken or outputting garbage data. Some even roll back to the hexdump-ed Vol2 version. 

I do believe keeping both columns is better, but the "printable" one purpose should only be to have a quick look over secrets and spot "human readable" ones. If someone wants to manipulate the secret, the "Hex" column will then come handy.

Here is the updated version, which improves readability while offering precise information about hex values: 

<img width="946" alt="image" src="https://github.com/user-attachments/assets/f9ab91dd-442f-4bbe-8106-29f2fdb64ada" />

`b''` enclosing is commonly used to indicate mixed printable and non-printable characters.

Thanks :)