### PR TITLE
Fix broken truncation from Vol3 bytes to string conversion

### DIFF
--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -188,7 +188,7 @@ def bytes_to_decoded_string(
             )
 
     # cut at terminating byte, if found
-    data = data[:idx]
+    data = bytes(full_decoded_string[:idx], encoding=encoding)
 
     # return with caller-specified encoding and errors
     return data.decode(encoding=encoding, errors=errors)

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -105,7 +105,7 @@ def pointer_to_string(
 
 def gather_contiguous_bytes_from_address(
     context, data_layer, starting_address: int, count: int
-) -> str:
+) -> bytes:
     """
     This method reconstructs a string from memory while also carefully examining each page
 
@@ -148,7 +148,7 @@ def gather_contiguous_bytes_from_address(
 
 def bytes_to_decoded_string(
     data: bytes, encoding: str, errors: str, return_truncated: bool = True
-) -> bytes:
+) -> str:
     """
     Args:
         data: The `bytes` buffer containing the string of a string at offset 0

--- a/volatility3/framework/objects/utility.py
+++ b/volatility3/framework/objects/utility.py
@@ -105,7 +105,7 @@ def pointer_to_string(
 
 def gather_contiguous_bytes_from_address(
     context, data_layer, starting_address: int, count: int
-) -> bytes:
+) -> str:
     """
     This method reconstructs a string from memory while also carefully examining each page
 


### PR DESCRIPTION
@ikelos when running mass testing today on the new GUI plugin, I noticed that some of the strings it was printing were truncated or had a junk byte at the end.

I debugged it and the recent addition on how we handled encode/decode was the culprit as I was indexing back into the original string due to `decode` returning a `str`. This worked for most strings, but depending on the encoding and trailing junk bytes it broke it.

This update makes the previously problematic strings (from the first overhaul PR) still return the valid string without junk at the end while also getting the newly discovered ones.

We need to cast to bytes() here as the `decode` to transform the whole string returns a `str` as seen here:

```
>>> type(b"abc".decode(encoding="utf8"))
<class 'str'>
```