### PR TITLE
Volshell: Display types pointer upgrade

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -605,9 +605,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                 # volobject branch
                 if isinstance(
                     value,
-                    Union[
-                        interfaces.objects.ObjectInterface, interfaces.objects.Template
-                    ],
+                    (interfaces.objects.ObjectInterface, interfaces.objects.Template),
                 ):
                     if isinstance(value, objects.Pointer):
                         # show pointers in hex to match output for struct addrs

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -502,11 +502,10 @@ class Volshell(interfaces.plugins.PluginInterface):
                 member_type_name = self._get_type_name_with_pointer(
                     member_type
                 )  # special case for pointers to show what they point to
-                if len(member_type_name) > MAX_TYPENAME_DISPLAY_LENGTH:
-                    member_type_name = (
-                        f"{member_type_name[:MAX_TYPENAME_DISPLAY_LENGTH - 3]}..."
-                    )
                 len_typename = len(member_type_name)
+                if len(member_type_name) > MAX_TYPENAME_DISPLAY_LENGTH:
+                    len_typename = MAX_TYPENAME_DISPLAY_LENGTH
+                    member_type_name = f"{member_type_name[:len_typename - 3]}..."
                 if isinstance(volobject, interfaces.objects.ObjectInterface):
                     # We're an instance, so also display the data
                     try:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -547,7 +547,7 @@ class Volshell(interfaces.plugins.PluginInterface):
         ],
         include_value: bool = True,
     ) -> str:
-        # build the display_type_string based on the aviable information
+        # build the display_type_string based on the available information
 
         if hasattr(volobject.vol, "size"):
             # the most common type to display, this shows their full size, e.g.:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -502,6 +502,10 @@ class Volshell(interfaces.plugins.PluginInterface):
                 len_typename = len(member_type_name)
                 if isinstance(volobject, interfaces.objects.ObjectInterface):
                     # We're an instance, so also display the data
+                    try:
+                        value = self._display_value(getattr(volobject, member))
+                    except exceptions.InvalidAddressException:
+                        value = self._display_value(renderers.NotAvailableValue())
                     print(
                         "    " * dereference_count,
                         " " * (longest_offset - len_offset),
@@ -513,7 +517,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                         member_type_name,
                         " " * (longest_typename - len_typename),
                         "  ",
-                        self._display_value(getattr(volobject, member)),
+                        value,
                     )
                 else:
                     # not provided with an actual object, nor an offset so just display the types
@@ -585,7 +589,9 @@ class Volshell(interfaces.plugins.PluginInterface):
 
     def _display_value(self, value: Any) -> str:
         try:
-            if isinstance(value, objects.Pointer):
+            if isinstance(value, interfaces.renderers.BaseAbsentValue):
+                return "N/A"
+            elif isinstance(value, objects.Pointer):
                 # show pointers in hex to match output for struct addrs
                 # highlight null or unreadable pointers
                 if value == 0:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -622,7 +622,12 @@ class Volshell(interfaces.plugins.PluginInterface):
                     elif isinstance(value, objects.Array):
                         return repr([self._display_value(val) for val in value])
                     else:
-                        return f"offset: {hex(value.vol.offset)}"
+                        if self.context.layers[self.current_layer].is_valid(
+                            value.vol.offset
+                        ):
+                            return f"offset: {hex(value.vol.offset)}"
+                        else:
+                            return f"offset: {hex(value.vol.offset)} (unreadable)"
                 else:
                     # non volobject
                     if value is None:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -630,7 +630,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                     if value is None:
                         return "N/A"
                     else:
