### PR TITLE
Windows: Fix raw Dpc offset calculation

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,6 +1,6 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 24  # Number of changes that only add to the interface
+VERSION_MINOR = 25  # Number of changes that only add to the interface
 VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -410,6 +410,19 @@ class Pointer(Integer):
         value = int.from_bytes(data, byteorder=endian, signed=signed)
         return value & mask
 
+    def get_raw_value(self) -> int:
+        formats = {
+            4: "I",
+            8: "Q",
+        }
+        length = self.vol.data_format.length
+        endian = self.vol.data_format.byteorder
+        raw_data = self._context.layers[self.vol.layer_name].read(
+            self.vol.offset, length
+        )
+        struct_format = ("<" if endian == "little" else ">") + formats[length]
+        return struct.unpack(struct_format, raw_data)[0]
+
     def dereference(
         self, layer_name: Optional[str] = None
     ) -> interfaces.objects.ObjectInterface:

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -402,26 +402,35 @@ class Pointer(Integer):
         pointer should be recast.  The "pointer" must always live within
         the space (even if the data provided is invalid).
         """
+        mask = context.layers[object_info.native_layer_name].address_mask
+        new = (
+            cls._get_raw_value(
+                context, data_format, object_info.layer_name, object_info.offset
+            )
+            & mask
+        )
+        return new
+
+    @classmethod
+    def _get_raw_value(
+        cls,
+        context: interfaces.context.ContextInterface,
+        data_format: DataFormatInfo,
+        layer_name: str,
+        offset: int,
+    ) -> int:
         length, endian, signed = data_format
         if signed:
             raise ValueError("Pointers cannot have signed values")
-        mask = context.layers[object_info.native_layer_name].address_mask
-        data = context.layers.read(object_info.layer_name, object_info.offset, length)
+        data = context.layers.read(layer_name, offset, length)
         value = int.from_bytes(data, byteorder=endian, signed=signed)
-        return value & mask
+        return value
 
     def get_raw_value(self) -> int:
-        formats = {
-            4: "I",
-            8: "Q",
-        }
-        length = self.vol.data_format.length
-        endian = self.vol.data_format.byteorder
-        raw_data = self._context.layers[self.vol.layer_name].read(
-            self.vol.offset, length
+        raw = self._get_raw_value(
+            self._context, self.vol.data_format, self.vol.layer_name, self.vol.offset
         )
-        struct_format = ("<" if endian == "little" else ">") + formats[length]
-        return struct.unpack(struct_format, raw_data)[0]
+        return raw
 
     def dereference(
         self, layer_name: Optional[str] = None

--- a/volatility3/framework/plugins/windows/timers.py
+++ b/volatility3/framework/plugins/windows/timers.py
@@ -131,6 +131,7 @@ class Timers(interfaces.plugins.PluginInterface):
         ):
             if not timer.valid_type():
                 continue
+
             try:
                 dpc = timer.get_dpc()
                 if dpc == 0:
@@ -138,7 +139,10 @@ class Timers(interfaces.plugins.PluginInterface):
                 if dpc.DeferredRoutine == 0:
                     continue
                 deferred_routine = dpc.DeferredRoutine
-            except Exception:
+            except Exception as exc:
+                vollog.debug(
+                    f"Failed to get _KTIMER.Dpc: {exc.__class__.__name__} {str(exc)}"
+                )
                 continue
 
             module_symbols = list(

--- a/volatility3/framework/plugins/windows/timers.py
+++ b/volatility3/framework/plugins/windows/timers.py
@@ -11,6 +11,7 @@ from volatility3.framework import (
     interfaces,
     constants,
     symbols,
+    exceptions,
 )
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
@@ -139,9 +140,9 @@ class Timers(interfaces.plugins.PluginInterface):
                 if dpc.DeferredRoutine == 0:
                     continue
                 deferred_routine = dpc.DeferredRoutine
-            except Exception as exc:
+            except exceptions.InvalidAddressException as exc:
                 vollog.debug(
-                    f"Failed to get _KTIMER.Dpc: {exc.__class__.__name__} {str(exc)}"
+                    f"Failed to get _KTIMER.Dpc due to {exc.__class__.__name__}"
                 )
                 continue
 

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -22,9 +22,8 @@ from volatility3.framework.interfaces.objects import ObjectInterface
 from volatility3.framework.layers import intel
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import conversion
-from volatility3.framework.symbols import generic
+from volatility3.framework.symbols import generic, windows
 from volatility3.framework.symbols.windows.extensions import pool
-from volatility3.framework.symbols import windows
 
 vollog = logging.getLogger(__name__)
 
@@ -1222,17 +1221,13 @@ class KTIMER(objects.StructType):
         return "-"
 
     def get_raw_dpc(self):
-        """Returns the encoded DPC since it may not look like a pointer after encoding"""
-        symbol_table_name = self.get_symbol_table_name()
-        pointer_type = self._context.symbol_space.get_type(
-            symbol_table_name + constants.BANG + "pointer"
-        )
-
-        return self._context.object(
-            object_type=pointer_type,
-            layer_name=self.vol.layer_name,
-            offset=self.Dpc.vol.offset,
-        )
+        """Returns the encoded DPC as an unsigned long long since the pointer is actually encoded"""
+        if symbols.symbol_table_is_64bit(
+            context=self._context, symbol_table_name=self.get_symbol_table_name()
+        ):
+            return self.Dpc.cast("unsigned long long")
+        else:
+            return self.Dpc.cast("unsigned long")
 
     def valid_type(self):
         return self.Header.Type in self.VALID_TYPES

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -1220,15 +1220,6 @@ class KTIMER(objects.StructType):
             return "Yes"
         return "-"
 
-    def get_raw_dpc(self):
-        """Returns the encoded DPC as an unsigned long long since the pointer is actually encoded"""
-        if symbols.symbol_table_is_64bit(
-            context=self._context, symbol_table_name=self.get_symbol_table_name()
-        ):
-            return self.Dpc.cast("unsigned long long")
-        else:
-            return self.Dpc.cast("unsigned long")
-
     def valid_type(self):
         return self.Header.Type in self.VALID_TYPES
 
@@ -1263,7 +1254,7 @@ class KTIMER(objects.StructType):
             )
 
             low_byte = (wait_never) & 0xFF
-            entry = utility.rol(self.get_raw_dpc() ^ wait_never, low_byte)
+            entry = utility.rol(self.Dpc.get_raw_value() ^ wait_never, low_byte)
             swap_xor = self._context.layers[self.vol.native_layer_name].canonicalize(
                 self.vol.offset
             )


### PR DESCRIPTION
The original code was still returning this as a pointer that ended up
dereferenced in later steps. However, this pointer value actually needs
to be cast to an `unsigned long long` and decoded first.
