### PR TITLE
Prevent truecrypt from throwing a backtrace when the module isn't fou…

### DIFF
--- a/volatility3/framework/plugins/windows/truecrypt.py
+++ b/volatility3/framework/plugins/windows/truecrypt.py
@@ -2,6 +2,8 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
+import logging
+
 from typing import Iterable, Generator, List, Tuple
 
 from volatility3.framework import constants, interfaces, renderers
@@ -16,6 +18,8 @@ from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.windows.extensions import pe
 
 from volatility3.plugins.windows import modules
+
+vollog = logging.getLogger(__name__)
 
 
 class Passphrase(interfaces.plugins.PluginInterface):
@@ -123,11 +127,18 @@ class Passphrase(interfaces.plugins.PluginInterface):
         mods: Iterable[ObjectInterface] = modules.Modules.list_modules(
             self.context, self.config["kernel"]
         )
-        truecrypt_module_base = next(
-            mod.DllBase
-            for mod in mods
-            if mod.BaseDllName.get_string().lower() == "truecrypt.sys"
-        )
+        try:
+            truecrypt_module_base = next(
+                mod.DllBase
+                for mod in mods
+                if mod.BaseDllName.get_string().lower() == "truecrypt.sys"
+            )
+        except StopIteration:
+            vollog.warning(
+                "Truecrypt module not found in the modules list. Unable to proceed."
+            )
+            return
+
         for offset, password in self.scan_module(
             truecrypt_module_base, kernel.layer_name
         ):


### PR DESCRIPTION
…nd and print a warning.

This threw a huge backtrace on any sample that didn't have truecrypt loaded (99.999999% of them).