### PR TITLE
Feature/use less memory

### DIFF
--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -8,7 +8,7 @@ import collections
 import collections.abc
 import contextlib
 import logging
-from typing import Any, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from volatility3.framework import constants, interfaces
 
@@ -22,8 +22,6 @@ class ReadOnlyMapping(collections.abc.Mapping):
     This ensures that the data stored in the mapping should not be
     modified, making an immutable mapping.
     """
-
-    __slots__ = ("_dict",)
 
     def __init__(self, dictionary: Mapping[str, Any]) -> None:
         self._dict = dictionary
@@ -54,7 +52,7 @@ class ReadOnlyMapping(collections.abc.Mapping):
         return dict(self) == dict(other)
 
 
-class ObjectInformation(collections.abc.Mapping):
+class ObjectInformation(ReadOnlyMapping):
     """Contains common information useful/pertinent only to an individual
     object (like an instance)
 
@@ -64,15 +62,6 @@ class ObjectInformation(collections.abc.Mapping):
     This is primarily used to reduce the number of parameters passed to object constructors and keep them all together
     in a single place.  These values are based on the :class:`ReadOnlyMapping` class, to prevent their modification.
     """
-
-    __slots__ = (
-        "layer_name",
-        "offset",
-        "member_name",
-        "parent",
-        "native_layer_name",
-        "size",
-    )
 
     def __init__(
         self,
@@ -93,35 +82,16 @@ class ObjectInformation(collections.abc.Mapping):
             native_layer_name: If this object references other objects (such as a pointer), what layer those objects live in
             size: The size that the whole structure consumes in bytes
         """
