### PR TITLE
No longer allocate session modules in support of the GUI objects at o…

### DIFF
--- a/volatility3/framework/plugins/windows/windowstations.py
+++ b/volatility3/framework/plugins/windows/windowstations.py
@@ -115,7 +115,9 @@ class WindowStations(interfaces.plugins.PluginInterface):
 
         for session_id, session_layer in session_map.items():
             session_module = context.module(
-                gui_table_name, layer_name=session_layer, offset=0
+                gui_table_name,
+                layer_name=session_layer,
+                offset=context.modules[module_name].offset,
             )
             session_map[session_id] = session_module
 
@@ -177,7 +179,9 @@ class WindowStations(interfaces.plugins.PluginInterface):
                 if session_module:
                     # create the object its own address space (per-session)
                     yield session_module.object(
-                        object_type=object_type, offset=mem_object.vol.offset
+                        object_type=object_type,
+                        offset=mem_object.vol.offset,
+                        absolute=True,
                     )
 
     @classmethod


### PR DESCRIPTION
…ffset 0. Instantiate objects at the absolute address explicitly.

This removes an instance of the pattern we changed yesterday of where modules get created at offset 0. The GUI subsystem support used this to create scanned for objects with the gui symbol table and the session layer the object was found in. Since this all happened through one call, we just have to set absolute=True to get it correct.