-                        return value
+                        return repr(value)
 
         except exceptions.InvalidAddressException:
             # if value causes an InvalidAddressException like BaseAbsentValue then display N/A

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -399,7 +399,7 @@ class Volshell(interfaces.plugins.PluginInterface):
         a pointer otherwise it returns just the normal type name."""
         pointer_marker = "*" * depth
         try:
-            if member_type.vol.object_class == objects.Pointer:
+            if isinstance(member_type, objects.Pointer):
                 sub_member_type = member_type.vol.subtype
                 # follow at most MAX_DEREFERENCE_COUNT pointers. A guard against, hopefully unlikely, infinite loops
                 if depth < MAX_DEREFERENCE_COUNT:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -503,7 +503,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                 if isinstance(volobject, interfaces.objects.ObjectInterface):
                     # We're an instance, so also display the data
                     try:
-                        value = self._display_value(getattr(volobject, member))
+                        value = self._display_value(volobject.member(member))
                     except exceptions.InvalidAddressException:
                         value = self._display_value(renderers.NotAvailableValue())
                     print(

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -489,9 +489,12 @@ class Volshell(interfaces.plugins.PluginInterface):
                 member_type_name = self._get_type_name_with_pointer(
                     member_type
                 )  # special case for pointers to show what they point to
+
+                # find the longest typename
                 longest_typename = max(len(member_type_name), longest_typename)
-                if longest_typename > MAX_TYPENAME_DISPLAY_LENGTH:
-                    longest_typename = MAX_TYPENAME_DISPLAY_LENGTH
+
+                # if the typename is very long then limit it to MAX_TYPENAME_DISPLAY_LENGTH
+                longest_typename = min(longest_typename, MAX_TYPENAME_DISPLAY_LENGTH)
 
             for member in sorted(
                 volobject.vol.members, key=lambda x: (volobject.vol.members[x][0], x)

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -32,6 +32,8 @@ try:
 except ImportError:
     has_ipython = False
 
+MAX_DEREFERENCE_COUNT = 4  # the max number of times display_type should follow pointers
+
 
 class Volshell(interfaces.plugins.PluginInterface):
     """Shell environment to directly interact with a memory image."""
@@ -386,6 +388,30 @@ class Volshell(interfaces.plugins.PluginInterface):
                 for i in disasm_types[architecture].disasm(remaining_data, offset):
                     print(f"0x{i.address:x}:\t{i.mnemonic}\t{i.op_str}")
 
+    def _get_type_name_with_pointer(
+        self,
+        member_type: Union[
+            str, interfaces.objects.ObjectInterface, interfaces.objects.Template
+        ],
+        depth: int = 0,
+    ) -> str:
+        """Takes a member_type from and returns the subtype name with a * if the member_type is
+        a pointer otherwise it returns just the normal type name."""
+        pointer_marker = "*" * depth
+        try:
+            if member_type.vol.object_class == objects.Pointer:
+                sub_member_type = member_type.vol.subtype
+                # follow at most MAX_DEREFERENCE_COUNT pointers. A guard against, hopefully unlikely, infinite loops
+                if depth < MAX_DEREFERENCE_COUNT:
+                    return self._get_type_name_with_pointer(sub_member_type, depth + 1)
+                else:
+                    return member_type_name
+        except AttributeError:
+            pass  # not all objects get a `object_class`, and those that don't are not pointers.
+        finally:
+            member_type_name = pointer_marker + member_type.vol.type_name
+        return member_type_name
+
     def display_type(
         self,
         object: Union[
@@ -418,26 +444,51 @@ class Volshell(interfaces.plugins.PluginInterface):
                 volobject.vol.type_name, layer_name=self.current_layer, offset=offset
             )
 
-        if hasattr(volobject.vol, "size"):
-            print(f"{volobject.vol.type_name} ({volobject.vol.size} bytes)")
-        elif hasattr(volobject.vol, "data_format"):
-            data_format = volobject.vol.data_format
-            print(
-                "{} ({} bytes, {} endian, {})".format(
-                    volobject.vol.type_name,
-                    data_format.length,
-                    data_format.byteorder,
-                    "signed" if data_format.signed else "unsigned",
-                )
-            )
+        # add special case for pointer so that information about the struct the
+        # pointer is pointing to is shown rather than simply the fact this is a
+        # pointer object. The "dereference_count < MAX_DEREFERENCE_COUNT" is to
+        # guard against loops
+        dereference_count = 0
+        while (
+            isinstance(volobject, objects.Pointer)
+            and dereference_count < MAX_DEREFERENCE_COUNT
+        ):
+            # before defreerencing the pointer, show it's information
+            print(f'{"    " * dereference_count}{self._display_simple_type(volobject)}')
+
+            # check that we can follow the pointer before dereferencing and do not
+            # attempt to follow null pointers.
+            if volobject.is_readable() and volobject != 0:
+                # now deference the pointer and store this as the new volobject
+                volobject = volobject.dereference()
+                dereference_count = dereference_count + 1
+            else:
+                # if we aren't able to follow the pointers anymore then there will
+                # be no more information to display as we've already printed the
+                # details of this pointer including the fact that we're not able to
+                # follow it anywhere
+                return
 
         if hasattr(volobject.vol, "members"):
+            # display the header for this object, if the orginal object was just a type string, display the type information
+            struct_header = f'{"    " * dereference_count}{volobject.vol.type_name} ({volobject.vol.size} bytes)'
+            if isinstance(object, str) and offset is None:
+                suffix = ":"
+            else:
+                # this is an actual object or an offset was given so the offset should be displayed
+                suffix = f" @ {hex(volobject.vol.offset)}:"
+            print(struct_header + suffix)
+
+            # it is a more complex type, so all members also need information displayed
             longest_member = longest_offset = longest_typename = 0
             for member in volobject.vol.members:
                 relative_offset, member_type = volobject.vol.members[member]
                 longest_member = max(len(member), longest_member)
                 longest_offset = max(len(hex(relative_offset)), longest_offset)
-                longest_typename = max(len(member_type.vol.type_name), longest_typename)
+                member_type_name = self._get_type_name_with_pointer(
+                    member_type
+                )  # special case for pointers to show what they point to
+                longest_typename = max(len(member_type_name), longest_typename)
 
             for member in sorted(
                 volobject.vol.members, key=lambda x: (volobject.vol.members[x][0], x)
@@ -445,40 +496,113 @@ class Volshell(interfaces.plugins.PluginInterface):
                 relative_offset, member_type = volobject.vol.members[member]
                 len_offset = len(hex(relative_offset))
                 len_member = len(member)
-                len_typename = len(member_type.vol.type_name)
+                member_type_name = self._get_type_name_with_pointer(
+                    member_type
+                )  # special case for pointers to show what they point to
+                len_typename = len(member_type_name)
                 if isinstance(volobject, interfaces.objects.ObjectInterface):
                     # We're an instance, so also display the data
                     print(
+                        "    " * dereference_count,
                         " " * (longest_offset - len_offset),
                         hex(relative_offset),
                         ":  ",
                         member,
                         " " * (longest_member - len_member),
                         "  ",
-                        member_type.vol.type_name,
+                        member_type_name,
                         " " * (longest_typename - len_typename),
                         "  ",
                         self._display_value(getattr(volobject, member)),
                     )
                 else:
+                    # not provided with an actual object, nor an offset so just display the types
                     print(
+                        "    " * dereference_count,
                         " " * (longest_offset - len_offset),
                         hex(relative_offset),
                         ":  ",
                         member,
                         " " * (longest_member - len_member),
                         "  ",
-                        member_type.vol.type_name,
+                        member_type_name,
                     )
 
-    @classmethod
-    def _display_value(cls, value: Any) -> str:
-        if isinstance(value, objects.PrimitiveObject):
-            return repr(value)
-        elif isinstance(value, objects.Array):
-            return repr([cls._display_value(val) for val in value])
+        else:  # simple type with no members, only one line to print
+            # if the orginal object was just a type string, display the type information
+            if isinstance(object, str) and offset is None:
+                print(self._display_simple_type(volobject, include_value=False))
+
+            # if the original object was an actual volobject or was a type string
+            # with an offset. Then append the actual data to the display.
+            else:
+                print("    " * dereference_count, self._display_simple_type(volobject))
+
+    def _display_simple_type(
+        self,
+        volobject: Union[
+            interfaces.objects.ObjectInterface, interfaces.objects.Template
+        ],
+        include_value: bool = True,
+    ) -> str:
+        # build the display_type_string based on the aviable information
+
+        if hasattr(volobject.vol, "size"):
+            # the most common type to display, this shows their full size, e.g.:
+            # (layer_name) >>> dt('task_struct')
+            # symbol_table_name1!task_struct (1784 bytes)
+            display_type_string = (
+                f"{volobject.vol.type_name} ({volobject.vol.size} bytes)"
+            )
+        elif hasattr(volobject.vol, "data_format"):
+            # this is useful for very simple types like ints, e.g.:
+            # (layer_name) >>> dt('int')
+            # symbol_table_name1!int (4 bytes, little endian, signed)
+            data_format = volobject.vol.data_format
+            display_type_string = "{} ({} bytes, {} endian, {})".format(
+                volobject.vol.type_name,
+                data_format.length,
+                data_format.byteorder,
+                "signed" if data_format.signed else "unsigned",
+            )
+        elif hasattr(volobject.vol, "type_name"):
+            # types like void have almost no values to display other than their name, e.g.:
+            # (layer_name) >>> dt('void')
+            # symbol_table_name1!void
+            display_type_string = volobject.vol.type_name
         else:
-            return hex(value.vol.offset)
+            # it should not be possible to have a volobject without at least a type_name
+            raise AttributeError("Unable to find any details for object")
+
+        if include_value:  # if include_value is true also add the value to the display
+            if isinstance(volobject, objects.Pointer):
+                # for pointers include the location of the pointer and where it points to
+                return f"{display_type_string} @ {hex(volobject.vol.offset)} -> {self._display_value(volobject)}"
+            else:
+                return f"{display_type_string}: {self._display_value(volobject)}"
+        else:
+            return display_type_string
+
+    def _display_value(self, value: Any) -> str:
+        try:
+            if isinstance(value, objects.Pointer):
+                # show pointers in hex to match output for struct addrs
+                # highlight null or unreadable pointers
+                if value == 0:
+                    suffix = " (null pointer)"
+                elif not value.is_readable():
+                    suffix = " (unreadable pointer)"
+                else:
+                    suffix = ""
+                return f"{hex(value)}{suffix}"
+            elif isinstance(value, objects.PrimitiveObject):
+                return repr(value)
+            elif isinstance(value, objects.Array):
+                return repr([self._display_value(val) for val in value])
+            else:
+                return hex(value.vol.offset)
+        except exceptions.InvalidAddressException:
+            return "-"
 
     def generate_treegrid(
         self, plugin: Type[interfaces.plugins.PluginInterface], **kwargs

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -636,9 +636,9 @@ class Volshell(interfaces.plugins.PluginInterface):
                         if self.context.layers[self.current_layer].is_valid(
                             value.vol.offset
                         ):
-                            return f"offset: {hex(value.vol.offset)}"
+                            return f"offset: 0x{value.vol.offset:x}"
                         else:
-                            return f"offset: {hex(value.vol.offset)} (unreadable)"
+                            return f"offset: 0x{value.vol.offset:x} (unreadable)"
                 else:
                     # non volobject
                     if value is None:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -418,6 +418,9 @@ class Volshell(interfaces.plugins.PluginInterface):
         offset: Optional[int] = None,
     ):
         """Display Type describes the members of a particular object in alphabetical order"""
+
+        MAX_TYPENAME_DISPLAY_LENGTH = 256
+
         if not isinstance(
             object,
             (str, interfaces.objects.ObjectInterface, interfaces.objects.Template),
@@ -487,6 +490,8 @@ class Volshell(interfaces.plugins.PluginInterface):
                     member_type
                 )  # special case for pointers to show what they point to
                 longest_typename = max(len(member_type_name), longest_typename)
+                if longest_typename > MAX_TYPENAME_DISPLAY_LENGTH:
+                    longest_typename = MAX_TYPENAME_DISPLAY_LENGTH
 
             for member in sorted(
                 volobject.vol.members, key=lambda x: (volobject.vol.members[x][0], x)
@@ -497,6 +502,10 @@ class Volshell(interfaces.plugins.PluginInterface):
                 member_type_name = self._get_type_name_with_pointer(
                     member_type
                 )  # special case for pointers to show what they point to
+                if len(member_type_name) > MAX_TYPENAME_DISPLAY_LENGTH:
+                    member_type_name = (
+                        f"{member_type_name[:MAX_TYPENAME_DISPLAY_LENGTH - 3]}..."
+                    )
                 len_typename = len(member_type_name)
                 if isinstance(volobject, interfaces.objects.ObjectInterface):
                     # We're an instance, so also display the data

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -622,7 +622,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                     elif isinstance(value, objects.Array):
                         return repr([self._display_value(val) for val in value])
                     else:
-                        return hex(value.vol.offset)
+                        return f"offset: {hex(value.vol.offset)}"
                 else:
                     # non volobject
                     if value is None:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -404,8 +404,6 @@ class Volshell(interfaces.plugins.PluginInterface):
                 # follow at most MAX_DEREFERENCE_COUNT pointers. A guard against, hopefully unlikely, infinite loops
                 if depth < MAX_DEREFERENCE_COUNT:
                     return self._get_type_name_with_pointer(sub_member_type, depth + 1)
-                else:
-                    return member_type_name
         except AttributeError:
             pass  # not all objects get a `object_class`, and those that don't are not pointers.
         finally:

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -587,26 +587,43 @@ class Volshell(interfaces.plugins.PluginInterface):
 
     def _display_value(self, value: Any) -> str:
         try:
+            # if value is a BaseAbsentValue they display N/A
             if isinstance(value, interfaces.renderers.BaseAbsentValue):
                 return "N/A"
-            elif isinstance(value, objects.Pointer):
-                # show pointers in hex to match output for struct addrs
-                # highlight null or unreadable pointers
-                if value == 0:
-                    suffix = " (null pointer)"
-                elif not value.is_readable():
-                    suffix = " (unreadable pointer)"
-                else:
-                    suffix = ""
-                return f"{hex(value)}{suffix}"
-            elif isinstance(value, objects.PrimitiveObject):
-                return repr(value)
-            elif isinstance(value, objects.Array):
-                return repr([self._display_value(val) for val in value])
             else:
-                return hex(value.vol.offset)
+                # volobject branch
+                if isinstance(
+                    value,
+                    Union[
+                        interfaces.objects.ObjectInterface, interfaces.objects.Template
+                    ],
+                ):
+                    if isinstance(value, objects.Pointer):
+                        # show pointers in hex to match output for struct addrs
+                        # highlight null or unreadable pointers
+                        if value == 0:
+                            suffix = " (null pointer)"
+                        elif not value.is_readable():
+                            suffix = " (unreadable pointer)"
+                        else:
+                            suffix = ""
+                        return f"{hex(value)}{suffix}"
+                    elif isinstance(value, objects.PrimitiveObject):
+                        return repr(value)
+                    elif isinstance(value, objects.Array):
+                        return repr([self._display_value(val) for val in value])
+                    else:
+                        return hex(value.vol.offset)
+                else:
+                    # non volobject
+                    if value is None:
+                        return "N/A"
+                    else:
+                        return value
+
         except exceptions.InvalidAddressException:
-            return "-"
+            # if value causes an InvalidAddressException like BaseAbsentValue then display N/A
+            return "N/A"
 
     def generate_treegrid(
         self, plugin: Type[interfaces.plugins.PluginInterface], **kwargs

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -399,7 +399,7 @@ class Volshell(interfaces.plugins.PluginInterface):
         a pointer otherwise it returns just the normal type name."""
         pointer_marker = "*" * depth
         try:
-            if isinstance(member_type, objects.Pointer):
+            if member_type.vol.object_class == objects.Pointer:
                 sub_member_type = member_type.vol.subtype
                 # follow at most MAX_DEREFERENCE_COUNT pointers. A guard against, hopefully unlikely, infinite loops
                 if depth < MAX_DEREFERENCE_COUNT:


### PR DESCRIPTION
Hello :wave: 

This PR updates volshell display types to follow pointers and display more information, and IMHO makes it easier to use. 

This is a replacement for PR https://github.com/volatilityfoundation/volatility3/pull/1028 as my git-fu is not strong enough to survive a rebase. 

Fixes https://github.com/volatilityfoundation/volatility3/issues/1714 
Fixes https://github.com/volatilityfoundation/volatility3/issues/1705

dt() updates
----
`dt()` will now follow pointers as needed to display information, up to a maximum of `MAX_DEREFERENCE_COUNT` times (currently set to 4).

With the a dt() of a `task_struct` you get a small hint at the changes. Here we see that `stack` and `files` are actually pointers as denoted by the `*` - we can also see what kind of struct it is, e.g. `files` is a `files_struct `. Previously it would have only displayed `pointer` so you wouldn't know what it was.  The value displayed is still the actual pointer data as before. It will show pointers in hex e.g. `0x880001f60000` rather than `149533614276608` as this feels more natural.

