### PR TITLE
Fix symbol table PDB API that mixes returns, None values, and exceptions

### DIFF
--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -649,10 +649,6 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             vollog.error("Unable to locate symbols for the memory image's tcpip module")
             return
 
-        if not tcpip_symbol_table:
-            vollog.error("Unable to reconstruct symbol table for tcpip.sys")
-            return
-
         for netw_obj in self.list_sockets(
             self.context,
             kernel.layer_name,

--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -411,7 +411,7 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
         )
 
         if symbol_table_name is None:
-            raise exceptions.VolatilityException(
+            raise exceptions.SymbolSpaceError(
                 f"Symbol table could not be reconstructed for module {pdb_name}"
             )
 
@@ -445,7 +445,7 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
         )
 
         if not guids:
-            raise exceptions.VolatilityException(
+            raise exceptions.SymbolSpaceError(
                 f"Did not find GUID of {pdb_name} in module @ 0x{module_offset:x}!"
             )
 

--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -409,6 +409,10 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
         _, symbol_table_name = cls._modtable_from_pdb(
             context, config_path, layer_name, pdb_name, module_offset, module_size
         )
+
+        if symbol_table_name is None:
+            raise exceptions.VolatilityException(f"Symbol table could not be reconstructed for module {pdb_name}")
+
         return symbol_table_name
 
     @classmethod

--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -411,7 +411,9 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
         )
 
         if symbol_table_name is None:
-            raise exceptions.VolatilityException(f"Symbol table could not be reconstructed for module {pdb_name}")
+            raise exceptions.VolatilityException(
+                f"Symbol table could not be reconstructed for module {pdb_name}"
+            )
 
         return symbol_table_name
 


### PR DESCRIPTION
@ikelos this is that weird API I explained to you in DM on Slack, where you can ask for a symbol table then, if the PDB string is found in memory, but the symbol server doesn't host the GUID, you run into problems.

In particular, the function usually throws the VolatilityException whenever a PDB downloading/parsing issue happens, but the code paths traversed when finding a GUID, but the symbol server not having it, were returning None.

The external API for this (`symbol_table_from_pdb`) did not correctly handle this case, which led to backtraces in plugins that were doing try/catch over the call thinking that would cover all error conditions and that the returned string name of the module would be set.

We recently patched a fix into netstat so it can run in the test harness as this is what the backtrace would look like otherwise when run on our internal symbol server that did not have the particular tcpip.sys PDB. The None was coming from the `symbol_table_from_pdb` call. We can now take this extra check out since the API handles it and the code is already doing try/except as expected.

```
DETAIL 3 volatility3.framework.symbols.windows.versions: Windows PE version data is not available
DEBUG    volatility3.plugins.windows.netscan: Determined OS Version: 6.1 15.7601
DEBUG    volatility3.plugins.windows.netscan: Determined symbol filename: netscan-win7-x64
DETAIL 4 volatility3.framework.symbols.intermed: Searching for symbols in /home/analyst/guiv3/volatility3/symbols, /home/analyst/guiv3/volatility3/framework/symbols
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
DEBUG    volatility3.framework.symbols: Unresolved reference: symbol_table_name1!_ACTIVATION_CONTEXT
DEBUG    volatility3.plugins.windows.netstat: Found tcpip.sys image base @ 0xf88001805000
DEBUG    volatility3.framework.symbols.windows.pdbutil: Found tcpip.pdb: 1E2708CA030243C79A781BBCA4E3D0F5-2
INFO     volatility3.framework.symbols.windows.pdbconv: Download PDB file...
DEBUG    volatility3.framework.symbols.windows.pdbconv: Attempting to retrieve https://[snip]/windows/msu-analysis/tcpip.pdb/1E2708CA030243C79A781BBCA4E3D0F52/tcpip.pdb
DEBUG    volatility3.framework.symbols.windows.pdbconv: Failed with HTTP Error 404: Not Found
DEBUG    volatility3.framework.symbols.windows.pdbconv: Attempting to retrieve https://[snip]/windows/msu-analysis/tcpip.pdb/1E2708CA030243C79A781BBCA4E3D0F52/tcpip.pd_
DEBUG    volatility3.framework.symbols.windows.pdbconv: Failed with HTTP Error 404: Not Found
WARNING  volatility3.framework.symbols.windows.pdbutil: Symbol file could not be downloaded from remote server                                                                                                    
DETAIL 4 volatility3.framework.symbols.intermed: Searching for symbols in /home/analyst/guiv3/volatility3/symbols, /home/analyst/guiv3/volatility3/framework/symbols
DEBUG    volatility3.framework.symbols.windows.pdbutil: Required symbol library path not found: tcpip.pdb/1E2708CA030243C79A781BBCA4E3D0F5-2
INFO     volatility3.framework.symbols.windows.pdbutil: The symbols can be downloaded later using pdbconv.py -p tcpip.pdb -g 1E2708CA030243C79A781BBCA4E3D0F52
Traceback (most recent call last):
  File "vol.py", line 11, in <module>
    volatility3.cli.main()
  File "/home/analyst/guiv3/volatility3/cli/__init__.py", line 924, in main
    CommandLine().run()
  File "/home/analyst/guiv3/volatility3/cli/__init__.py", line 512, in run
    renderer.render(grid)
  File "/home/analyst/guiv3/volatility3/cli/text_renderer.py", line 232, in render
    grid.populate(visitor, outfd)
  File "/home/analyst/guiv3/volatility3/framework/renderers/__init__.py", line 240, in populate
    for level, item in self._generator:
  File "/home/analyst/guiv3/volatility3/framework/plugins/windows/netstat.py", line 650, in _generator
    for netw_obj in self.list_sockets(
  File "/home/analyst/guiv3/volatility3/framework/plugins/windows/netstat.py", line 557, in list_sockets
    yield from cls.parse_partitions(
  File "/home/analyst/guiv3/volatility3/framework/plugins/windows/netstat.py", line 330, in parse_partitions
    tcpip_symbol_table + constants.BANG + "PartitionTable"
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```