### PR TITLE
Add a --script-only flag that exits after the given volshell script i…

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -60,7 +60,13 @@ class Volshell(interfaces.plugins.PluginInterface):
                     description="File to load and execute at start",
                     default=None,
                     optional=True,
-                )
+                ),
+                requirements.BooleanRequirement(
+                    name="script-only",
+                    description="Exit volshell after the script specified in --script completes",
+                    default=False,
+                    optional=True,
+                ),
             ]
         return reqs + [
             requirements.TranslationLayerRequirement(
@@ -134,6 +140,9 @@ class Volshell(interfaces.plugins.PluginInterface):
         # rely on the default having been set
         if self.config.get("script", None) is not None:
             self.run_script(location=self.config["script"])
+
+            if self.config.get("script-only"):
+                exit()
 
         if has_ipython:
             self.__console()


### PR DESCRIPTION
…s completed.

@ikelos While testing https://github.com/volatilityfoundation/volatility3/issues/1732, I remembered that I had a local patch to my volshell for scripts that I never made into a PR. I am fixing that now. Currently you cannot sanely run volshell scripts across many samples due to volshell dropping into the shell after the script runs. This PR adds a `--script-only` flag that, when set, exits volshell after the script is completed. When `-q` is set and no `-v`, only the script output is returned, which is what is needed for quick artifact gathering. If `--script-only` is not set then volshell loads like normal after script completion. 