### PR TITLE
Create versioned parent class for all plugins that enumerate Linux ke…

### DIFF
--- a/volatility3/framework/plugins/linux/check_modules.py
+++ b/volatility3/framework/plugins/linux/check_modules.py
@@ -3,24 +3,25 @@
 #
 
 import logging
-from typing import List, Dict
+from typing import List, Dict, Generator
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
-from volatility3.framework import interfaces, renderers, deprecation
+from volatility3.framework import interfaces, deprecation
 from volatility3.framework.configuration import requirements
-from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
-from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols.linux import extensions
 
 vollog = logging.getLogger(__name__)
 
 
-class Check_modules(plugins.PluginInterface):
+class Check_modules(linux_utilities_modules.ModuleDisplayPlugin):
     """Compares module list to sysfs info, if available"""
 
-    _version = (2, 0, 0)
+    _version = (3, 0, 0)
     _required_framework_version = (2, 0, 0)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(self.compare_kset_and_lsmod, *args, **kwargs)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -31,9 +32,9 @@ class Check_modules(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="linux_utilities_modules",
-                component=linux_utilities_modules.Modules,
-                version=(3, 0, 0),
+                name="linux_utilities_modules_module_display_plugin",
+                component=linux_utilities_modules.ModuleDisplayPlugin,
+                version=(1, 0, 0),
             ),
         ]
 
@@ -48,23 +49,20 @@ class Check_modules(plugins.PluginInterface):
     ) -> Dict[str, extensions.module]:
         return linux_utilities_modules.Modules.get_kset_modules(context, vmlinux_name)
 
-    def _generator(self):
+    @classmethod
+    def compare_kset_and_lsmod(
+        cls, context: str, vmlinux_name: str
+    ) -> Generator[extensions.module, None, None]:
         kset_modules = linux_utilities_modules.Modules.get_kset_modules(
-            self.context, self.config["kernel"]
+            context=context, vmlinux_name=vmlinux_name
         )
 
         lsmod_modules = set(
             str(utility.array_to_string(modules.name))
             for modules in linux_utilities_modules.Modules.list_modules(
-                self.context, self.config["kernel"]
+                context=context, vmlinux_module_name=vmlinux_name
             )
         )
 
         for mod_name in set(kset_modules.keys()).difference(lsmod_modules):
-            yield (0, (format_hints.Hex(kset_modules[mod_name]), str(mod_name)))
-
-    def run(self):
-        return renderers.TreeGrid(
-            [("Module Address", format_hints.Hex), ("Module Name", str)],
-            self._generator(),
-        )
+            yield kset_modules[mod_name]

--- a/volatility3/framework/plugins/linux/check_modules.py
+++ b/volatility3/framework/plugins/linux/check_modules.py
@@ -10,11 +10,14 @@ from volatility3.framework import interfaces, deprecation
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols.linux import extensions
+from volatility3.framework.interfaces import plugins
 
 vollog = logging.getLogger(__name__)
 
 
-class Check_modules(linux_utilities_modules.ModuleDisplayPlugin):
+class Check_modules(
+    linux_utilities_modules.ModuleDisplayPlugin, plugins.PluginInterface
+):
     """Compares module list to sysfs info, if available"""
 
     _version = (3, 0, 0)

--- a/volatility3/framework/plugins/linux/hidden_modules.py
+++ b/volatility3/framework/plugins/linux/hidden_modules.py
@@ -10,11 +10,14 @@ from volatility3.framework import interfaces, exceptions, deprecation
 from volatility3.framework.constants import architectures
 from volatility3.framework.configuration import requirements
 from volatility3.framework.symbols.linux import extensions
+from volatility3.framework.interfaces import plugins
 
 vollog = logging.getLogger(__name__)
 
 
-class Hidden_modules(linux_utilities_modules.ModuleDisplayPlugin):
+class Hidden_modules(
+    linux_utilities_modules.ModuleDisplayPlugin, plugins.PluginInterface
+):
     """Carves memory to find hidden kernel modules"""
 
     _required_framework_version = (2, 10, 0)

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -9,11 +9,12 @@ from typing import List, Iterable
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
 from volatility3.framework import interfaces, deprecation
 from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
 
 vollog = logging.getLogger(__name__)
 
 
-class Lsmod(linux_utilities_modules.ModuleDisplayPlugin):
+class Lsmod(linux_utilities_modules.ModuleDisplayPlugin, plugins.PluginInterface):
     """Lists loaded kernel modules."""
 
     _required_framework_version = (2, 0, 0)

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -7,20 +7,20 @@ import logging
 from typing import List, Iterable
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
-from volatility3.framework import exceptions, renderers, interfaces, deprecation
+from volatility3.framework import interfaces, deprecation
 from volatility3.framework.configuration import requirements
-from volatility3.framework.interfaces import plugins
-from volatility3.framework.objects import utility
-from volatility3.framework.renderers import format_hints
 
 vollog = logging.getLogger(__name__)
 
 