-        self.layer_name = layer_name
-        self.offset = offset
-        self.member_name = member_name
-        self.parent = parent
-        self.native_layer_name = native_layer_name or layer_name
-        self.size = size
-
-    def __getattr__(self, attr: str) -> Any:
-        """Returns the item as an attribute."""
-        if attr in self.__slots__:
-            return getattr(self, attr)
-        raise AttributeError(
-            f"Object has no attribute: {self.__class__.__name__}.{attr}"
+        super().__init__(
+            {
+                "layer_name": layer_name,
+                "offset": offset,
+                "member_name": member_name,
+                "parent": parent,
+                "native_layer_name": native_layer_name or layer_name,
+                "size": size,
+            }
         )
-
-    def __getitem__(self, name: str) -> Any:
-        """Returns the item requested."""
-        return getattr(self, name)
-
-    def __iter__(self):
-        """Returns an iterator of the dictionary items."""
-        return self.__slots__.__iter__()
-
-    def __len__(self) -> int:
-        """Returns the length of the internal dictionary."""
-        return len(self.__slots__)
-
-    def __eq__(self, other):
-        return dict(self) == dict(other)
 
 
 class ObjectInterface(metaclass=abc.ABCMeta):
@@ -337,8 +307,6 @@ class Template:
     contain different length limits, without affecting all other strings using the same template from a SymbolTable,
     constructed at resolution time and then cached.
     """
-
-    __slots__ = "_vol"
 
     def __init__(self, type_name: str, **arguments) -> None:
         """Stores the keyword arguments for later object creation."""

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -23,6 +23,8 @@ class ReadOnlyMapping(collections.abc.Mapping):
     modified, making an immutable mapping.
     """
 
+    __slots__ = ("_dict",)
+
     def __init__(self, dictionary: Mapping[str, Any]) -> None:
         self._dict = dictionary
 
@@ -63,6 +65,8 @@ class ObjectInformation(ReadOnlyMapping):
     in a single place.  These values are based on the :class:`ReadOnlyMapping` class, to prevent their modification.
     """
 
+    __slots__ = ()
+
     def __init__(
         self,
         layer_name: str,
@@ -97,6 +101,8 @@ class ObjectInformation(ReadOnlyMapping):
 class ObjectInterface(metaclass=abc.ABCMeta):
     """A base object required to be the ancestor of every object used in
     volatility."""
+
+    __slots__ = ()
 
     def __init__(
         self,
@@ -304,6 +310,8 @@ class Template:
     contain different length limits, without affecting all other strings using the same template from a SymbolTable,
     constructed at resolution time and then cached.
     """
+
+    __slots__ = "_vol"
 
     def __init__(self, type_name: str, **arguments) -> None:
         """Stores the keyword arguments for later object creation."""

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -159,11 +159,11 @@ class ObjectInterface(metaclass=abc.ABCMeta):
         mask = context.layers[object_info.layer_name].address_mask
         normalized_offset = object_info.offset & mask
 
-        self._vol = kwargs
+        vol = kwargs
         vol_info_dict = {"type_name": type_name, "offset": normalized_offset}
-        self._vol.update(object_info)
-        self._vol.update(vol_info_dict)
-        self._vol = collections.ChainMap({}, self._vol)
+        vol.update(object_info)
+        vol.update(vol_info_dict)
+        self._vol = collections.ChainMap({}, vol)
         self._context = context
 
     def __getattr__(self, attr: str) -> Any:

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -133,8 +133,10 @@ class ObjectInterface(metaclass=abc.ABCMeta):
         mask = context.layers[object_info.layer_name].address_mask
         normalized_offset = object_info.offset & mask
 
+        self._vol = kwargs
         vol_info_dict = {"type_name": type_name, "offset": normalized_offset}
-        self._vol = collections.ChainMap({}, vol_info_dict, object_info, kwargs)
+        self._vol.update(object_info)
+        self._vol.update(vol_info_dict)
         self._context = context
 
     def __getattr__(self, attr: str) -> Any:
@@ -317,10 +319,8 @@ class Template:
         """Stores the keyword arguments for later object creation."""
         # Allow the updating of template arguments whilst still in template form
         super().__init__()
-        empty_dict: Dict[str, Any] = {}
-        self._vol = collections.ChainMap(
-            empty_dict, arguments, {"type_name": type_name}
-        )
+        self._vol = {"type_name": type_name}
+        self._vol.update(arguments)
 
     @property
     def vol(self) -> ReadOnlyMapping:
@@ -364,7 +364,7 @@ class Template:
     def clone(self) -> "Template":
         """Returns a copy of the original Template as constructed (without
         `update_vol` additions having been made)"""
-        clone = self.__class__(**self._vol.parents.new_child())
+        clone = self.__class__(**self._vol)
         return clone
 
     def update_vol(self, **new_arguments) -> None:

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -346,9 +346,8 @@ class Template:
         """Stores the keyword arguments for later object creation."""
         # Allow the updating of template arguments whilst still in template form
         super().__init__()
-        self._vol = {"type_name": type_name}
-        self._vol.update(arguments)
-        self._vol = collections.ChainMap({}, self._vol)
+        vol = {"type_name": type_name}.update(arguments)
+        self._vol = collections.ChainMap({}, vol)
 
     @property
     def vol(self) -> ReadOnlyMapping:
@@ -392,7 +391,7 @@ class Template:
     def clone(self) -> "Template":
         """Returns a copy of the original Template as constructed (without
         `update_vol` additions having been made)"""
-        clone = self.__class__(**self._vol)
+        clone = self.__class__(**self._vol.parents.new_child())
         return clone
 
     def update_vol(self, **new_arguments) -> None:

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -346,7 +346,8 @@ class Template:
         """Stores the keyword arguments for later object creation."""
         # Allow the updating of template arguments whilst still in template form
         super().__init__()
-        vol = {"type_name": type_name}.update(arguments)
+        vol = {"type_name": type_name}
+        vol.update(arguments)
         self._vol = collections.ChainMap({}, vol)
 
     @property

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -8,7 +8,7 @@ import collections
 import collections.abc
 import contextlib
 import logging
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 from volatility3.framework import constants, interfaces
 

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -128,8 +128,6 @@ class ObjectInterface(metaclass=abc.ABCMeta):
     """A base object required to be the ancestor of every object used in
     volatility."""
 
-    __slots__ = ()
-
     def __init__(
         self,
         context: "interfaces.context.ContextInterface",

--- a/volatility3/framework/renderers/__init__.py
+++ b/volatility3/framework/renderers/__init__.py
@@ -61,7 +61,7 @@ class TreeNode(interfaces.renderers.TreeNode):
         self._treegrid = treegrid
         self._parent = parent
         self._path = path
-        validated_values = self._validate_values(values)
+        self._validate_values(values)
         self._values = treegrid.RowStructure(*values)  # type: ignore
 
     def __repr__(self) -> str:
@@ -73,12 +73,9 @@ class TreeNode(interfaces.renderers.TreeNode):
     def __len__(self) -> int:
         return len(self._treegrid.children(self))
 
-    def _validate_values(
-        self, values: List[interfaces.renderers.BaseTypes]
-    ) -> List[interfaces.renderers.BaseTypes]:
+    def _validate_values(self, values: List[interfaces.renderers.BaseTypes]) -> None:
         """A function for raising exceptions if a given set of values is
         invalid according to the column properties."""
-        new_values = ()
         if not (
             isinstance(values, collections.abc.Sequence)
             and len(values) == len(self._treegrid.columns)

--- a/volatility3/framework/renderers/__init__.py
+++ b/volatility3/framework/renderers/__init__.py
@@ -61,7 +61,7 @@ class TreeNode(interfaces.renderers.TreeNode):
         self._treegrid = treegrid
         self._parent = parent
         self._path = path
-        self._validate_values(values)
+        validated_values = self._validate_values(values)
         self._values = treegrid.RowStructure(*values)  # type: ignore
 
     def __repr__(self) -> str:
@@ -73,9 +73,12 @@ class TreeNode(interfaces.renderers.TreeNode):
     def __len__(self) -> int:
         return len(self._treegrid.children(self))
 
-    def _validate_values(self, values: List[interfaces.renderers.BaseTypes]) -> None:
+    def _validate_values(
+        self, values: List[interfaces.renderers.BaseTypes]
+    ) -> List[interfaces.renderers.BaseTypes]:
         """A function for raising exceptions if a given set of values is
         invalid according to the column properties."""
+        new_values = ()
         if not (
             isinstance(values, collections.abc.Sequence)
             and len(values) == len(self._treegrid.columns)


### PR DESCRIPTION
So, the main thing this does, is to combine multiple dictionaries into just one before it goes into the chainmap (we still have to use the chainmap, because we need to be able to undo changes temporarily made to a type when cloning it), but that saves a huge chunk of memory.  The use of `__slots__` doesn't save as much memory as I'd hoped, it's possible slightly more judicious use of it throughout the object model might help, but this should be a minimal change that has a significant reduction in memory usage (using only about 60% of the previous memory on dicts).  Please test it, it would be good to through it through all the tests, because it makes some very deep level changes, which could have very subtle bugs...

Other things that could reduce memory usage are to reduce the simple types to their simple types (currently all the volatility objects are saved up in the big treegrid, even though all their associated machinery won't ever get used).  There should be a way of doing this in populate, but when I tried it I couldn't get it to affect the memory (I think maybe casting an Integer, which is subclassed from `int`, to an `int`, didn't change it).

Helps with #1725