### PR TITLE
Properly reconstruct strings from memory buffers and allow for plugin…

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 23  # Number of changes that only add to the interface
+VERSION_MINOR = 24  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -2,6 +2,7 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
+import re
 from typing import Optional, Union
 
 from volatility3.framework import interfaces, objects, constants
@@ -33,6 +34,7 @@ def array_to_string(
     count: Optional[int] = None,
     errors: str = "replace",
     block_size=32,
+    encoding="utf-8",
 ) -> str:
     """Takes a Volatility 'Array' of characters and returns a Python string.
 
@@ -60,6 +62,7 @@ def array_to_string(
         count=count,
         errors=errors,
         block_size=block_size,
+        encoding=encoding,
     )
 
 
@@ -68,6 +71,7 @@ def pointer_to_string(
     count: int,
     errors: str = "replace",
     block_size=32,
+    encoding="utf-8",
 ) -> str:
     """Takes a Volatility 'Pointer' to characters and returns a Python string.
 
@@ -94,6 +98,7 @@ def pointer_to_string(
         count=count,
         errors=errors,
         block_size=block_size,
+        encoding=encoding,
     )
 
 
@@ -104,6 +109,7 @@ def address_to_string(
     count: int,
     errors: str = "replace",
     block_size=32,
+    encoding="utf-8",
 ) -> str:
     """Reads a null-terminated string from a given specified memory address, processing
        it in blocks for efficiency.
@@ -126,18 +132,17 @@ def address_to_string(
         raise ValueError("Count must be greater than 0")
 
     layer = context.layers[layer_name]
-    text = b""
-    while len(text) < count:
-        current_block_size = min(count - len(text), block_size)
-        temp_text = layer.read(address + len(text), current_block_size)
-        idx = temp_text.find(b"\x00")
-        if idx != -1:
-            temp_text = temp_text[:idx]
-            text += temp_text
-            break
-        text += temp_text
 
-    return text.decode(errors=errors)
+    # Purposely do not catch exception
+    data = layer.read(address, count)
+
+    decoded_data = data.decode(encoding=encoding, errors=errors)
+    try:
+        idx = re.search("\ufffd|\x00", decoded_data).start()
+    except AttributeError:
+        idx = len(decoded_data)
+
+    return decoded_data[:idx]
 
 
 def array_of_pointers(

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -2,10 +2,9 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
-import re
 from typing import Optional, Union
 
-from volatility3.framework import interfaces, objects, constants
+from volatility3.framework import interfaces, objects, constants, exceptions
 
 
 def rol(value: int, count: int, max_bits: int = 64) -> int:
@@ -102,6 +101,64 @@ def pointer_to_string(
     )
 
 
+def gather_contiguous_bytes_from_address(layer, address: int, count: int) -> bytes:
+    """
+    This method reconstructs a string from memory while also carefully examining each page
+
+    It goes page-by-page reading the bytes. This is done by calculating page boundaries
+    and then only reading one page at a time.
+
+    If a page is missing, the code initially catches the exception.
+    If data is non-empty (meaning at least one read succeeded), then we return what was read
+    If the first page fails, then we re-raise the exception
+    """
+
+    data = b""
+
+    left_to_read = count
+
+    # read as many pages as possible that are contiguous
+    # if the first page is missed, we re-raise the InvalidAddressException
+    # if we have at least 1 page that was read succesfully,
+    # then we try to construct a string from it
+    while left_to_read > 0:
+        # compute aligned address of current page and next the page
+        aligned = address & ~0xFFF
+        next_page = aligned + 0xFFF + 1
+
+        # all fits on the current page, last read
+        if address + left_to_read < next_page:
+            try:
+                data += layer.read(address, left_to_read)
+            except exceptions.InvalidAddressException:
+                # if we have data, just break the loop
+                if data:
+                    break
+                # Raise if no data was read as this means the first page was invalid
+                else:
+                    raise
+
+            left_to_read = 0
+
+        else:
+            # how many bytes are left on the current page
+            len_to_read = next_page - address
+
+            try:
+                data += layer.read(address, len_to_read)
+            except exceptions.InvalidAddressException:
+                if data:
+                    break
+                # Raise if no data was read as this means the first page was invalid
+                else:
+                    raise
+
+            address += len_to_read
+            left_to_read -= len_to_read
+
+    return data
+
+
 def address_to_string(
     context: interfaces.context.ContextInterface,
     layer_name: str,
@@ -131,18 +188,38 @@ def address_to_string(
     if count < 1:
         raise ValueError("Count must be greater than 0")
 
+    encodings = {"utf8": 1, "utf16": 2, "utf32": 4}
+    if encoding not in encodings:
+        raise ValueError(
+            f"Encoding ({encoding} is invalid. Must be one of {[e for e in encodings]}."
+        )
+
     layer = context.layers[layer_name]
 
-    # Purposely do not catch exception
-    data = layer.read(address, count)
+    data = gather_contiguous_bytes_from_address(layer, address, count)
 
-    decoded_data = data.decode(encoding=encoding, errors=errors)
-    try:
-        idx = re.search("\ufffd|\x00", decoded_data).start()
-    except AttributeError:
-        idx = len(decoded_data)
+    # we need to find the ending nulls, which the amount of nulls varies based on encoding
+    ending_nulls = b"\x00" * encodings[encoding]
 
-    return decoded_data[:idx]
+    end_idx = data.find(ending_nulls)
+    # send back the bytes even if the ending nulls aren't found (can be on the next page)
+    if end_idx == -1:
+        return data
+
+    # cut at the nulls
+    data = data[:end_idx]
+
+    # For utf16 and utf32, just looking for the nulls cuts the final null from the string when its ascii characters
+    # This occurs as the string 'vol.py' in utf-16 will look like this, with two ending nulls:
+    # "v\x00o\x00l\x00.\x00p\x00y\x00\x00\x00"
+    # By cutting at the first \x00\x00, we are taking the second byte of the character for 'y'
+    # With real unicode strings this character can be non-zero
+    # This check and added null, pads out the last byte(s) to the width of each character to avoid this issue
+    end_size = len(ending_nulls)
+    if len(data) > end_size and len(data) % end_size != 0:
+        data += b"\x00" * (end_size - (len(data) % end_size))
+
+    return data.decode(encoding=encoding, errors=errors)
 
 
 def array_of_pointers(

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -188,7 +188,14 @@ def address_to_string(
     if count < 1:
         raise ValueError("Count must be greater than 0")
 
-    encodings = {"utf8": 1, "utf16": 2, "utf32": 4}
+    encodings = {
+        "utf-8": 1,
+        "utf8": 1,
+        "utf-16": 2,
+        "utf16": 2,
+        "utf32": 4,
+        "utf-32": 4,
+    }
     if encoding not in encodings:
         raise ValueError(
             f"Encoding ({encoding} is invalid. Must be one of {[e for e in encodings]}."

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -120,17 +120,13 @@ def gather_contiguous_bytes_from_address(
     data = b""
 
     if isinstance(data_layer, interfaces.layers.TranslationLayerInterface):
-        last_address = None
+        last_address = starting_address
 
         for address, length, _, _, _ in data_layer.mapping(
             offset=starting_address, length=count, ignore_errors=True
         ):
-            # Used to track when we hit a paged out page
-            if not last_address:
-                last_address = address + length
-
             # we hit a swapped out page
-            elif last_address and last_address != address:
+            if last_address != address:
                 break
 
             data += data_layer.read(address, length)

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -150,8 +150,19 @@ def gather_contiguous_bytes_from_address(
         )
 
 
-def bytes_to_decoded_string(data: bytes, encoding: str, errors: str) -> bytes:
+def bytes_to_decoded_string(
+    data: bytes, encoding: str, errors: str, return_truncated: bool = True
+) -> bytes:
     """
