### PR TITLE
Ensure that new symbol tables are only created when needed. Avoid nam…

### DIFF
--- a/volatility3/framework/plugins/windows/callbacks.py
+++ b/volatility3/framework/plugins/windows/callbacks.py
@@ -42,7 +42,7 @@ class Callbacks(interfaces.plugins.PluginInterface):
                 name="ssdt", plugin=ssdt.SSDT, version=(2, 0, 0)
             ),
             requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
             requirements.PluginRequirement(
                 name="driverirp", plugin=driverirp.DriverIrp, version=(1, 0, 0)

--- a/volatility3/framework/plugins/windows/driverscan.py
+++ b/volatility3/framework/plugins/windows/driverscan.py
@@ -25,7 +25,7 @@ class DriverScan(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/filescan.py
+++ b/volatility3/framework/plugins/windows/filescan.py
@@ -25,7 +25,7 @@ class FileScan(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/modscan.py
+++ b/volatility3/framework/plugins/windows/modscan.py
@@ -32,7 +32,7 @@ class ModScan(modules.Modules):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="poolscanner", component=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="modules", component=modules.Modules, version=(3, 0, 0)

--- a/volatility3/framework/plugins/windows/mutantscan.py
+++ b/volatility3/framework/plugins/windows/mutantscan.py
@@ -25,7 +25,7 @@ class MutantScan(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/netscan.py
+++ b/volatility3/framework/plugins/windows/netscan.py
@@ -34,7 +34,7 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="poolscanner", component=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="info", component=info.Info, version=(2, 0, 0)

--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -129,7 +129,7 @@ class PoolScanner(plugins.PluginInterface):
     """A generic pool scanner plugin."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (2, 0, 0)
+    _version = (3, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -423,6 +423,7 @@ class PoolScanner(plugins.PluginInterface):
         # scan in the main kernel layer for the object(s)
         for constraint, header in cls.pool_scan(
             context,
+            kernel_module_name,
             scan_layer,
             object_symbol_table_name,
             constraints,
@@ -501,6 +502,7 @@ class PoolScanner(plugins.PluginInterface):
     def pool_scan(
         cls,
         context: interfaces.context.ContextInterface,
+        kernel_module_name: str,
         layer_name: str,
         symbol_table: str,
         pool_constraints: List[PoolConstraint],
@@ -534,8 +536,16 @@ class PoolScanner(plugins.PluginInterface):
                 )
             constraint_lookup[constraint.tag] = constraint
 
-        pool_header_table_name = cls.get_pool_header_table(context, symbol_table)
-        module = context.module(pool_header_table_name, layer_name, offset=0)
+        kernel = context.modules[kernel_module_name]
+
+        if kernel.has_type("_POOL_HEADER"):
+            pool_header_table_name = kernel.symbol_table_name
+        else:
+            pool_header_table_name = cls.get_pool_header_table(context, symbol_table)
+
+        module = context.module(
+            pool_header_table_name, layer_name, offset=kernel.offset
+        )
 
         # Run the scan locating the offsets of a particular tag
         layer = context.layers[layer_name]
@@ -553,43 +563,37 @@ class PoolScanner(plugins.PluginInterface):
             context: The context that the symbol tables does (or will) reside in
             symbol_table: The expected symbol_table to contain the _POOL_HEADER type
         """
-        # Setup the pool header and offset differential
-        try:
-            context.symbol_space.get_type(
-                symbol_table + constants.BANG + "_POOL_HEADER"
-            )
-            table_name = symbol_table
-        except exceptions.SymbolError:
-            # We have to manually load a symbol table
+        # We have to manually load a symbol table
 
-            if symbols.symbol_table_is_64bit(
-                context=context, symbol_table_name=symbol_table
-            ):
-                is_win_7 = versions.is_windows_7(context, symbol_table)
-                if is_win_7:
-                    pool_header_json_filename = "poolheader-x64-win7"
-                else:
-                    pool_header_json_filename = "poolheader-x64"
+        if symbols.symbol_table_is_64bit(
+            context=context, symbol_table_name=symbol_table
+        ):
+            is_win_7 = versions.is_windows_7(context, symbol_table)
+            if is_win_7:
+                pool_header_json_filename = "poolheader-x64-win7"
             else:
-                pool_header_json_filename = "poolheader-x86"
+                pool_header_json_filename = "poolheader-x64"
+        else:
+            pool_header_json_filename = "poolheader-x86"
 
-            # set the class_type to match the normal WindowsKernelIntermedSymbols
-            is_vista_or_later = versions.is_vista_or_later(context, symbol_table)
-            if is_vista_or_later:
-                class_type = extensions.pool.POOL_HEADER_VISTA
-            else:
-                class_type = extensions.pool.POOL_HEADER
+        # set the class_type to match the normal WindowsKernelIntermedSymbols
+        is_vista_or_later = versions.is_vista_or_later(context, symbol_table)
+        if is_vista_or_later:
+            class_type = extensions.pool.POOL_HEADER_VISTA
+        else:
+            class_type = extensions.pool.POOL_HEADER
 
-            table_name = intermed.IntermediateSymbolTable.create(
-                context=context,
-                config_path=configuration.path_join(
-                    context.symbol_space[symbol_table].config_path, "poolheader"
-                ),
-                sub_path="windows",
-                filename=pool_header_json_filename,
-                table_mapping={"nt_symbols": symbol_table},
-                class_types={"_POOL_HEADER": class_type},
-            )
+        table_name = intermed.IntermediateSymbolTable.create(
+            context=context,
+            config_path=configuration.path_join(
+                context.symbol_space[symbol_table].config_path, "poolheader"
+            ),
+            sub_path="windows",
+            filename=pool_header_json_filename,
+            table_mapping={"nt_symbols": symbol_table},
+            class_types={"_POOL_HEADER": class_type},
+        )
+
         return table_name
 
     def run(self) -> renderers.TreeGrid:

--- a/volatility3/framework/plugins/windows/psscan.py
+++ b/volatility3/framework/plugins/windows/psscan.py
@@ -40,7 +40,7 @@ class PsScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 name="info", component=info.Info, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="poolscanner", component=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/registry/hivescan.py
+++ b/volatility3/framework/plugins/windows/registry/hivescan.py
@@ -26,7 +26,7 @@ class HiveScan(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
             requirements.PluginRequirement(
                 name="bigpools", plugin=bigpools.BigPools, version=(2, 0, 0)

--- a/volatility3/framework/plugins/windows/symlinkscan.py
+++ b/volatility3/framework/plugins/windows/symlinkscan.py
@@ -28,7 +28,7 @@ class SymlinkScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfa
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="poolscanner", component=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/thrdscan.py
+++ b/volatility3/framework/plugins/windows/thrdscan.py
@@ -34,7 +34,7 @@ class ThrdScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/windowstations.py
+++ b/volatility3/framework/plugins/windows/windowstations.py
@@ -47,7 +47,7 @@ class WindowStations(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="poolscanner", component=poolscanner.PoolScanner, version=(2, 0, 0)
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="modules", component=modules.Modules, version=(3, 0, 0)


### PR DESCRIPTION
…e collisions leading to inconsistent behaviour. Make API for symbol table acquisition sane.

This PR fixes a very nasty bug that @dgmcdona 's comparison harness detected between Vol2 and Vol3. In particular, it was reported that Vol2 was recovering names of drivers inside of devicetrees that Vol3 was reported as not available (paged out).

I debugged it today and the root cause is the API fixed here - `get_pool_header_table` - which had a really bad issue. 

The purpose of this function is to return the symbol table name that the pool scanners should use when scanning (really just one with POOL_HEADER), but the function was receiving the name of a symbol table and then checking the global symbol space to see if it had the type. For kernels with the POOL_HEADER inside the regular types or existing tables with it, this led to getting back the same table again. After that, the code would then make a module() with this name at offset 0. Having an offset at 0 completely breaks operations of getting names out of POOL_HEADERs as they use relative offsets.

Figuring out all this out was very complicated and very hard to debug as we tried git bisect, but we were pointed to a previous PR that broke it, but then realized that Vol3 has had on and off again support all along the way - a situation that the automated regression tests and harness will catch much quicker going forward.

The reason for the back and forth between working or not, was that, for some versions of Vol3, the symbol table named passed into the pool scanners (always `symbol_table_name1` in testing),  was already defined as a module (context.modules[] element) and already had the right kernel offset set. In these cases, the broken `get_pool_header_table` had no effect as the name was already used. In the versions of Vol3 where a previous `symbol_table_name1` was not set due to code changes over time, then the pool scanners broke when reconstructing names as they were constructing the module at kernel offset 0.

This PR fixes all the above - directly using the kernel when it has the symbol, and only going to json files when needed, plus always constructing the module at the kernel offset as the plugins expect. 

Devicetree matches Vol2 across samples with this code in place. 