### PR TITLE
Remove deepcopy call in pe_symbols. Validate wanted symbol informatio…

### DIFF
--- a/volatility3/framework/plugins/windows/debugregisters.py
+++ b/volatility3/framework/plugins/windows/debugregisters.py
@@ -41,7 +41,7 @@ class DebugRegisters(interfaces.plugins.PluginInterface):
                 name="threads", component=threads.Threads, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="pe_symbols", component=pe_symbols.PESymbols, version=(2, 0, 0)
+                name="pe_symbols", component=pe_symbols.PESymbols, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/pe_symbols.py
+++ b/volatility3/framework/plugins/windows/pe_symbols.py
@@ -671,8 +671,9 @@ class PESymbols(interfaces.plugins.PluginInterface):
                         else:
                             yield symbol_key, value_index, symbol_value, wanted_value  # type: ignore
 
-    @staticmethod
+    @classmethod
     def _validate_wanted_modules(
+        cls,
         wanted: PESymbolFinder.cached_module_lists,
     ) -> Optional[PESymbolFinder.cached_module_lists]:
         """

--- a/volatility3/framework/plugins/windows/pe_symbols.py
+++ b/volatility3/framework/plugins/windows/pe_symbols.py
@@ -1,7 +1,6 @@
 # This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 
-import copy
 import io
 import logging
 import ntpath
@@ -11,7 +10,7 @@ from typing import Dict, Tuple, Optional, List, Generator, Union, Callable
 import pefile
 
 from volatility3.framework import interfaces, exceptions
-from volatility3.framework import renderers, constants
+from volatility3.framework import renderers, constants, objects
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import intermed
@@ -245,7 +244,8 @@ class PESymbols(interfaces.plugins.PluginInterface):
     _required_framework_version = (2, 7, 0)
 
     # 2.0.0 - changed signature of get_kernel_modules, get_all_vads_with_file_paths, addresses_for_process_symbols, get_process_modules
-    _version = (2, 0, 0)
+    # 3.0.0 - find_symbols wil now throw a ValueError if the provided wanted symbol information does not follow the spec
+    _version = (3, 0, 0)
 
     # used for special handling of the kernel PDB file. See later notes
     os_module_name = "ntoskrnl.exe"
@@ -672,6 +672,52 @@ class PESymbols(interfaces.plugins.PluginInterface):
                             yield symbol_key, value_index, symbol_value, wanted_value  # type: ignore
 
     @staticmethod
+    def _validate_wanted_modules(
+        wanted: PESymbolFinder.cached_module_lists,
+    ) -> Optional[PESymbolFinder.cached_module_lists]:
+        """
+        Validates and makes a copy of the address(es) and/or name(s) wanted from a particular module
+        Throws ValueError if invalid values found
+        """
+        remaining: PESymbolFinder.cached_module_lists = {}
+
+        valid_name_types = [str]
+        valid_address_types = [int, objects.Pointer]
+
+        for wanted_type, wanted_symbols in wanted.items():
+            if wanted_type not in [
+                wanted_names_identifier,
+                wanted_addresses_identifier,
+            ]:
+                raise ValueError(
+                    f"The symbol type specified ({wanted_type}) is not valid. Values choices: {wanted_names_identifier}, {wanted_addresses_identifier}"
+                )
+
+            remaining[wanted_type] = []
+
+            # symbol_info will be a symbol name or address requested
+            for symbol_info in wanted_symbols:
+                if (
+                    wanted_type == wanted_names_identifier
+                    and type(symbol_info) not in valid_name_types
+                ):
+                    raise ValueError(
+                        f"The requested symbol name has a type of {type(symbol_info)} which is not in the allowed set of {valid_name_types}"
+                    )
+
+                elif (
+                    wanted_type == wanted_addresses_identifier
+                    and type(symbol_info) not in valid_address_types
+                ):
+                    raise ValueError(
+                        f"The requested address has a type of {type(symbol_info)} which is not in the allowed set of {valid_address_types}"
+                    )
+
+                remaining[wanted_type].append(symbol_info)
+
+        return remaining
+
+    @staticmethod
     def _resolve_symbols_through_methods(
         context: interfaces.context.ContextInterface,
         config_path: str,
@@ -700,8 +746,8 @@ class PESymbols(interfaces.plugins.PluginInterface):
         # the symbols wanted from this module by the caller
         wanted = wanted_modules[mod_name]
 
-        # make a copy to remove from inside this function for returning to the caller
-        remaining = copy.deepcopy(wanted)
+        # The ValueError will pass through to the caller
+        remaining = PESymbols._validate_wanted_modules(wanted)
 
         done_processing = False
 
@@ -748,6 +794,8 @@ class PESymbols(interfaces.plugins.PluginInterface):
         Loops through each method of symbol analysis until each wanted symbol is found
         Returns the resolved symbols as a dictionary that includes the name and runtime address
 
+        `wanted_modules` must be correctly formatted or a ValueError will be thrown
+
         Args:
             wanted_modules: the dictionary of modules and symbols to resolve. Modified to remove symbols as they are resolved.
             collected_modules: return value from `get_kernel_modules` or `get_process_modules`
@@ -763,6 +811,7 @@ class PESymbols(interfaces.plugins.PluginInterface):
 
             module_instances = collected_modules[mod_name]
 
+            # The ValueError from an invalid wanted_modules will pass through to the caller
             # try to resolve the symbols for `mod_name` through each method (PDB and export table currently)
             (
                 found_in_module,

--- a/volatility3/framework/plugins/windows/skeleton_key_check.py
+++ b/volatility3/framework/plugins/windows/skeleton_key_check.py
@@ -61,7 +61,7 @@ class Skeleton_Key_Check(interfaces.plugins.PluginInterface):
                 name="pdbutil", component=pdbutil.PDBUtility, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="pe_symbols", component=pe_symbols.PESymbols, version=(2, 0, 0)
+                name="pe_symbols", component=pe_symbols.PESymbols, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/suspended_threads.py
+++ b/volatility3/framework/plugins/windows/suspended_threads.py
@@ -33,7 +33,7 @@ class SuspendedThreads(interfaces.plugins.PluginInterface):
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="pe_symbols", component=pe_symbols.PESymbols, version=(2, 0, 0)
+                name="pe_symbols", component=pe_symbols.PESymbols, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="threads", component=threads.Threads, version=(3, 0, 0)

--- a/volatility3/framework/plugins/windows/unhooked_system_calls.py
+++ b/volatility3/framework/plugins/windows/unhooked_system_calls.py
@@ -98,7 +98,7 @@ class unhooked_system_calls(interfaces.plugins.PluginInterface):
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.PluginRequirement(
-                name="pe_symbols", plugin=pe_symbols.PESymbols, version=(2, 0, 0)
+                name="pe_symbols", plugin=pe_symbols.PESymbols, version=(3, 0, 0)
             ),
         ]
 


### PR DESCRIPTION
…n passed through resolving functions

The entry point to the issue in https://github.com/volatilityfoundation/volatility3/pull/1674

Was that the deepcopy() call was receiving Pointers and then the `self.vol.type_name` was going off the deep end, hence 1674.

This PR updates pe_symbols to avoid the deep copy call, so that instead of just accepting anything in the set of symbols to resolve, we actually validate each entry before resolving it.

This only required dependecy updates in the core plugins as they already call the API correctly, but will ensure that future plugins do not have mystery errors or missing data. 