The `@ 0x88001d06c800` also shows where in the layer this object is. Previously you'd need to use `.vol.offset` or similar to find this out as an extra step.

```
symbol_table_name1!task_struct (1784 bytes) @ 0x88001d06c800:
    0x0 :   state                           symbol_table_name1!long int                     1
    0x8 :   stack                           *symbol_table_name1!void                        0x880001f60000
   0x10 :   usage                           symbol_table_name1!atomic_t                     0x88001d06c810
   0x14 :   flags                           symbol_table_name1!unsigned int                 4202752
   0x18 :   ptrace                          symbol_table_name1!unsigned int                 0
<snip>
  0x480 :   files                           *symbol_table_name1!files_struct                0x88001cbd59c0
<snip>
```

However things get useful when we would need to follow pointers, e.g. the `files` member of `task_struct`

Here we can see that `.files` is a pointer. It was located at offset `0x88001d06cc80` and points to `0x88001cbd59c0`. At `0x88001cbd59c0` we have the `files_struct` and dt will display the details of it. The results for `files_struct` is indented to show that it is the result of following a pointer. Previously if you did  `dt(task.files)` you would simply be told it was a pointer, you'd need to type `dt(task.files.dereference())` to get the results. I personally struggle to spell dereference correctly most of the time and these changes make my life a little easier!

