### PR TITLE
Consoles: Fix requirement versions

### DIFF
--- a/volatility3/framework/plugins/windows/consoles.py
+++ b/volatility3/framework/plugins/windows/consoles.py
@@ -46,10 +46,10 @@ class Consoles(interfaces.plugins.PluginInterface):
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="verinfo", component=verinfo.VerInfo, version=(2, 0, 0)
+                name="verinfo", component=verinfo.VerInfo, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="info", component=info.Info, version=(1, 0, 0)
+                name="info", component=info.Info, version=(2, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)


### PR DESCRIPTION
When I updated the requirements for `Consoles` in #1738, I bumped the version number on the `VerInfo` requirement instead of on the `Info` requirement.

closes #1741