-class Lsmod(plugins.PluginInterface):
+class Lsmod(linux_utilities_modules.ModuleDisplayPlugin):
     """Lists loaded kernel modules."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (2, 0, 0)
+    _version = (3, 0, 0)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(linux_utilities_modules.ModuleGathererLsmod, *args, **kwargs)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -31,9 +31,14 @@ class Lsmod(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="linux_utilities_modules",
-                component=linux_utilities_modules.Modules,
-                version=(3, 0, 0),
+                name="linux_utilities_modules_gatherers_lsmod",
+                component=linux_utilities_modules.ModuleGathererLsmod,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="linux_utilities_modules_module_display_plugin",
+                component=linux_utilities_modules.ModuleDisplayPlugin,
+                version=(1, 0, 0),
             ),
         ]
 
@@ -48,26 +53,4 @@ class Lsmod(plugins.PluginInterface):
     ) -> Iterable[interfaces.objects.ObjectInterface]:
         return linux_utilities_modules.Modules.list_modules(
             context, vmlinux_module_name
-        )
-
-    def _generator(self):
-        try:
-            for module in linux_utilities_modules.Modules.list_modules(
-                self.context, self.config["kernel"]
-            ):
-                mod_size = module.get_init_size() + module.get_core_size()
-
-                mod_name = utility.array_to_string(module.name)
-
-                yield 0, (format_hints.Hex(module.vol.offset), mod_name, mod_size)
-
-        except exceptions.SymbolError:
-            vollog.warning(
-                "The required symbol 'module' is not present in symbol table. Please check that kernel modules are enabled for the system under analysis."
-            )
-
-    def run(self):
-        return renderers.TreeGrid(
-            [("Offset", format_hints.Hex), ("Name", str), ("Size", int)],
-            self._generator(),
         )

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -14,14 +14,15 @@ from volatility3.framework.interfaces import plugins
 vollog = logging.getLogger(__name__)
 
 
-class Lsmod(linux_utilities_modules.ModuleDisplayPlugin, plugins.PluginInterface):
+class Lsmod(plugins.PluginInterface):
     """Lists loaded kernel modules."""
 
     _required_framework_version = (2, 0, 0)
     _version = (3, 0, 0)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(linux_utilities_modules.Modules.list_modules, *args, **kwargs)
+    run = linux_utilities_modules.ModuleDisplayPlugin.run
+    _generator = linux_utilities_modules.ModuleDisplayPlugin.generator
+    implementation = linux_utilities_modules.Modules.list_modules
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -20,7 +20,7 @@ class Lsmod(linux_utilities_modules.ModuleDisplayPlugin):
     _version = (3, 0, 0)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(linux_utilities_modules.ModuleGathererLsmod, *args, **kwargs)
+        super().__init__(linux_utilities_modules.Modules.list_modules, *args, **kwargs)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -31,9 +31,9 @@ class Lsmod(linux_utilities_modules.ModuleDisplayPlugin):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="linux_utilities_modules_gatherers_lsmod",
-                component=linux_utilities_modules.ModuleGathererLsmod,
-                version=(1, 0, 0),
+                name="linux_utilities_modules",
+                component=linux_utilities_modules.Modules,
+                version=(3, 0, 0),
             ),
             requirements.VersionRequirement(
                 name="linux_utilities_modules_module_display_plugin",

--- a/volatility3/framework/symbols/linux/kallsyms.py
+++ b/volatility3/framework/symbols/linux/kallsyms.py
@@ -305,7 +305,6 @@ class Kallsyms(interfaces.configuration.VersionableInterface):
     def _assert_versions(cls) -> None:
         """Verify versions of shared dependencies"""
         linux_utilities_modules_version_required = (3, 0, 0)
-
         if not requirements.VersionRequirement.matches_required(
             linux_utilities_modules_version_required,
             linux_utilities_modules.Modules.version,

--- a/volatility3/framework/symbols/linux/kallsyms.py
+++ b/volatility3/framework/symbols/linux/kallsyms.py
@@ -305,6 +305,7 @@ class Kallsyms(interfaces.configuration.VersionableInterface):
     def _assert_versions(cls) -> None:
         """Verify versions of shared dependencies"""
         linux_utilities_modules_version_required = (3, 0, 0)
+
         if not requirements.VersionRequirement.matches_required(
             linux_utilities_modules_version_required,
             linux_utilities_modules.Modules.version,

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -701,10 +701,6 @@ class ModuleDisplayPlugin(interfaces.configuration.VersionableInterface):
 
     framework.require_interface_version(*_required_framework_version)
 
-    def __init__(self, implementation, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.implementation = implementation
-
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         return [
@@ -723,7 +719,7 @@ class ModuleDisplayPlugin(interfaces.configuration.VersionableInterface):
             ),
         ]
 
-    def _generator(self):
+    def generator(self):
         """
         Uses the implementation set in the constructor call to produce consistent output fields
         across module gathering plugins

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -28,7 +28,6 @@ from volatility3.framework.renderers import format_hints
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols.linux import extensions
-from volatility3.framework.interfaces import plugins
 from volatility3.framework.symbols.linux.utilities import tainting
 
 vollog = logging.getLogger(__name__)

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -690,7 +690,7 @@ class ModuleGatherers(
         return reqs
 
 
-class ModuleDisplayPlugin(plugins.PluginInterface):
+class ModuleDisplayPlugin(interfaces.configuration.VersionableInterface):
     """
     Plugins that enumerate kernel modules (lsmod, check_modules, etc.)
     must inherit from this class to have unified output columns across plugins.


### PR DESCRIPTION
…rnel modules. Convert plugins to new method.

Ok @ikelos I am really happy to see how this turned out. Previously each of the enumeration plugins printed different columns and used different names. This gets us to where everything is consistent with a proper name.

Furthermore, given the maturity we now have with the versioning of modules, there is no need for a particular plugin to be the "main" one that the others inherit from (like thrdscan in Windows for threads plugins), and instead we can have a fully versioned chain of classes that plugins can use for our `self.implementation` style enumeration when the outputs will be the same.

You will see the in the comment I left, but this also sets us up to display Load Arguments, but jamming that into this PR would have spiraled it, so that will fill in here once merged.