```
(layer_name) >>> dt(gp(pid=8497).files)
symbol_table_name1!pointer (8 bytes) @ 0x88001d06cc80 -> 0x88001cbd59c0
    symbol_table_name1!files_struct (704 bytes) @ 0x88001cbd59c0:
       0x0 :   count                  symbol_table_name1!atomic_t            0x88001cbd59c0
       0x8 :   fdt                    *symbol_table_name1!fdtable            0x88001cbd59d0
      0x10 :   fdtab                  symbol_table_name1!fdtable             0x88001cbd59d0
      0x80 :   file_lock              symbol_table_name1!spinlock_t          0x88001cbd5a40
      0x84 :   next_fd                symbol_table_name1!int                 1
      0x88 :   close_on_exec_init     symbol_table_name1!embedded_fd_set     0x88001cbd5a48
      0x90 :   open_fds_init          symbol_table_name1!embedded_fd_set     0x88001cbd5a50
```

The changes will follow multiple pointers if needed too. If we look at the `fdt` here we can see that the `fd` member is a double pointer which eventually gets to a `file` as denoted by the `**`.

```
(layer_name) >>> dt(gp(pid=8497).files.fdt)
symbol_table_name1!pointer (8 bytes) @ 0x88001cbd59c8 -> 0x88001cbd59d0
    symbol_table_name1!fdtable (56 bytes) @ 0x88001cbd59d0:
       0x0 :   max_fds           symbol_table_name1!unsigned int         64
       0x8 :   fd                **symbol_table_name1!file               0x88001cbd5a58
      0x10 :   close_on_exec     *symbol_table_name1!__kernel_fd_set     0x88001cbd5a48
      0x18 :   open_fds          *symbol_table_name1!__kernel_fd_set     0x88001cbd5a50
      0x20 :   rcu               symbol_table_name1!rcu_head             0x88001cbd59f0
      0x30 :   next              *symbol_table_name1!fdtable             0x0 (null pointer)
```
Lastly we can see `fd` just as easily by using `dt(task.files.fdt.fd)`. Here we see the first pointer located at `0x88001cbd59d8` points to `0x88001cbd5a58`. The second pointer at `0x88001cbd5a58` then points to `0x88001d145580`. Finally at `0x88001d145580` we have the `file` itself. You still get all the information about the pointers themselves if that is what you're interested in but you quickly get to the struct information which is what I think is the more common use case. 

