### PR TITLE
Update fbdev plugin to gracefully handle old/broken symbol tables

### DIFF
--- a/volatility3/framework/plugins/linux/graphics/fbdev.py
+++ b/volatility3/framework/plugins/linux/graphics/fbdev.py
@@ -262,7 +262,7 @@ You can try using ffmpeg to decode the raw buffer. Example usage:
 
         if not kernel.has_symbol("num_registered_fb"):
             vollog.error(
-                '"num_registered_fb" symbol does not exist in the symbol table. This means you are either analyzing an unsupported kernel version,  your symbol table is corrupt, or the fbdev driver is compiled as a kernel module..'
+                '"num_registered_fb" symbol does not exist in the symbol table. This means you are either analyzing an unsupported kernel version,  your symbol table is corrupt, or the fbdev driver is compiled as a kernel module.'
             )
             return
 

--- a/volatility3/framework/plugins/linux/graphics/fbdev.py
+++ b/volatility3/framework/plugins/linux/graphics/fbdev.py
@@ -255,22 +255,28 @@ You can try using ffmpeg to decode the raw buffer. Example usage:
             vollog.error(
                 "PIL (pillow) module is required to use this plugin. Please install it manually or through pyproject.toml."
             )
-            return None
+            return
 
         kernel_name = self.config["kernel"]
         kernel = self.context.modules[kernel_name]
 
         if not kernel.has_symbol("num_registered_fb"):
-            raise exceptions.SymbolError(
-                "num_registered_fb",
-                kernel.symbol_table_name,
-                "The provided symbol does not exist in the symbol table. This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt.",
+            vollog.error(
+                '"num_registered_fb" symbol does not exist in the symbol table. This means you are either analyzing an unsupported kernel version,  your symbol table is corrupt, or the fbdev driver is compiled as a kernel module..'
             )
+            return
 
-        num_registered_fb = kernel.object_from_symbol("num_registered_fb")
+        try:
+            num_registered_fb = kernel.object_from_symbol("num_registered_fb")
+        except exceptions.SymbolError:
+            vollog.error(
+                'Creating an object from "num_registered_fb" caused a symbol error. This is a sign that the symbol table is outdated. Please re-generate your symbol table using the latest dwarf2json'
+            )
+            return
+
         if num_registered_fb < 1:
             vollog.info("No registered framebuffer in the fbdev API.")
-            return None
+            return
 
         registered_fb = kernel.object_from_symbol("registered_fb")
         fb_info_list = utility.array_of_pointers(


### PR DESCRIPTION
This plugin backtraced when 1) fbdev was compiled as a module and 2) an old version of dwarf2json was used to generate the symbol table.

This caused the existing check for the symbol to exist to succeed, but its only as a forward declaration. Then `object_from_symbol` would fail as the address was recorded as 0.

My patch here makes it gracefully warn the user + exit when an old symbol table is passed, and then the existing check will work for modern symbol tables and samples with fbdev as a kernel module.