### PR TITLE
Framework: Missing `VersionRequirement`s

### DIFF
--- a/volatility3/framework/plugins/linux/bash.py
+++ b/volatility3/framework/plugins/linux/bash.py
@@ -35,6 +35,11 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
             requirements.ListRequirement(
                 name="pid",
                 element_type=int,

--- a/volatility3/framework/plugins/linux/boottime.py
+++ b/volatility3/framework/plugins/linux/boottime.py
@@ -26,6 +26,11 @@ class Boottime(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
         ]

--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -124,6 +124,11 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="linuxutils", component=linux.LinuxUtilities, version=(2, 0, 0)
             ),
             requirements.ListRequirement(

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -129,6 +129,11 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.VersionRequirement(
                 name="mountinfo", component=mountinfo.MountInfo, version=(1, 2, 0)
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
             requirements.ListRequirement(
                 name="type",
                 description="List of space-separated file type filters i.e. --type REG DIR",

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -53,6 +53,11 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 element_type=int,
                 optional=True,
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
             requirements.BooleanRequirement(
                 name="threads",
                 description="Include user threads",

--- a/volatility3/framework/plugins/mac/bash.py
+++ b/volatility3/framework/plugins/mac/bash.py
@@ -33,6 +33,11 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
             requirements.ListRequirement(
                 name="pid",
                 description="Filter on specific process IDs",

--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -25,9 +25,13 @@ class TimeLinerType(enum.IntEnum):
     CHANGED = 4
 
 
-class TimeLinerInterface(metaclass=abc.ABCMeta):
+class TimeLinerInterface(
+    interfaces.configuration.VersionableInterface, metaclass=abc.ABCMeta
+):
     """Interface defining methods that timeliner will use to generate a body
     file."""
+
+    _version = (1, 0, 0)
 
     @abc.abstractmethod
     def generate_timeline(

--- a/volatility3/framework/plugins/windows/amcache.py
+++ b/volatility3/framework/plugins/windows/amcache.py
@@ -234,6 +234,11 @@ class Amcache(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.VersionRequirement(
                 name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
         ]
 
     def generate_timeline(

--- a/volatility3/framework/plugins/windows/consoles.py
+++ b/volatility3/framework/plugins/windows/consoles.py
@@ -46,7 +46,10 @@ class Consoles(interfaces.plugins.PluginInterface):
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="verinfo", component=verinfo.VerInfo, version=(1, 0, 0)
+                name="verinfo", component=verinfo.VerInfo, version=(2, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="info", component=info.Info, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)

--- a/volatility3/framework/plugins/windows/dlllist.py
+++ b/volatility3/framework/plugins/windows/dlllist.py
@@ -37,6 +37,11 @@ class DllList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="psscan", component=psscan.PsScan, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(

--- a/volatility3/framework/plugins/windows/driverscan.py
+++ b/volatility3/framework/plugins/windows/driverscan.py
@@ -27,6 +27,9 @@ class DriverScan(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(3, 0, 0)
+            ),
         ]
 
     @classmethod

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -33,7 +33,15 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="yarascanner", component=yarascan.YaraScanner, version=(2, 1, 0)
+            ),
+            requirements.VersionRequirement(
+                name="yarascan", component=yarascan.YaraScan, version=(2, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/netscan.py
+++ b/volatility3/framework/plugins/windows/netscan.py
@@ -40,6 +40,11 @@ class NetScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 name="info", component=info.Info, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="verinfo", component=verinfo.VerInfo, version=(1, 0, 0)
             ),
             requirements.BooleanRequirement(

--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -40,6 +40,11 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 name="modules", component=modules.Modules, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="pdbutil", component=pdbutil.PDBUtility, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(

--- a/volatility3/framework/plugins/windows/processghosting.py
+++ b/volatility3/framework/plugins/windows/processghosting.py
@@ -33,6 +33,9 @@ class ProcessGhosting(interfaces.plugins.PluginInterface):
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="vadinfo", component=vadinfo.VadInfo, version=(2, 0, 1)
+            ),
         ]
 
     @classmethod

--- a/volatility3/framework/plugins/windows/pslist.py
+++ b/volatility3/framework/plugins/windows/pslist.py
@@ -41,6 +41,11 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 default=cls.PHYSICAL_DEFAULT,
                 optional=True,
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
             requirements.ListRequirement(
                 name="pid",
                 element_type=int,

--- a/volatility3/framework/plugins/windows/psscan.py
+++ b/volatility3/framework/plugins/windows/psscan.py
@@ -37,6 +37,11 @@ class PsScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="info", component=info.Info, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(

--- a/volatility3/framework/plugins/windows/registry/userassist.py
+++ b/volatility3/framework/plugins/windows/registry/userassist.py
@@ -59,6 +59,11 @@ class UserAssist(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfac
             requirements.VersionRequirement(
                 name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
         ]
 
     def parse_userassist_data(self, reg_val):

--- a/volatility3/framework/plugins/windows/scheduled_tasks.py
+++ b/volatility3/framework/plugins/windows/scheduled_tasks.py
@@ -1126,6 +1126,11 @@ information about triggers, actions, run times, and creation times."""
             requirements.VersionRequirement(
                 name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
         ]
 
     def generate_timeline(

--- a/volatility3/framework/plugins/windows/sessions.py
+++ b/volatility3/framework/plugins/windows/sessions.py
@@ -30,6 +30,11 @@ class Sessions(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
             requirements.ListRequirement(
                 name="pid",
                 element_type=int,

--- a/volatility3/framework/plugins/windows/shimcachemem.py
+++ b/volatility3/framework/plugins/windows/shimcachemem.py
@@ -68,6 +68,11 @@ class ShimcacheMem(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterf
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="vadinfo", component=vadinfo.VadInfo, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(

--- a/volatility3/framework/plugins/windows/svclist.py
+++ b/volatility3/framework/plugins/windows/svclist.py
@@ -34,6 +34,9 @@ class SvcList(svcscan.SvcScan):
             requirements.VersionRequirement(
                 name="svcscan", component=svcscan.SvcScan, version=(4, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
+            ),
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Windows kernel",

--- a/volatility3/framework/plugins/windows/symlinkscan.py
+++ b/volatility3/framework/plugins/windows/symlinkscan.py
@@ -28,6 +28,11 @@ class SymlinkScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterfa
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
         ]

--- a/volatility3/framework/plugins/windows/thrdscan.py
+++ b/volatility3/framework/plugins/windows/thrdscan.py
@@ -36,6 +36,14 @@ class ThrdScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
             requirements.VersionRequirement(
                 name="poolscanner", component=poolscanner.PoolScanner, version=(3, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="pe_symbols", component=pe_symbols.PESymbols, version=(3, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
         ]
 
     @classmethod

--- a/volatility3/framework/plugins/windows/threads.py
+++ b/volatility3/framework/plugins/windows/threads.py
@@ -34,6 +34,9 @@ class Threads(thrdscan.ThrdScan):
             requirements.VersionRequirement(
                 name="thrdscan", component=thrdscan.ThrdScan, version=(2, 0, 0)
             ),
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
+            ),
         ]
 
     @classmethod

--- a/volatility3/framework/plugins/windows/unloadedmodules.py
+++ b/volatility3/framework/plugins/windows/unloadedmodules.py
@@ -33,6 +33,14 @@ class UnloadedModules(interfaces.plugins.PluginInterface, timeliner.TimeLinerInt
                 description="Windows kernel",
                 architectures=["Intel32", "Intel64"],
             ),
+            requirements.VersionRequirement(
+                name="timeliner",
+                component=timeliner.TimeLinerInterface,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="modules", component=modules.Modules, version=(3, 0, 0)
+            ),
         ]
 
     @classmethod


### PR DESCRIPTION
This PR:
- Adds the `VersionableInterface` class as a superclass of `TimeLinerInterface` to make it consistent with other versioned interfaces.
- Audits the codebase for uses of versioned components that are not listed in the consumer's `get_requirements()` classmethod, and adds them as needed.