```
(layer_name) >>> dt(gp(pid=8497).files.fdt.fd)
symbol_table_name1!pointer (8 bytes) @ 0x88001cbd59d8 -> 0x88001cbd5a58
    symbol_table_name1!pointer (8 bytes) @ 0x88001cbd5a58 -> 0x88001d145580
        symbol_table_name1!file (208 bytes) @ 0x88001d145580:
           0x0 :   f_u               symbol_table_name1!unnamed_6733425fe3c7f4c9     0x88001d145580
          0x10 :   f_path            symbol_table_name1!path                         0x88001d145590
          0x20 :   f_op              *symbol_table_name1!file_operations             0xffff8143aa70
          0x28 :   f_lock            symbol_table_name1!spinlock_t                   0x88001d1455a8
          0x2c :   f_sb_list_cpu     symbol_table_name1!int                          0
          0x30 :   f_count           symbol_table_name1!atomic64_t                   0x88001d1455b0
          0x38 :   f_flags           symbol_table_name1!unsigned int                 32768
          0x3c :   f_mode            symbol_table_name1!unsigned int                 29
          0x40 :   f_pos             symbol_table_name1!long long int                0
          0x48 :   f_owner           symbol_table_name1!fown_struct                  0x88001d1455c8
          0x68 :   f_cred            *symbol_table_name1!cred                        0x88001ca33cc0
          0x70 :   f_ra              symbol_table_name1!file_ra_state                0x88001d1455f0
          0x90 :   f_version         symbol_table_name1!long long unsigned int       0
          0x98 :   f_security        *symbol_table_name1!void                        0x0 (null pointer)
          0xa0 :   private_data      *symbol_table_name1!void                        0x0 (null pointer)
          0xa8 :   f_ep_links        symbol_table_name1!list_head                    0x88001d145628
          0xb8 :   f_tfile_llink     symbol_table_name1!list_head                    0x88001d145638
          0xc8 :   f_mapping         *symbol_table_name1!address_space               0x88001f9b0480
```
Fixing https://github.com/volatilityfoundation/volatility3/issues/1705
---
Before the changes, you cannot `dt()` a `file_operations` struct as it includes `write` which is a python function for the vol object.

