### PR TITLE
Update nearly all callers of now deprecated Linux kernel APIs

### DIFF
--- a/volatility3/framework/plugins/linux/check_idt.py
+++ b/volatility3/framework/plugins/linux/check_idt.py
@@ -36,6 +36,11 @@ class Check_idt(interfaces.plugins.PluginInterface):
                 version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
+                name="linux_utilities_module_gatherers",
+                component=linux_utilities_modules.ModuleGatherers,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
             ),
         ]
@@ -81,7 +86,7 @@ class Check_idt(interfaces.plugins.PluginInterface):
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
             context=self.context,
             kernel_module_name=self.config["kernel"],
-            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
+            caller_wanted_gatherers=linux_utilities_modules.ModuleGatherers.all_gatherers_identifier,
         )
 
         idt_table_size = 256

--- a/volatility3/framework/plugins/linux/check_idt.py
+++ b/volatility3/framework/plugins/linux/check_idt.py
@@ -33,7 +33,7 @@ class Check_idt(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
@@ -79,7 +79,9 @@ class Check_idt(interfaces.plugins.PluginInterface):
         vmlinux = self.context.modules[self.config["kernel"]]
 
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
-            self.context, self.config["kernel"], run_hidden_modules=True
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
         )
 
         idt_table_size = 256

--- a/volatility3/framework/plugins/linux/check_idt.py
+++ b/volatility3/framework/plugins/linux/check_idt.py
@@ -10,7 +10,6 @@ from volatility3.framework import interfaces, renderers, symbols
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import linux
-from volatility3.plugins.linux import lsmod
 
 vollog = logging.getLogger(__name__)
 
@@ -38,9 +37,6 @@ class Check_idt(interfaces.plugins.PluginInterface):
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
-            ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
             ),
         ]
 
@@ -82,10 +78,8 @@ class Check_idt(interfaces.plugins.PluginInterface):
 
         vmlinux = self.context.modules[self.config["kernel"]]
 