+    Args:
+        data: The `bytes` buffer containing the string of a string at offset 0
+        encoding: An encoding value for the encoding paramater of `bytes.decode`
+        errors: An errors value for the errors parameter of `bytes.decode`
+        return_truncated: Dictates whether truncated strings should be returned or
+        if a ValueError should be thrown if a truncated (broken) string was decoded
+    Returns:
+        bytes: The decoded string starting at offset of data
+
     This function takes a bytes buffer that contains at a string of unknown
     length starting at the first byte, and returns the properly decoded string
 
@@ -173,7 +184,12 @@ def bytes_to_decoded_string(data: bytes, encoding: str, errors: str) -> bytes:
     try:
         idx = termination_re.search(full_decoded_string).start()
     except AttributeError:
-        idx = len(full_decoded_string)
+        if return_truncated:
+            idx = len(full_decoded_string)
+        else:
+            raise ValueError(
+                "return_truncated set to False and truncated string decoded."
+            )
 
     # cut at terminating byte, if found
     data = data[:idx]

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -119,20 +119,26 @@ def gather_contiguous_bytes_from_address(
 
     data = b""
 
-    last_address = None
+    if isinstance(data_layer, interfaces.layers.TranslationLayerInterface):
+        last_address = None
 
-    for address, length, _, _, _ in data_layer.mapping(
-        offset=starting_address, length=count, ignore_errors=True
-    ):
-        # Used to track when we hit a paged out page
-        if not last_address:
+        for address, length, _, _, _ in data_layer.mapping(
+            offset=starting_address, length=count, ignore_errors=True
+        ):
+            # Used to track when we hit a paged out page
+            if not last_address:
+                last_address = address + length
+
+            # we hit a swapped out page
+            elif last_address and last_address != address:
+                break
+
+            data += data_layer.read(address, length)
+
             last_address = address + length
 
-        # we hit a swapped out page
-        elif last_address and last_address != address:
-            break
-
-        data += data_layer.read(address, length)
+    elif starting_address + count < data_layer.maximum_address:
+        data = data_layer.read(starting_address, count)
 
     # if we were able to read from the first page, we want to try and construct the string
     # if the first page fails -> throw exception
@@ -142,8 +148,6 @@ def gather_contiguous_bytes_from_address(
         raise exceptions.InvalidAddressException(
             layer_name=data_layer, invalid_address=starting_address
         )
-
-    return data
 
 
 def bytes_to_decoded_string(data: bytes, encoding: str, errors: str) -> bytes:


### PR DESCRIPTION
…-specified encodings

When working on the final GUI support, I ran into an issue with how Vol3 handles reading strings from memory and then reconstructing them. I then asked @dgmcdona for help as he has extensive experience with parsing UTF craziness in forensics context, and he said the existing function was just broken and incorrect.

In particular, the code assumes all strings are 1 char in length even though most Windows strings are utf8. Windows also have utf16, 32, etc. strings in use.

This code removes the hardcoded behaviour and allows Python's comprehensive decode() function to determine the characters. Our code then removes the junk off the end, including the unicode replacement character and obviously null.

This patch also expands the API so that callers can set the encoding to anything supported by Python. Finally, there is a minor framework bump since this expands the API.