```
(layer_name) >>> dt(gp(pid=8497).files.fd_array[0].f_op.dereference())
symbol_table_name1!file_operations (208 bytes)
  0x0 :   owner                 symbol_table_name1!pointer     0
  0x8 :   llseek                symbol_table_name1!pointer     281472848377746
 0x10 :   read                  symbol_table_name1!pointer     281472848377728
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/eve/Documents/volatility3/volatility3/cli/volshell/linux.py", line 147, in display_type
    return super().display_type(object, offset)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eve/Documents/volatility3/volatility3/cli/volshell/generic.py", line 461, in display_type
    self._display_value(getattr(volobject, member)),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eve/Documents/volatility3/volatility3/cli/volshell/generic.py", line 481, in _display_value
    return hex(value.vol.offset)
               ^^^^^^^^^
AttributeError: 'function' object has no attribute 'vol'
```

With the change to use `.member()` as suggested by @atcuno (https://github.com/volatilityfoundation/volatility3/issues/1714#issuecomment-2731186920) it now works as expected:

```
(layer_name) >>> dt(gp(pid=8497).files.fd_array[0].f_op)
symbol_table_name1!pointer (8 bytes) @ 0x88001d1455a0 -> 0xffff8143aa70
    symbol_table_name1!file_operations (208 bytes) @ 0xffff8143aa70:
       0x0 :   owner                 *symbol_table_name1!module       0x0 (null pointer)
       0x8 :   llseek                *symbol_table_name1!function     0xffff81243792
      0x10 :   read                  *symbol_table_name1!function     0xffff81243780
      0x18 :   write                 *symbol_table_name1!function     0xffff81243783
      0x20 :   aio_read              *symbol_table_name1!function     0x0 (null pointer)
      0x28 :   aio_write             *symbol_table_name1!function     0x0 (null pointer)
      0x30 :   readdir               *symbol_table_name1!function     0x0 (null pointer)
      0x38 :   poll                  *symbol_table_name1!function     0x0 (null pointer)
      0x40 :   unlocked_ioctl        *symbol_table_name1!function     0x0 (null pointer)
      0x48 :   compat_ioctl          *symbol_table_name1!function     0x0 (null pointer)
      0x50 :   mmap                  *symbol_table_name1!function     0x0 (null pointer)
      0x58 :   open                  *symbol_table_name1!function     0x0 (null pointer)
      0x60 :   flush                 *symbol_table_name1!function     0x0 (null pointer)
      0x68 :   release               *symbol_table_name1!function     0x0 (null pointer)
      0x70 :   fsync                 *symbol_table_name1!function     0x0 (null pointer)
      0x78 :   aio_fsync             *symbol_table_name1!function     0x0 (null pointer)
      0x80 :   fasync                *symbol_table_name1!function     0x0 (null pointer)
      0x88 :   lock                  *symbol_table_name1!function     0x0 (null pointer)
      0x90 :   sendpage              *symbol_table_name1!function     0x0 (null pointer)
      0x98 :   get_unmapped_area     *symbol_table_name1!function     0x0 (null pointer)
      0xa0 :   check_flags           *symbol_table_name1!function     0x0 (null pointer)
      0xa8 :   flock                 *symbol_table_name1!function     0x0 (null pointer)
      0xb0 :   splice_write          *symbol_table_name1!function     0xffff81243a77
      0xb8 :   splice_read           *symbol_table_name1!function     0x0 (null pointer)
      0xc0 :   setlease              *symbol_table_name1!function     0x0 (null pointer)
      0xc8 :   fallocate             *symbol_table_name1!function     0x0 (null pointer)
```

Fixing https://github.com/volatilityfoundation/volatility3/issues/1714
---
Previously if you used dt() on a struct where a member was paged out it would backtrace and show no future results. As per @atcuno suggestion it will now just display `N/A` and continue. Here is a short example with a nonsensical dt at 0x0. 

```
(layer_name) >>> dt('task_struct', 0x0)
symbol_table_name1!task_struct (1784 bytes) @ 0x0:
    0x0 :   state                           symbol_table_name1!long int                   N/A
    0x8 :   stack                           symbol_table_name1!pointer                    N/A
<snip>
```


Let me know what you think! Huge thanks to @atcuno and @ikelos for the encouragement. :pray: 