-        modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
-
-        handlers = linux.LinuxUtilities.generate_kernel_handler_info(
-            self.context, vmlinux.name, modules
+        known_modules = linux_utilities_modules.Modules.run_modules_scanners(
+            self.context, self.config["kernel"], run_hidden_modules=True
         )
 
         idt_table_size = 256
@@ -134,11 +128,16 @@ class Check_idt(interfaces.plugins.PluginInterface):
                 module_name = renderers.NotAvailableValue()
                 symbol_name = renderers.NotAvailableValue()
             else:
-                module_name, symbol_name = (
-                    linux_utilities_modules.Modules.lookup_module_address(
-                        self.context, vmlinux.name, handlers, idt_addr
+                module_info, symbol_name = (
+                    linux_utilities_modules.Modules.module_lookup_by_address(
+                        self.context, vmlinux.name, known_modules, idt_addr
                     )
                 )
+
+                if module_info:
+                    module_name = module_info.name
+                else:
+                    module_name = renderers.NotAvailableValue()
 
             yield (
                 0,
@@ -146,7 +145,7 @@ class Check_idt(interfaces.plugins.PluginInterface):
                     format_hints.Hex(i),
                     format_hints.Hex(idt_addr),
                     module_name,
-                    symbol_name,
+                    symbol_name or renderers.NotAvailableValue(),
                 ],
             )
 

--- a/volatility3/framework/plugins/linux/check_modules.py
+++ b/volatility3/framework/plugins/linux/check_modules.py
@@ -41,7 +41,7 @@ class Check_modules(plugins.PluginInterface):
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_kset_modules,
         removal_date="2025-09-25",
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
     )
     def get_kset_modules(
         cls, context: interfaces.context.ContextInterface, vmlinux_name: str

--- a/volatility3/framework/plugins/linux/check_modules.py
+++ b/volatility3/framework/plugins/linux/check_modules.py
@@ -33,7 +33,7 @@ class Check_modules(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/hidden_modules.py
+++ b/volatility3/framework/plugins/linux/hidden_modules.py
@@ -31,7 +31,7 @@ class Hidden_modules(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/hidden_modules.py
+++ b/volatility3/framework/plugins/linux/hidden_modules.py
@@ -10,7 +10,6 @@ from volatility3.framework import renderers, interfaces, exceptions, deprecation
 from volatility3.framework.constants import architectures
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.configuration import requirements
-from volatility3.plugins.linux import lsmod
 
 vollog = logging.getLogger(__name__)
 
@@ -28,9 +27,6 @@ class Hidden_modules(interfaces.plugins.PluginInterface):
                 name="kernel",
                 description="Linux kernel",
                 architectures=architectures.LINUX_ARCHS,
-            ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
@@ -163,7 +159,9 @@ class Hidden_modules(interfaces.plugins.PluginInterface):
 
         known_module_addresses = {
             vmlinux_layer.canonicalize(module.vol.offset)
-            for module in lsmod.Lsmod.list_modules(context, vmlinux_module_name)
+            for module in linux_utilities_modules.Modules.list_modules(
+                context, vmlinux_module_name
+            )
         }
         return known_module_addresses
 

--- a/volatility3/framework/plugins/linux/hidden_modules.py
+++ b/volatility3/framework/plugins/linux/hidden_modules.py
@@ -39,7 +39,7 @@ class Hidden_modules(interfaces.plugins.PluginInterface):
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_modules_memory_boundaries,
         removal_date="2025-09-25",
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
     )
     def get_modules_memory_boundaries(
         context: interfaces.context.ContextInterface,
@@ -52,7 +52,7 @@ class Hidden_modules(interfaces.plugins.PluginInterface):
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_module_address_alignment,
         removal_date="2025-09-25",
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
     )
     @classmethod
     def _get_module_address_alignment(
@@ -80,7 +80,7 @@ class Hidden_modules(interfaces.plugins.PluginInterface):
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_hidden_modules,
         removal_date="2025-09-25",
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
     )
     @classmethod
     def get_hidden_modules(
@@ -120,7 +120,7 @@ class Hidden_modules(interfaces.plugins.PluginInterface):
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.validate_alignment_patterns,
         removal_date="2025-09-25",
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
     )
     def _validate_alignment_patterns(
         addresses: Iterable[int],

--- a/volatility3/framework/plugins/linux/keyboard_notifiers.py
+++ b/volatility3/framework/plugins/linux/keyboard_notifiers.py
@@ -9,7 +9,6 @@ from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import linux
-from volatility3.plugins.linux import lsmod
 
 vollog = logging.getLogger(__name__)
 
@@ -32,9 +31,6 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
                 component=linux_utilities_modules.Modules,
                 version=(2, 0, 0),
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
-            ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
             ),
@@ -42,12 +38,6 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
 
     def _generator(self):
         vmlinux = self.context.modules[self.config["kernel"]]
-
-        modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
-
-        handlers = linux.LinuxUtilities.generate_kernel_handler_info(
-            self.context, vmlinux.name, modules
-        )
 
         try:
             knl_addr = vmlinux.object_from_symbol("keyboard_notifier_list")
@@ -65,6 +55,10 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
             vollog.error("The head of the keyboard notifier list is paged out.")
             return
 
+        known_modules = linux_utilities_modules.Modules.run_modules_scanners(
+            self.context, self.config["kernel"], run_hidden_modules=True
+        )
+
         knl = vmlinux.object(
             object_type="atomic_notifier_head",
             offset=knl_addr.vol.offset,
@@ -76,13 +70,25 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
         ):
             call_addr = call_back.notifier_call
 
-            module_name, symbol_name = (
-                linux_utilities_modules.Modules.lookup_module_address(
-                    self.context, vmlinux.name, handlers, call_addr
+            module_info, symbol_name = (
+                linux_utilities_modules.Modules.module_lookup_by_address(
+                    self.context, vmlinux.name, known_modules, call_addr
                 )
             )
 
-            yield (0, [format_hints.Hex(call_addr), module_name, symbol_name])
+            if module_info:
+                module_name = module_info.name
+            else:
+                module_name = renderers.NotAvailableValue()
+
+            yield (
+                0,
+                [
+                    format_hints.Hex(call_addr),
+                    module_name,
+                    symbol_name or renderers.NotAvailableValue(),
+                ],
+            )
 
     def run(self):
         return renderers.TreeGrid(

--- a/volatility3/framework/plugins/linux/keyboard_notifiers.py
+++ b/volatility3/framework/plugins/linux/keyboard_notifiers.py
@@ -32,6 +32,11 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
                 version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
+                name="linux_utilities_module_gatherers",
+                component=linux_utilities_modules.ModuleGatherers,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
             ),
         ]
@@ -58,7 +63,7 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
             context=self.context,
             kernel_module_name=self.config["kernel"],
-            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
+            caller_wanted_gatherers=linux_utilities_modules.ModuleGatherers.all_gatherers_identifier,
         )
 
         knl = vmlinux.object(

--- a/volatility3/framework/plugins/linux/keyboard_notifiers.py
+++ b/volatility3/framework/plugins/linux/keyboard_notifiers.py
@@ -29,7 +29,7 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
@@ -56,7 +56,9 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
             return
 
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
-            self.context, self.config["kernel"], run_hidden_modules=True
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
         )
 
         knl = vmlinux.object(

--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -34,7 +34,7 @@ class Kthreads(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
@@ -55,7 +55,9 @@ class Kthreads(plugins.PluginInterface):
             )
 
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
-            self.context, self.config["kernel"], run_hidden_modules=True
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
         )
 
         for task in pslist.PsList.list_tasks(

--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -37,6 +37,11 @@ class Kthreads(plugins.PluginInterface):
                 version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
+                name="linux_utilities_module_gatherers",
+                component=linux_utilities_modules.ModuleGatherers,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
             ),
             requirements.PluginRequirement(
@@ -57,7 +62,7 @@ class Kthreads(plugins.PluginInterface):
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
             context=self.context,
             kernel_module_name=self.config["kernel"],
-            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
+            caller_wanted_gatherers=linux_utilities_modules.ModuleGatherers.all_gatherers_identifier,
         )
 
         for task in pslist.PsList.list_tasks(

--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -5,14 +5,14 @@ import logging
 from typing import List
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
-from volatility3.framework import constants, exceptions, interfaces, renderers
+from volatility3.framework import exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import linux
 from volatility3.framework.constants import architectures
 from volatility3.framework.objects import utility
-from volatility3.plugins.linux import pslist, lsmod
+from volatility3.plugins.linux import pslist
 
 vollog = logging.getLogger(__name__)
 
@@ -42,27 +42,21 @@ class Kthreads(plugins.PluginInterface):
             requirements.PluginRequirement(
                 name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
-            ),
         ]
 
     def _generator(self):
         vmlinux = self.context.modules[self.config["kernel"]]
 
-        modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
-        handlers = linux.LinuxUtilities.generate_kernel_handler_info(
-            self.context, vmlinux.name, modules
-        )
-
-        kthread_type = vmlinux.get_type(
-            vmlinux.symbol_table_name + constants.BANG + "kthread"
-        )
+        kthread_type = vmlinux.get_type("kthread")
 
         if not kthread_type.has_member("threadfn"):
             raise exceptions.VolatilityException(
                 "Unsupported kthread implementation. This plugin only works with kernels >= 5.8"
             )
+
+        known_modules = linux_utilities_modules.Modules.run_modules_scanners(
+            self.context, self.config["kernel"], run_hidden_modules=True
+        )
 
         for task in pslist.PsList.list_tasks(
             self.context, vmlinux.name, include_threads=True
@@ -86,9 +80,7 @@ class Kthreads(plugins.PluginInterface):
             if not (threadfn and threadfn.is_readable()):
                 continue
 
-            task_name = utility.array_to_string(task.comm)
-
-            thread_name = task_name
+            thread_name = utility.array_to_string(task.comm)
 
             # kernels >= 5.17 in d6986ce24fc00b0638bd29efe8fb7ba7619ed2aa full_name was added to kthread
             if kthread.has_member("full_name"):
@@ -101,18 +93,23 @@ class Kthreads(plugins.PluginInterface):
                         f"full_name pointer for thread at {kthread.vol.offset:#x} is paged out."
                     )
 
-            module_name, symbol_name = (
-                linux_utilities_modules.Modules.lookup_module_address(
-                    self.context, vmlinux.name, handlers, threadfn
+            module_info, symbol_name = (
+                linux_utilities_modules.Modules.module_lookup_by_address(
+                    self.context, vmlinux.name, known_modules, threadfn
                 )
             )
+
+            if module_info:
+                module_name = module_info.name
+            else:
+                module_name = renderers.NotAvailableValue()
 
             fields = [
                 task.pid,
                 thread_name,
                 format_hints.Hex(threadfn),
                 module_name,
-                symbol_name,
+                symbol_name or renderers.NotAvailableValue(),
             ]
             yield 0, fields
 

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -40,7 +40,7 @@ class Lsmod(plugins.PluginInterface):
     @classmethod
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.list_modules,
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
         removal_date="2025-09-25",
     )
     def list_modules(

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -33,7 +33,7 @@ class Lsmod(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/modxview.py
+++ b/volatility3/framework/plugins/linux/modxview.py
@@ -38,7 +38,17 @@ spot modules presence and taints."""
             ),
             requirements.VersionRequirement(
                 name="linux_utilities_module_gatherers",
-                component=linux_utilities_modules.ModuleGatherers,
+                component=linux_utilities_modules.ModuleGathererLsmod,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="linux_utilities_module_gatherers",
+                component=linux_utilities_modules.ModuleGathererSysFs,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="linux_utilities_module_gatherers",
+                component=linux_utilities_modules.ModuleGathererScanner,
                 version=(1, 0, 0),
             ),
             requirements.VersionRequirement(
@@ -113,14 +123,14 @@ spot modules presence and taints."""
         # We want to be explicit on the plugins results we are interested in
         for gatherer in wanted_gatherers:
             # Iterate over each recovered module
-            for mod_info in run_results[gatherer]:
+            for mod_info in run_results[gatherer.name]:
                 # Use offsets as unique keys, whether a module
                 # appears in many plugin runs or not
                 if aggregated_modules.get(mod_info.offset, None) is not None:
                     # Append the plugin to the list of originating plugins
-                    aggregated_modules[mod_info.offset].append(gatherer)
+                    aggregated_modules[mod_info.offset].append(gatherer.name)
                 else:
-                    aggregated_modules[mod_info.offset] = [gatherer]
+                    aggregated_modules[mod_info.offset] = [gatherer.name]
 
         for module_offset, gatherers in aggregated_modules.items():
             module = kernel.object("module", offset=module_offset, absolute=True)
@@ -148,9 +158,9 @@ spot modules presence and taints."""
                 (
                     module.get_name() or NotAvailableValue(),
                     format_hints.Hex(module_offset),
-                    linux_utilities_modules.ModuleGathererLsmod in gatherers,
-                    linux_utilities_modules.ModuleGathererSysFs in gatherers,
-                    linux_utilities_modules.ModuleGathererScanner in gatherers,
+                    linux_utilities_modules.ModuleGathererLsmod.name in gatherers,
+                    linux_utilities_modules.ModuleGathererSysFs.name in gatherers,
+                    linux_utilities_modules.ModuleGathererScanner.name in gatherers,
                     taints or NotAvailableValue(),
                 ),
             )

--- a/volatility3/framework/plugins/linux/modxview.py
+++ b/volatility3/framework/plugins/linux/modxview.py
@@ -34,7 +34,7 @@ spot modules presence and taints."""
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
                 name="linux-tainting", component=tainting.Tainting, version=(1, 0, 0)
@@ -93,13 +93,22 @@ spot modules presence and taints."""
 
         kernel = self.context.modules[kernel_name]
 
+        wanted_sources = [
+            linux_utilities_modules.Modules.source_lsmod_identifier,
+            linux_utilities_modules.Modules.source_sysfs_identifier,
+            linux_utilities_modules.Modules.source_hidden_identifier,
+        ]
+
         run_results = linux_utilities_modules.Modules.run_modules_scanners(
-            self.context, kernel_name, flatten=False
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            caller_wanted_sources=wanted_sources,
+            flatten=False,
         )
 
         aggregated_modules = {}
         # We want to be explicit on the plugins results we are interested in
-        for plugin_name in ["lsmod", "check_modules", "hidden_modules"]:
+        for plugin_name in wanted_sources:
             # Iterate over each recovered module
             for mod_info in run_results[plugin_name]:
                 # Use offsets as unique keys, whether a module

--- a/volatility3/framework/plugins/linux/modxview.py
+++ b/volatility3/framework/plugins/linux/modxview.py
@@ -50,7 +50,7 @@ spot modules presence and taints."""
     @classmethod
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.flatten_run_modules_results,
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
         removal_date="2025-09-25",
     )
     def flatten_run_modules_results(
@@ -73,7 +73,7 @@ spot modules presence and taints."""
     @classmethod
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.run_modules_scanners,
-        replacement_version=(2, 0, 0),
+        replacement_version=(3, 0, 0),
         removal_date="2025-09-25",
     )
     def run_modules_scanners(

--- a/volatility3/framework/plugins/linux/modxview.py
+++ b/volatility3/framework/plugins/linux/modxview.py
@@ -37,17 +37,17 @@ spot modules presence and taints."""
                 version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
-                name="linux_utilities_module_gatherers",
+                name="linux_utilities_module_gatherer_lsmod",
                 component=linux_utilities_modules.ModuleGathererLsmod,
                 version=(1, 0, 0),
             ),
             requirements.VersionRequirement(
-                name="linux_utilities_module_gatherers",
+                name="linux_utilities_module_gatherer_sysfs",
                 component=linux_utilities_modules.ModuleGathererSysFs,
                 version=(1, 0, 0),
             ),
             requirements.VersionRequirement(
-                name="linux_utilities_module_gatherers",
+                name="linux_utilities_module_gatherer_scanner",
                 component=linux_utilities_modules.ModuleGathererScanner,
                 version=(1, 0, 0),
             ),

--- a/volatility3/framework/plugins/linux/netfilter.py
+++ b/volatility3/framework/plugins/linux/netfilter.py
@@ -726,7 +726,7 @@ class Netfilter(interfaces.plugins.PluginInterface):
 
     _version = (1, 1, 1)
 
-    _required_linux_utilities_modules_version = (2, 0, 0)
+    _required_linux_utilities_modules_version = (3, 0, 0)
     _required_linuxutils_version = (2, 1, 0)
     _required_lsmod_version = (2, 0, 0)
     _required_linuxnet_version = (1, 0, 0)

--- a/volatility3/framework/plugins/linux/tracing/ftrace.py
+++ b/volatility3/framework/plugins/linux/tracing/ftrace.py
@@ -79,7 +79,7 @@ class CheckFtrace(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
             requirements.BooleanRequirement(
                 name="show_ftrace_flags",
@@ -223,7 +223,9 @@ class CheckFtrace(interfaces.plugins.PluginInterface):
             return
 
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
-            self.context, kernel_name, run_hidden_modules=True
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
         )
 
         for ftrace_ops in self.iterate_ftrace_ops_list(self.context, kernel_name):

--- a/volatility3/framework/plugins/linux/tracing/tracepoints.py
+++ b/volatility3/framework/plugins/linux/tracing/tracepoints.py
@@ -5,7 +5,7 @@
 # Public researches: https://i.blackhat.com/USA21/Wednesday-Handouts/us-21-Fixing-A-Memory-Forensics-Blind-Spot-Linux-Kernel-Tracing-wp.pdf
 
 import logging
-from typing import Dict, Iterable, List, Optional
+from typing import Iterable, List, Optional
 from dataclasses import dataclass
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
@@ -38,7 +38,7 @@ class CheckTracepoints(interfaces.plugins.PluginInterface):
     Investigate the tracepoints subsystem to uncover kernel attached probes, which can be leveraged
     to hook kernel functions and modify their behaviour."""
 
-    _version = (1, 0, 0)
+    _version = (2, 0, 0)
     _required_framework_version = (2, 19, 0)
 
     @classmethod
@@ -53,6 +53,11 @@ class CheckTracepoints(interfaces.plugins.PluginInterface):
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
                 version=(3, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="linux_utilities_module_gatherers",
+                component=linux_utilities_modules.ModuleGatherers,
+                version=(1, 0, 0),
             ),
         ]
 
@@ -96,7 +101,7 @@ class CheckTracepoints(interfaces.plugins.PluginInterface):
         cls,
         context: interfaces.context.ContextInterface,
         kernel_module_name: str,
-        known_modules: Dict[str, List[linux_utilities_modules.Modules.ModuleInfo]],
+        known_modules: List[linux_utilities_modules.ModuleInfo],
         tracepoint: interfaces.objects.ObjectInterface,
         run_hidden_modules: bool = True,
     ) -> Optional[Iterable[ParsedTracepointFunc]]:
@@ -231,7 +236,7 @@ class CheckTracepoints(interfaces.plugins.PluginInterface):
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
             context=self.context,
             kernel_module_name=self.config["kernel"],
-            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
+            caller_wanted_gatherers=linux_utilities_modules.ModuleGatherers.all_gatherers_identifier,
         )
         tracepoints = self.iterate_tracepoints_array(self.context, kernel_name)
 

--- a/volatility3/framework/plugins/linux/tracing/tracepoints.py
+++ b/volatility3/framework/plugins/linux/tracing/tracepoints.py
@@ -52,7 +52,7 @@ class CheckTracepoints(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
         ]
 
@@ -229,7 +229,9 @@ class CheckTracepoints(interfaces.plugins.PluginInterface):
             return
 
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
-            self.context, kernel_name, run_hidden_modules=False
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
         )
         tracepoints = self.iterate_tracepoints_array(self.context, kernel_name)
 

--- a/volatility3/framework/plugins/linux/tty_check.py
+++ b/volatility3/framework/plugins/linux/tty_check.py
@@ -12,7 +12,6 @@ from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import linux
-from volatility3.plugins.linux import lsmod
 
 vollog = logging.getLogger(__name__)
 
@@ -35,9 +34,6 @@ class tty_check(plugins.PluginInterface):
                 component=linux_utilities_modules.Modules,
                 version=(2, 0, 0),
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
-            ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
             ),
@@ -45,12 +41,6 @@ class tty_check(plugins.PluginInterface):
 
     def _generator(self):
         vmlinux = self.context.modules[self.config["kernel"]]
-
-        modules = lsmod.Lsmod.list_modules(self.context, vmlinux.name)
-
-        handlers = linux.LinuxUtilities.generate_kernel_handler_info(
-            self.context, vmlinux.name, modules
-        )
 
         try:
             tty_drivers = vmlinux.object_from_symbol("tty_drivers").cast("list_head")
@@ -63,6 +53,10 @@ class tty_check(plugins.PluginInterface):
                 "This structure is not present in the supplied symbol table."
                 "This means you are either analyzing an unsupported kernel version or that your symbol table is corrupt."
             )
+
+        known_modules = linux_utilities_modules.Modules.run_modules_scanners(
+            self.context, self.config["kernel"], run_hidden_modules=True
+        )
 
         for tty in tty_drivers.to_list(
             vmlinux.symbol_table_name + constants.BANG + "tty_driver", "tty_drivers"
@@ -87,13 +81,23 @@ class tty_check(plugins.PluginInterface):
                 except exceptions.InvalidAddressException:
                     continue
 
-                module_name, symbol_name = (
-                    linux_utilities_modules.Modules.lookup_module_address(
-                        self.context, vmlinux.name, handlers, recv_buf
+                module_info, symbol_name = (
+                    linux_utilities_modules.Modules.module_lookup_by_address(
+                        self.context, vmlinux.name, known_modules, recv_buf
                     )
                 )
 
-                yield (0, (name, format_hints.Hex(recv_buf), module_name, symbol_name))
+                if module_info:
+                    module_name = module_info.name
+                else:
+                    module_name = renderers.NotAvailableValue()
+
+                yield 0, (
+                    name,
+                    format_hints.Hex(recv_buf),
+                    module_name,
+                    symbol_name or renderers.NotAvailableValue(),
+                )
 
     def run(self):
         return renderers.TreeGrid(

--- a/volatility3/framework/plugins/linux/tty_check.py
+++ b/volatility3/framework/plugins/linux/tty_check.py
@@ -32,7 +32,7 @@ class tty_check(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linux_utilities_modules",
                 component=linux_utilities_modules.Modules,
-                version=(2, 0, 0),
+                version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
@@ -55,7 +55,9 @@ class tty_check(plugins.PluginInterface):
             )
 
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
-            self.context, self.config["kernel"], run_hidden_modules=True
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
         )
 
         for tty in tty_drivers.to_list(

--- a/volatility3/framework/plugins/linux/tty_check.py
+++ b/volatility3/framework/plugins/linux/tty_check.py
@@ -35,6 +35,11 @@ class tty_check(plugins.PluginInterface):
                 version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
+                name="linux_utilities_module_gatherers",
+                component=linux_utilities_modules.ModuleGatherers,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
             ),
         ]
@@ -57,7 +62,7 @@ class tty_check(plugins.PluginInterface):
         known_modules = linux_utilities_modules.Modules.run_modules_scanners(
             context=self.context,
             kernel_module_name=self.config["kernel"],
-            caller_wanted_sources=linux_utilities_modules.Modules.all_sources_identifier,
+            caller_wanted_gatherers=linux_utilities_modules.ModuleGatherers.all_gatherers_identifier,
         )
 
         for tty in tty_drivers.to_list(

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -237,14 +237,9 @@ class Modules(interfaces.configuration.VersionableInterface):
         to not operate any inter-plugin results triage.
 
         Rules for `caller_wanted_sources`:
-
-            If `ModuleGathers.all_gathers_identifier` is specified then every source will be populated
-
-            If `ModuleGathers.Scanner` is in the list, then at least one other sources must be
-            specified so a comparison will be populated
+            If `ModuleGatherers.all_gathers_identifier` is specified then every source will be populated
 
             If empty or an invalid source is specified then a ValueError is thrown
-
         Args:
             called_wanted_sources: The list of sources to gather modules.
             flatten: Whether to de-duplicate modules across sources

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -268,7 +268,7 @@ class Modules(interfaces.configuration.VersionableInterface):
                     f"Invalid gatherer sent through `caller_wanted_gatherers`: {gatherer}"
                 )
 
-            if gatherer.name is None or len(gatherer.name) == 0:
+            if not gatherer.name:
                 raise ValueError(
                     f"{gatherer} does not have a valid name attribute, which is required. It must be a non-zero length string."
                 )

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -226,23 +226,6 @@ class Modules(interfaces.configuration.VersionableInterface):
         return ModuleInfo(module.vol.offset, mod_name, start, end)
 
     @classmethod
-    def _validate_gatherers(cls, caller_wanted_gatherers) -> List[str]:
-        """
-        Called by `run_modules_scanners` to validate the caller supplied gatherers list
-        An exception is thrown if an empty gatherers list is given or a list containing an invalid source
-        """
-        if not caller_wanted_gatherers:
-            raise ValueError(
-                "`caller_wanted_gatherers` must have at least one gatherer."
-            )
-
-        for gatherer in caller_wanted_gatherers:
-            if gatherer not in ModuleGatherers.all_gatherers_identifier:
-                raise ValueError(
-                    f"Invalid gatherer sent through `caller_wanted_gatherers`: {gatherer}"
-                )
-
-    @classmethod
     def run_modules_scanners(
         cls,
         context: interfaces.context.ContextInterface,
@@ -268,8 +251,20 @@ class Modules(interfaces.configuration.VersionableInterface):
         Returns:
             Dictionary mapping each plugin to its corresponding result
         """
-        # Throws ValueError if invalid gatherers sent in
-        Modules._validate_gatherers(caller_wanted_gatherers)
+        if not caller_wanted_gatherers:
+            raise ValueError(
+                "`caller_wanted_gatherers` must have at least one gatherer."
+            )
+
+        if not isinstance(caller_wanted_gatherers, Iterable):
+            raise ValueError("`caller_wanted_gatherers` must be iterable")
+
+        for gatherer in caller_wanted_gatherers:
+            if not issubclass(gatherer, ModuleGathererInterface):
+                raise ValueError(
+                    f"Invalid gatherer sent through `caller_wanted_gatherers`: {gatherer}"
+                )
+
 
         kernel = context.modules[kernel_module_name]
 

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -265,7 +265,6 @@ class Modules(interfaces.configuration.VersionableInterface):
                     f"Invalid gatherer sent through `caller_wanted_gatherers`: {gatherer}"
                 )
 
-
         kernel = context.modules[kernel_module_name]
 
         address_mask = context.layers[kernel.layer_name].address_mask

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -23,6 +23,7 @@ from volatility3.framework import (
     objects,
 )
 
+from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols.linux import extensions
 
@@ -274,7 +275,7 @@ class Modules(interfaces.configuration.VersionableInterface):
             for module in gatherer.gather_modules(context, kernel_module_name):
 
                 # the kernel sends back a ModuleInfo directly
-                if gatherer == ModuleGathererKernel:
+                if isinstance(module, ModuleInfo):
                     modinfo = module
                 else:
                     modinfo = cls.get_module_info_for_module(address_mask, module)
@@ -541,6 +542,10 @@ class ModuleGathererLsmod(ModuleGathererInterface):
     Gathers modules from the main kernel list
     """
 
+    _version = (1, 0, 0)
+
+    name = "Lsmod"
+
     @classmethod
     def gather_modules(
         cls, context: interfaces.context.ContextInterface, kernel_module_name: str
@@ -552,6 +557,10 @@ class ModuleGathererSysFs(ModuleGathererInterface):
     """
     Gathers modules from the sysfs /sys/modules objects
     """
+
+    _version = (1, 0, 0)
+
+    name = "SysFs"
 
     @classmethod
     def gather_modules(
@@ -569,6 +578,10 @@ class ModuleGathererScanner(ModuleGathererInterface):
     """
     Gathers modules by scanning memory
     """
+
+    _version = (1, 0, 0)
+
+    name = "Scanner"
 
     @classmethod
     def gather_modules(
@@ -593,6 +606,10 @@ class ModuleGathererKernel(ModuleGathererInterface):
     can determine when function pointers reference the kernel
     """
 
+    _version = (1, 0, 0)
+
+    name = "kernel"
+
     @classmethod
     def gather_modules(
         cls, context: interfaces.context.ContextInterface, kernel_module_name: str
@@ -614,7 +631,10 @@ class ModuleGathererKernel(ModuleGathererInterface):
         yield ModuleInfo(start_addr, constants.linux.KERNEL_NAME, start_addr, end_addr)
 
 
-class ModuleGatherers(interfaces.configuration.VersionableInterface):
+class ModuleGatherers(
+    interfaces.configuration.VersionableInterface,
+    interfaces.configuration.ConfigurableInterface,
+):
     _version = (1, 0, 0)
     _required_framework_version = (2, 0, 0)
 
@@ -629,3 +649,19 @@ class ModuleGatherers(interfaces.configuration.VersionableInterface):
         ModuleGathererScanner,
         ModuleGathererKernel,
     ]
+
+    @classmethod
+    def get_requirements(cls):
+        reqs = []
+
+        # for now, all versions are 1, this will be broken out if/when that changes
+        for gatherer in ModuleGatherers.all_gatherers_identifier:
+            reqs.append(
+                requirements.VersionRequirement(
+                    name=gatherer.name.replace(" ", ""),
+                    component=gatherer,
+                    version=(1, 0, 0),
+                )
+            )
+
+        return reqs

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -51,6 +51,9 @@ class ModuleGathererInterface(
 
     gatherer_return_type = Generator[Union[ModuleInfo, "extensions.module"], None, None]
 
+    # Must be set to a unique, descriptive name of the gathering technique or data structure source
+    name = None
+
     @classmethod
     @abstractmethod
     def gather_modules(
@@ -265,9 +268,9 @@ class Modules(interfaces.configuration.VersionableInterface):
                     f"Invalid gatherer sent through `caller_wanted_gatherers`: {gatherer}"
                 )
 
-            if not hasattr(gatherer, "name"):
+            if gatherer.name is None or len(gatherer.name) == 0:
                 raise ValueError(
-                    f"{gatherer} does not have a name attribute, which is required."
+                    f"{gatherer} does not have a valid name attribute, which is required. It must be a non-zero length string."
                 )
 
             if gatherer.name in seen_names:


### PR DESCRIPTION
This updates all callers except netfilter and kallsyms as netfilters needed an API change and kallsyms is having its own huge update after this.