### PR TITLE
README: Modern shell / Python3 Fix for local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The latest stable version of Volatility will always be the `stable` branch of th
 git clone https://github.com/volatilityfoundation/volatility3.git
 cd volatility3/
 python3 -m venv venv && . venv/bin/activate
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 ## Quick Start


### PR DESCRIPTION
Description:
Added quotes to the pip install command: The command was updated to pip install -e ".[dev]" to ensure compatibility with environments that may have issues interpreting the square brackets without quotes. This change improves the installation process for development dependencies.
Changes:
Updated the pip install command in the setup instructions or script to use quotes around ".[dev]" for better compatibility.
Motivation:
Ensures that the development dependencies are installed correctly across different environments and systems. Some systems or shells might not interpret .[dev] correctly without quotes, leading to potential issues during setup.
How to test:
Run pip install -e ".[dev]" and verify that the development dependencies are installed successfully without any errors.
