### PR TITLE
Fix first set of ELF parsing unhandled smear protection

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -256,14 +256,18 @@ class module(generic.GenericIntelProcess):
             elf_sym_obj.cached_strtab = self.section_strtab
             yield elf_sym_obj
 
-    def get_symbols_names_and_addresses(self) -> Iterable[Tuple[str, int]]:
+    def get_symbols_names_and_addresses(self, max_symbols: int = 4096) -> Iterable[Tuple[str, int]]:
         """Get names and addresses for each symbol of the module
 
         Yields:
                 A tuple for each symbol containing the symbol name and its corresponding value
         """
         layer = self._context.layers[self.vol.layer_name]
-        for elf_sym_obj in self.get_symbols():
+        for iteration_counter, elf_sym_obj in enumerate(self.get_symbols()):
+            if iteration_counter > max_symbols:
+                vollog.debug(f"Hit maximum symbols ({max_symbols}) for ELF at {self.vol.offset:#x} in layer {self.vol.layer_name}")
+                return
+
             sym_name = elf_sym_obj.get_name()
             if not sym_name:
                 continue

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -256,7 +256,9 @@ class module(generic.GenericIntelProcess):
             elf_sym_obj.cached_strtab = self.section_strtab
             yield elf_sym_obj
 
-    def get_symbols_names_and_addresses(self, max_symbols: int = 4096) -> Iterable[Tuple[str, int]]:
+    def get_symbols_names_and_addresses(
+        self, max_symbols: int = 4096
+    ) -> Iterable[Tuple[str, int]]:
         """Get names and addresses for each symbol of the module
 
         Yields:
@@ -265,7 +267,9 @@ class module(generic.GenericIntelProcess):
         layer = self._context.layers[self.vol.layer_name]
         for iteration_counter, elf_sym_obj in enumerate(self.get_symbols()):
             if iteration_counter > max_symbols:
-                vollog.debug(f"Hit maximum symbols ({max_symbols}) for ELF at {self.vol.offset:#x} in layer {self.vol.layer_name}")
+                vollog.debug(
+                    f"Hit maximum symbols ({max_symbols}) for ELF at {self.vol.offset:#x} in layer {self.vol.layer_name}"
+                )
                 return
 
             sym_name = elf_sym_obj.get_name()

--- a/volatility3/framework/symbols/linux/extensions/elf.py
+++ b/volatility3/framework/symbols/linux/extensions/elf.py
@@ -329,7 +329,10 @@ class elf_sym(objects.StructType):
     def get_name(self) -> Optional[str]:
         """Returns the symbol name"""
 
-        addr = self._cached_strtab + self.st_name
+        try:
+            addr = self._cached_strtab + self.st_name
+        except exceptions.InvalidAddressException:
+            return None
 
         layer = self._context.layers[self.vol.layer_name]
         name_bytes = layer.read(addr, self._MAX_NAME_LENGTH, pad=True)


### PR DESCRIPTION
The ELF parsing code is very, very rough when it comes to properly handling smear, returning `None` in failures of `get_*` functions and so on. These two code paths were making testing impossible.