### PR TITLE
Add win32 start address listing. Add paths for both thread starting a…

### DIFF
--- a/volatility3/framework/plugins/windows/orphan_kernel_threads.py
+++ b/volatility3/framework/plugins/windows/orphan_kernel_threads.py
@@ -34,7 +34,7 @@ class Threads(thrdscan.ThrdScan):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="thrdscan", plugin=thrdscan.ThrdScan, version=(1, 1, 0)
+                name="thrdscan", plugin=thrdscan.ThrdScan, version=(2, 0, 0)
             ),
             requirements.PluginRequirement(
                 name="ssdt", plugin=ssdt.SSDT, version=(2, 0, 0)

--- a/volatility3/framework/plugins/windows/psxview.py
+++ b/volatility3/framework/plugins/windows/psxview.py
@@ -55,7 +55,7 @@ We recommend using -r pretty if you are looking at this plugin's output in a ter
                 name="psscan", component=psscan.PsScan, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="thrdscan", component=thrdscan.ThrdScan, version=(1, 0, 0)
+                name="thrdscan", component=thrdscan.ThrdScan, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="handles", component=handles.Handles, version=(3, 0, 0)

--- a/volatility3/framework/plugins/windows/suspicious_threads.py
+++ b/volatility3/framework/plugins/windows/suspicious_threads.py
@@ -35,7 +35,7 @@ class SuspiciousThreads(interfaces.plugins.PluginInterface):
                 optional=True,
             ),
             requirements.VersionRequirement(
-                name="thrdscan", component=thrdscan.ThrdScan, version=(1, 1, 0)
+                name="thrdscan", component=thrdscan.ThrdScan, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
@@ -181,11 +181,11 @@ class SuspiciousThreads(interfaces.plugins.PluginInterface):
                 if not info:
                     continue
 
-                _, _, tid, start_address, _, _ = info
+                _, _, tid, start_address, _, win32_start_address, _, _, _ = info
 
                 addresses = [
                     (start_address, "Start"),
-                    (thread.Win32StartAddress, "Win32Start"),
+                    (win32_start_address, "Win32Start"),
                 ]
 
                 for address, context in addresses:

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -32,7 +32,7 @@ class Threads(thrdscan.ThrdScan):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.PluginRequirement(
-                name="thrdscan", plugin=thrdscan.ThrdScan, version=(1, 1, 0)
+                name="thrdscan", plugin=thrdscan.ThrdScan, version=(2, 0, 0)
             ),
         ]
 


### PR DESCRIPTION
…ddress types

@ikelos this is the one I mentioned some weeks ago and just got to finish and test today. Previously, we only listed the address of the `start address` thread address, which is not very helpful.

Now we also list the second thread start address, the `win32` one + we list the full path for all the threads.