### PR TITLE
Volshell: Add byteorder argument for display_* functions

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -310,23 +310,25 @@ class Volshell(interfaces.plugins.PluginInterface):
         self._display_data(offset, remaining_data)
 
     def display_quadwords(
-        self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None
+        self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None, byteorder="@"
     ):
         """Displays quad-word values (8 bytes) and corresponding ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
-        self._display_data(offset, remaining_data, format_string="Q")
+        self._display_data(offset, remaining_data, format_string=f"{byteorder}Q")
 
     def display_doublewords(
-        self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None
+        self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None, byteorder="@"
     ):
         """Displays double-word values (4 bytes) and corresponding ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
-        self._display_data(offset, remaining_data, format_string="I")
+        self._display_data(offset, remaining_data, format_string=f"{byteorder}I")
 
-    def display_words(self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None):
+    def display_words(
+        self, offset, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None, byteorder="@"
+    ):
         """Displays word values (2 bytes) and corresponding ASCII characters"""
         remaining_data = self._read_data(offset, count=count, layer_name=layer_name)
-        self._display_data(offset, remaining_data, format_string="H")
+        self._display_data(offset, remaining_data, format_string=f"{byteorder}H")
 
     def regex_scan(self, pattern, count=DEFAULT_NUM_DISPLAY_BYTES, layer_name=None):
         """Scans for regex pattern in layer using RegExScanner."""


### PR DESCRIPTION
Add a byte order argument to `display_*` functions, to display data in different endianness