### PR TITLE
Volshell: handle case where paged out member would cause backtrace for dt output. 

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -450,7 +450,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                 if isinstance(volobject, interfaces.objects.ObjectInterface):
                     # We're an instance, so also display the data
                     try:
-                        value = self._display_value(getattr(volobject, member))
+                        value = self._display_value(volobject.member(member))
                     except exceptions.InvalidAddressException:
                         value = self._display_value(renderers.NotAvailableValue())
 

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -446,8 +446,14 @@ class Volshell(interfaces.plugins.PluginInterface):
                 len_offset = len(hex(relative_offset))
                 len_member = len(member)
                 len_typename = len(member_type.vol.type_name)
+
                 if isinstance(volobject, interfaces.objects.ObjectInterface):
                     # We're an instance, so also display the data
+                    try:
+                        value = self._display_value(getattr(volobject, member))
+                    except exceptions.InvalidAddressException:
+                        value = self._display_value(renderers.NotAvailableValue())
+
                     print(
                         " " * (longest_offset - len_offset),
                         hex(relative_offset),
@@ -458,7 +464,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                         member_type.vol.type_name,
                         " " * (longest_typename - len_typename),
                         "  ",
-                        self._display_value(getattr(volobject, member)),
+                        value,
                     )
                 else:
                     print(
@@ -473,7 +479,9 @@ class Volshell(interfaces.plugins.PluginInterface):
 
     @classmethod
     def _display_value(cls, value: Any) -> str:
-        if isinstance(value, objects.PrimitiveObject):
+        if isinstance(value, interfaces.renderers.BaseAbsentValue):
+            return "N/A"
+        elif isinstance(value, objects.PrimitiveObject):
             return repr(value)
         elif isinstance(value, objects.Array):
             return repr([cls._display_value(val) for val in value])


### PR DESCRIPTION
Rather than waiting on https://github.com/volatilityfoundation/volatility3/pull/1748 this PR would fix https://github.com/volatilityfoundation/volatility3/issues/1714

It's just the changes suggested by @atcuno.

I know it's needed for the parity work this weekend. 