### PR TITLE
Framework: Replace PluginRequirements

### DIFF
--- a/doc/source/simple-plugin.rst
+++ b/doc/source/simple-plugin.rst
@@ -53,9 +53,9 @@ to be able to run properly.  Any that are defined as optional need not necessari
                     description = "Process IDs to include (all other processes are excluded)",
                     optional = True
                 ),
-                requirements.PluginRequirement(
+                requirements.VersionRequirement(
                     name = 'pslist',
-                    plugin = pslist.PsList,
+                    component = pslist.PsList,
                     version = (2, 0, 0)
                 ),
             ]

--- a/volatility3/cli/volshell/linux.py
+++ b/volatility3/cli/volshell/linux.py
@@ -30,8 +30,8 @@ class Volshell(generic.Volshell):
             requirements.ModuleRequirement(
                 name="kernel", description="Linux kernel module"
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.IntRequirement(
                 name="pid", description="Process ID", optional=True

--- a/volatility3/cli/volshell/mac.py
+++ b/volatility3/cli/volshell/mac.py
@@ -19,8 +19,8 @@ class Volshell(generic.Volshell):
             requirements.ModuleRequirement(
                 name="kernel", description="Darwin kernel module"
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.IntRequirement(
                 name="pid", description="Process ID", optional=True

--- a/volatility3/cli/volshell/windows.py
+++ b/volatility3/cli/volshell/windows.py
@@ -17,8 +17,8 @@ class Volshell(generic.Volshell):
     def get_requirements(cls):
         return [
             requirements.ModuleRequirement(name="kernel", description="Windows kernel"),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.IntRequirement(
                 name="pid", description="Process ID", optional=True

--- a/volatility3/framework/plugins/linux/bash.py
+++ b/volatility3/framework/plugins/linux/bash.py
@@ -32,8 +32,8 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/boottime.py
+++ b/volatility3/framework/plugins/linux/boottime.py
@@ -25,8 +25,8 @@ class Boottime(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/capabilities.py
+++ b/volatility3/framework/plugins/linux/capabilities.py
@@ -60,8 +60,8 @@ class Capabilities(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pids",

--- a/volatility3/framework/plugins/linux/check_creds.py
+++ b/volatility3/framework/plugins/linux/check_creds.py
@@ -22,8 +22,8 @@ class Check_creds(interfaces.plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -35,8 +35,8 @@ class Elfs(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/envars.py
+++ b/volatility3/framework/plugins/linux/envars.py
@@ -29,8 +29,8 @@ class Envars(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/kthreads.py
+++ b/volatility3/framework/plugins/linux/kthreads.py
@@ -44,8 +44,8 @@ class Kthreads(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/library_list.py
+++ b/volatility3/framework/plugins/linux/library_list.py
@@ -31,8 +31,8 @@ class LibraryList(interfaces.plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pids",

--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -120,8 +120,8 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)

--- a/volatility3/framework/plugins/linux/malfind.py
+++ b/volatility3/framework/plugins/linux/malfind.py
@@ -28,8 +28,8 @@ class Malfind(interfaces.plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/mountinfo.py
+++ b/volatility3/framework/plugins/linux/mountinfo.py
@@ -46,8 +46,8 @@ class MountInfo(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -126,8 +126,8 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 description="Linux kernel",
                 architectures=architectures.LINUX_ARCHS,
             ),
-            requirements.PluginRequirement(
-                name="mountinfo", plugin=mountinfo.MountInfo, version=(1, 2, 0)
+            requirements.VersionRequirement(
+                name="mountinfo", component=mountinfo.MountInfo, version=(1, 2, 0)
             ),
             requirements.ListRequirement(
                 name="type",
@@ -431,8 +431,8 @@ class InodePages(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=architectures.LINUX_ARCHS,
             ),
-            requirements.PluginRequirement(
-                name="files", plugin=Files, version=(1, 0, 0)
+            requirements.VersionRequirement(
+                name="files", component=Files, version=(1, 0, 0)
             ),
             requirements.StringRequirement(
                 name="find",
@@ -650,11 +650,11 @@ class RecoverFs(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=architectures.LINUX_ARCHS,
             ),
-            requirements.PluginRequirement(
-                name="files", plugin=Files, version=(1, 1, 0)
+            requirements.VersionRequirement(
+                name="files", component=Files, version=(1, 1, 0)
             ),
-            requirements.PluginRequirement(
-                name="inodepages", plugin=InodePages, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="inodepages", component=InodePages, version=(3, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="tmpfs_only",

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -29,8 +29,8 @@ class PIDHashTable(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 1, 0)

--- a/volatility3/framework/plugins/linux/proc.py
+++ b/volatility3/framework/plugins/linux/proc.py
@@ -34,8 +34,8 @@ class Maps(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/psaux.py
+++ b/volatility3/framework/plugins/linux/psaux.py
@@ -26,8 +26,8 @@ class PsAux(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/pscallstack.py
+++ b/volatility3/framework/plugins/linux/pscallstack.py
@@ -45,8 +45,8 @@ class PsCallStack(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="Kallsyms", component=kallsyms.Kallsyms, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -44,8 +44,8 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="elfs", plugin=elfs.Elfs, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="elfs", component=elfs.Elfs, version=(2, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/psscan.py
+++ b/volatility3/framework/plugins/linux/psscan.py
@@ -38,8 +38,8 @@ class PsScan(interfaces.plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -27,8 +27,8 @@ class PsTree(interfaces.plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/ptrace.py
+++ b/volatility3/framework/plugins/linux/ptrace.py
@@ -29,8 +29,8 @@ class Ptrace(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=architectures.LINUX_ARCHS,
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -463,11 +463,11 @@ class Sockstat(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="SockHandlers", component=SockHandlers, version=(4, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsof", plugin=lsof.Lsof, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsof", component=lsof.Lsof, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)

--- a/volatility3/framework/plugins/linux/vmaregexscan.py
+++ b/volatility3/framework/plugins/linux/vmaregexscan.py
@@ -34,8 +34,8 @@ class VmaRegExScan(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/linux/vmayarascan.py
+++ b/volatility3/framework/plugins/linux/vmayarascan.py
@@ -30,11 +30,11 @@ class VmaYaraScan(interfaces.plugins.PluginInterface):
                 description="Process IDs to include (all other processes are excluded)",
                 optional=True,
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="yarascan", plugin=yarascan.YaraScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="yarascan", component=yarascan.YaraScan, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="yarascanner", component=yarascan.YaraScanner, version=(2, 0, 0)

--- a/volatility3/framework/plugins/mac/bash.py
+++ b/volatility3/framework/plugins/mac/bash.py
@@ -30,8 +30,8 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/mac/check_syscall.py
+++ b/volatility3/framework/plugins/mac/check_syscall.py
@@ -31,8 +31,8 @@ class Check_syscall(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsmod", component=lsmod.Lsmod, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/mac/check_sysctl.py
+++ b/volatility3/framework/plugins/mac/check_sysctl.py
@@ -33,8 +33,8 @@ class Check_sysctl(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsmod", component=lsmod.Lsmod, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/mac/check_trap_table.py
+++ b/volatility3/framework/plugins/mac/check_trap_table.py
@@ -29,8 +29,8 @@ class Check_trap_table(plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsmod", component=lsmod.Lsmod, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 0, 0)

--- a/volatility3/framework/plugins/mac/kauth_listeners.py
+++ b/volatility3/framework/plugins/mac/kauth_listeners.py
@@ -26,11 +26,13 @@ class Kauth_listeners(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 1, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsmod", component=lsmod.Lsmod, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="kauth_scopes", plugin=kauth_scopes.Kauth_scopes, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="kauth_scopes",
+                component=kauth_scopes.Kauth_scopes,
+                version=(2, 0, 0),
             ),
         ]
 

--- a/volatility3/framework/plugins/mac/kauth_scopes.py
+++ b/volatility3/framework/plugins/mac/kauth_scopes.py
@@ -31,8 +31,8 @@ class Kauth_scopes(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 1, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsmod", component=lsmod.Lsmod, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/mac/kevents.py
+++ b/volatility3/framework/plugins/mac/kevents.py
@@ -71,8 +71,8 @@ class Kevents(interfaces.plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 2, 0)

--- a/volatility3/framework/plugins/mac/list_files.py
+++ b/volatility3/framework/plugins/mac/list_files.py
@@ -28,8 +28,8 @@ class List_Files(plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="mount", plugin=mount.Mount, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="mount", component=mount.Mount, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/mac/lsof.py
+++ b/volatility3/framework/plugins/mac/lsof.py
@@ -29,8 +29,8 @@ class Lsof(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/mac/malfind.py
+++ b/volatility3/framework/plugins/mac/malfind.py
@@ -23,8 +23,8 @@ class Malfind(interfaces.plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/mac/netstat.py
+++ b/volatility3/framework/plugins/mac/netstat.py
@@ -29,8 +29,8 @@ class Netstat(plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 0, 0)

--- a/volatility3/framework/plugins/mac/proc_maps.py
+++ b/volatility3/framework/plugins/mac/proc_maps.py
@@ -28,8 +28,8 @@ class Maps(interfaces.plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/mac/psaux.py
+++ b/volatility3/framework/plugins/mac/psaux.py
@@ -24,8 +24,8 @@ class Psaux(plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/mac/pstree.py
+++ b/volatility3/framework/plugins/mac/pstree.py
@@ -28,8 +28,8 @@ class PsTree(plugins.PluginInterface):
                 description="Kernel module for the OS",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/mac/socket_filters.py
+++ b/volatility3/framework/plugins/mac/socket_filters.py
@@ -32,8 +32,8 @@ class Socket_filters(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsmod", component=lsmod.Lsmod, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/mac/trustedbsd.py
+++ b/volatility3/framework/plugins/mac/trustedbsd.py
@@ -33,8 +33,8 @@ class Trustedbsd(plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="macutils", component=mac.MacUtilities, version=(1, 3, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsmod", plugin=lsmod.Lsmod, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="lsmod", component=lsmod.Lsmod, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/amcache.py
+++ b/volatility3/framework/plugins/windows/amcache.py
@@ -231,8 +231,8 @@ class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/cachedump.py
+++ b/volatility3/framework/plugins/windows/cachedump.py
@@ -32,14 +32,14 @@ class Cachedump(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="lsadump", plugin=lsadump.Lsadump, version=(1, 0, 0)
+            requirements.VersionRequirement(
+                name="lsadump", component=lsadump.Lsadump, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="hashdump", plugin=hashdump.Hashdump, version=(1, 1, 0)
+            requirements.VersionRequirement(
+                name="hashdump", component=hashdump.Hashdump, version=(1, 1, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/callbacks.py
+++ b/volatility3/framework/plugins/windows/callbacks.py
@@ -38,17 +38,17 @@ class Callbacks(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="ssdt", plugin=ssdt.SSDT, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="ssdt", component=ssdt.SSDT, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="driverirp", plugin=driverirp.DriverIrp, version=(1, 0, 0)
+            requirements.VersionRequirement(
+                name="driverirp", component=driverirp.DriverIrp, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="handles", plugin=handles.Handles, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="handles", component=handles.Handles, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/cmdline.py
+++ b/volatility3/framework/plugins/windows/cmdline.py
@@ -27,8 +27,8 @@ class CmdLine(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/cmdscan.py
+++ b/volatility3/framework/plugins/windows/cmdscan.py
@@ -38,8 +38,8 @@ class CmdScan(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="consoles", plugin=consoles.Consoles, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="consoles", component=consoles.Consoles, version=(3, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="no_registry",

--- a/volatility3/framework/plugins/windows/consoles.py
+++ b/volatility3/framework/plugins/windows/consoles.py
@@ -48,8 +48,8 @@ class Consoles(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="verinfo", component=verinfo.VerInfo, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="no_registry",

--- a/volatility3/framework/plugins/windows/deskscan.py
+++ b/volatility3/framework/plugins/windows/deskscan.py
@@ -31,12 +31,12 @@ class DeskScan(desktops.Desktops):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="desktops", plugin=desktops.Desktops, version=(1, 0, 0)
+            requirements.VersionRequirement(
+                name="desktops", component=desktops.Desktops, version=(1, 0, 0)
             ),
-            requirements.PluginRequirement(
+            requirements.VersionRequirement(
                 name="windowstations",
-                plugin=windowstations.WindowStations,
+                component=windowstations.WindowStations,
                 version=(1, 0, 0),
             ),
         ]

--- a/volatility3/framework/plugins/windows/desktops.py
+++ b/volatility3/framework/plugins/windows/desktops.py
@@ -31,9 +31,9 @@ class Desktops(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
+            requirements.VersionRequirement(
                 name="windowstations",
-                plugin=windowstations.WindowStations,
+                component=windowstations.WindowStations,
                 version=(1, 0, 0),
             ),
         ]

--- a/volatility3/framework/plugins/windows/devicetree.py
+++ b/volatility3/framework/plugins/windows/devicetree.py
@@ -89,8 +89,8 @@ class DeviceTree(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="driverscan", plugin=driverscan.DriverScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="driverscan", component=driverscan.DriverScan, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/direct_system_calls.py
+++ b/volatility3/framework/plugins/windows/direct_system_calls.py
@@ -91,14 +91,14 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="yarascanner", component=yarascan.YaraScanner, version=(2, 1, 0)
             ),
-            requirements.PluginRequirement(
-                name="yarascan", plugin=yarascan.YaraScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="yarascan", component=yarascan.YaraScan, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/driverirp.py
+++ b/volatility3/framework/plugins/windows/driverirp.py
@@ -58,14 +58,14 @@ class DriverIrp(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="ssdt", plugin=ssdt.SSDT, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="ssdt", component=ssdt.SSDT, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="driverscan", plugin=driverscan.DriverScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="driverscan", component=driverscan.DriverScan, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="modules", plugin=modules.Modules, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/drivermodule.py
+++ b/volatility3/framework/plugins/windows/drivermodule.py
@@ -25,14 +25,14 @@ class DriverModule(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="ssdt", plugin=ssdt.SSDT, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="ssdt", component=ssdt.SSDT, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="driverscan", plugin=driverscan.DriverScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="driverscan", component=driverscan.DriverScan, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="modules", plugin=modules.Modules, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/driverscan.py
+++ b/volatility3/framework/plugins/windows/driverscan.py
@@ -24,8 +24,8 @@ class DriverScan(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/envars.py
+++ b/volatility3/framework/plugins/windows/envars.py
@@ -39,11 +39,11 @@ class Envars(interfaces.plugins.PluginInterface):
                 description="Suppress common and non-persistent variables",
                 optional=True,
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/filescan.py
+++ b/volatility3/framework/plugins/windows/filescan.py
@@ -24,8 +24,8 @@ class FileScan(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/getservicesids.py
+++ b/volatility3/framework/plugins/windows/getservicesids.py
@@ -68,8 +68,8 @@ class GetServiceSIDs(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/getsids.py
+++ b/volatility3/framework/plugins/windows/getsids.py
@@ -83,11 +83,11 @@ class GetSIDs(interfaces.plugins.PluginInterface):
                 element_type=int,
                 optional=True,
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/handles.py
+++ b/volatility3/framework/plugins/windows/handles.py
@@ -35,8 +35,8 @@ class Handles(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="psscan", component=psscan.PsScan, version=(2, 0, 0)

--- a/volatility3/framework/plugins/windows/hashdump.py
+++ b/volatility3/framework/plugins/windows/hashdump.py
@@ -33,8 +33,8 @@ class Hashdump(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/indirect_system_calls.py
+++ b/volatility3/framework/plugins/windows/indirect_system_calls.py
@@ -46,12 +46,12 @@ class IndirectSystemCalls(direct_system_calls.DirectSystemCalls):
             requirements.VersionRequirement(
                 name="yarascanner", component=yarascan.YaraScanner, version=(2, 1, 0)
             ),
-            requirements.PluginRequirement(
-                name="yarascan", plugin=yarascan.YaraScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="yarascan", component=yarascan.YaraScan, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
+            requirements.VersionRequirement(
                 name="direct_system_calls",
-                plugin=direct_system_calls.DirectSystemCalls,
+                component=direct_system_calls.DirectSystemCalls,
                 version=(2, 0, 0),
             ),
         ]

--- a/volatility3/framework/plugins/windows/memmap.py
+++ b/volatility3/framework/plugins/windows/memmap.py
@@ -27,8 +27,8 @@ class Memmap(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.IntRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -333,8 +333,8 @@ class ADS(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.PluginRequirement(
-                name="MFTScan", plugin=MFTScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="MFTScan", component=MFTScan, version=(2, 0, 0)
             ),
             requirements.TranslationLayerRequirement(
                 name="primary",
@@ -403,8 +403,8 @@ class ResidentData(interfaces.plugins.PluginInterface):
     @classmethod
     def get_requirements(cls):
         return [
-            requirements.PluginRequirement(
-                name="MFTScan", plugin=MFTScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="MFTScan", component=MFTScan, version=(2, 0, 0)
             ),
             requirements.TranslationLayerRequirement(
                 name="primary",

--- a/volatility3/framework/plugins/windows/mutantscan.py
+++ b/volatility3/framework/plugins/windows/mutantscan.py
@@ -24,8 +24,8 @@ class MutantScan(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/orphan_kernel_threads.py
+++ b/volatility3/framework/plugins/windows/orphan_kernel_threads.py
@@ -33,14 +33,14 @@ class Threads(thrdscan.ThrdScan):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="thrdscan", plugin=thrdscan.ThrdScan, version=(1, 1, 0)
+            requirements.VersionRequirement(
+                name="thrdscan", component=thrdscan.ThrdScan, version=(1, 1, 0)
             ),
-            requirements.PluginRequirement(
-                name="ssdt", plugin=ssdt.SSDT, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="ssdt", component=ssdt.SSDT, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="modules", plugin=modules.Modules, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -139,8 +139,8 @@ class PoolScanner(plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="handles", plugin=handles.Handles, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="handles", component=handles.Handles, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/privileges.py
+++ b/volatility3/framework/plugins/windows/privileges.py
@@ -60,8 +60,8 @@ class Privs(interfaces.plugins.PluginInterface):
                 element_type=int,
                 optional=True,
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/psscan.py
+++ b/volatility3/framework/plugins/windows/psscan.py
@@ -33,8 +33,8 @@ class PsScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="info", component=info.Info, version=(2, 0, 0)

--- a/volatility3/framework/plugins/windows/registry/getcellroutine.py
+++ b/volatility3/framework/plugins/windows/registry/getcellroutine.py
@@ -27,11 +27,11 @@ class GetCellRoutine(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="ssdt", plugin=ssdt.SSDT, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="ssdt", component=ssdt.SSDT, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/registry/hivelist.py
+++ b/volatility3/framework/plugins/windows/registry/hivelist.py
@@ -60,8 +60,8 @@ class HiveList(interfaces.plugins.PluginInterface):
                 optional=True,
                 default=None,
             ),
-            requirements.PluginRequirement(
-                name="hivescan", plugin=hivescan.HiveScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivescan", component=hivescan.HiveScan, version=(2, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="dump",

--- a/volatility3/framework/plugins/windows/registry/hivescan.py
+++ b/volatility3/framework/plugins/windows/registry/hivescan.py
@@ -25,11 +25,11 @@ class HiveScan(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="bigpools", plugin=bigpools.BigPools, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="bigpools", component=bigpools.BigPools, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/registry/printkey.py
+++ b/volatility3/framework/plugins/windows/registry/printkey.py
@@ -35,8 +35,8 @@ class PrintKey(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
             requirements.IntRequirement(
                 name="offset", description="Hive Offset", default=None, optional=True

--- a/volatility3/framework/plugins/windows/registry/userassist.py
+++ b/volatility3/framework/plugins/windows/registry/userassist.py
@@ -56,8 +56,8 @@ class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfac
             requirements.IntRequirement(
                 name="offset", description="Hive Offset", default=None, optional=True
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/scheduled_tasks.py
+++ b/volatility3/framework/plugins/windows/scheduled_tasks.py
@@ -1123,8 +1123,8 @@ information about triggers, actions, run times, and creation times."""
                 description="Windows kernel",
                 architectures=["Intel33", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/sessions.py
+++ b/volatility3/framework/plugins/windows/sessions.py
@@ -27,8 +27,8 @@ class Sessions(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/shimcachemem.py
+++ b/volatility3/framework/plugins/windows/shimcachemem.py
@@ -64,8 +64,8 @@ class ShimcacheMem(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterf
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="vadinfo", component=vadinfo.VadInfo, version=(2, 0, 0)

--- a/volatility3/framework/plugins/windows/ssdt.py
+++ b/volatility3/framework/plugins/windows/ssdt.py
@@ -31,8 +31,8 @@ class SSDT(plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="modules", plugin=modules.Modules, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/strings.py
+++ b/volatility3/framework/plugins/windows/strings.py
@@ -33,8 +33,8 @@ class Strings(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/svclist.py
+++ b/volatility3/framework/plugins/windows/svclist.py
@@ -31,8 +31,8 @@ class SvcList(svcscan.SvcScan):
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         # Since we're calling the plugin, make sure we have the plugin's requirements
         return [
-            requirements.PluginRequirement(
-                name="svcscan", plugin=svcscan.SvcScan, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="svcscan", component=svcscan.SvcScan, version=(4, 0, 0)
             ),
             requirements.ModuleRequirement(
                 name="kernel",

--- a/volatility3/framework/plugins/windows/svcscan.py
+++ b/volatility3/framework/plugins/windows/svcscan.py
@@ -50,11 +50,11 @@ class SvcScan(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/thrdscan.py
+++ b/volatility3/framework/plugins/windows/thrdscan.py
@@ -33,8 +33,8 @@ class ThrdScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="poolscanner", plugin=poolscanner.PoolScanner, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -31,8 +31,8 @@ class Threads(thrdscan.ThrdScan):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="thrdscan", plugin=thrdscan.ThrdScan, version=(1, 1, 0)
+            requirements.VersionRequirement(
+                name="thrdscan", component=thrdscan.ThrdScan, version=(1, 1, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/unhooked_system_calls.py
+++ b/volatility3/framework/plugins/windows/unhooked_system_calls.py
@@ -97,8 +97,8 @@ class unhooked_system_calls(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="pe_symbols", plugin=pe_symbols.PESymbols, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pe_symbols", component=pe_symbols.PESymbols, version=(3, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -63,8 +63,8 @@ class VadInfo(interfaces.plugins.PluginInterface):
                 element_type=int,
                 optional=True,
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="dump",

--- a/volatility3/framework/plugins/windows/vadregexscan.py
+++ b/volatility3/framework/plugins/windows/vadregexscan.py
@@ -32,8 +32,8 @@ class VadRegExScan(plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/vadwalk.py
+++ b/volatility3/framework/plugins/windows/vadwalk.py
@@ -28,11 +28,11 @@ class VadWalk(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="vadinfo", plugin=vadinfo.VadInfo, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="vadinfo", component=vadinfo.VadInfo, version=(2, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/vadyarascan.py
+++ b/volatility3/framework/plugins/windows/vadyarascan.py
@@ -29,14 +29,14 @@ class VadYaraScan(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="yarascanner", component=yarascan.YaraScanner, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="yarascan", plugin=yarascan.YaraScan, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="yarascan", component=yarascan.YaraScan, version=(2, 0, 0)
             ),
             requirements.ListRequirement(
                 name="pid",

--- a/volatility3/framework/plugins/windows/verinfo.py
+++ b/volatility3/framework/plugins/windows/verinfo.py
@@ -42,11 +42,11 @@ class VerInfo(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="modules", plugin=modules.Modules, version=(3, 0, 0)
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(3, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="extensive",

--- a/volatility3/plugins/windows/registry/certificates.py
+++ b/volatility3/plugins/windows/registry/certificates.py
@@ -24,11 +24,11 @@ class Certificates(interfaces.plugins.PluginInterface):
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="hivelist", plugin=hivelist.HiveList, version=(2, 0, 0)
+            requirements.VersionRequirement(
+                name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
-            requirements.PluginRequirement(
-                name="printkey", plugin=printkey.PrintKey, version=(1, 0, 0)
+            requirements.VersionRequirement(
+                name="printkey", component=printkey.PrintKey, version=(1, 0, 0)
             ),
             requirements.BooleanRequirement(
                 name="dump",


### PR DESCRIPTION
This replaces all uses of `requirements.PluginRequirements` with `requirements.VersionRequirement`.

closes #1644 
