### PR TITLE
Remove duplicate reference of capstone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dev = [
 test = [
     "volatility3[dev]",
     "pytest>=8.3.3,<9",
-    "capstone>=5.0.3,<6",
     "yara-x>=0.10.0,<1",
 ]
 


### PR DESCRIPTION
The capstone dependency under test is not needed, because test references volatility3[dev] which references volatility3[full,cloud], and full has the capstone dependency.