### PR TITLE
Don't completely remove the chainmap, but change one dict to a namedm…

### DIFF
--- a/volatility3/framework/contexts/__init__.py
+++ b/volatility3/framework/contexts/__init__.py
@@ -130,7 +130,7 @@ class Context(interfaces.context.ContextInterface):
             object_info=interfaces.objects.ObjectInformation(
                 layer_name=layer_name,
                 offset=offset,
-                native_layer_name=native_layer_name,
+                native_layer_name=native_layer_name or layer_name,
                 size=object_template.size,
             ),
         )

--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -8,7 +8,7 @@ import collections
 import collections.abc
 import contextlib
 import logging
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional
 
 from volatility3.framework import constants, interfaces
 
@@ -52,7 +52,7 @@ class ReadOnlyMapping(collections.abc.Mapping):
         return dict(self) == dict(other)
 
 
-class ObjectInformation(ReadOnlyMapping):
+class ObjectInformation(NamedTuple):
     """Contains common information useful/pertinent only to an individual
     object (like an instance)
 
@@ -63,35 +63,20 @@ class ObjectInformation(ReadOnlyMapping):
     in a single place.  These values are based on the :class:`ReadOnlyMapping` class, to prevent their modification.
     """
 
-    def __init__(
-        self,
-        layer_name: str,
-        offset: int,
-        member_name: Optional[str] = None,
-        parent: Optional["ObjectInterface"] = None,
-        native_layer_name: Optional[str] = None,
-        size: Optional[int] = None,
-    ):
-        """Constructs a container for basic information about an object.
+    layer_name: str
+    offset: int
+    native_layer_name: str
+    member_name: Optional[str] = None
+    parent: Optional["ObjectInterface"] = None
+    size: Optional[int] = None
 
-        Args:
-            layer_name: Layer from which the data for the object will be read
-            offset: Offset within the layer at which the data for the object will be read
-            member_name: If the object was accessed as a member of a parent object, this was the name used to access it
-            parent: If the object was accessed as a member of a parent object, this is the parent object
-            native_layer_name: If this object references other objects (such as a pointer), what layer those objects live in
-            size: The size that the whole structure consumes in bytes
-        """
-        super().__init__(
-            {
-                "layer_name": layer_name,
-                "offset": offset,
-                "member_name": member_name,
-                "parent": parent,
-                "native_layer_name": native_layer_name or layer_name,
-                "size": size,
-            }
-        )
+    def __getitem__(self, key):
+        if key in self._fields:
+            return getattr(self, key)
+        raise KeyError(f"NamedTuple does not have a key {key}")
+
+    def __contains__(self, key):
+        return key in self._fields
 
 
 class ObjectInterface(metaclass=abc.ABCMeta):
@@ -183,7 +168,7 @@ class ObjectInterface(metaclass=abc.ABCMeta):
             offset=self.vol.offset,
             member_name=self.vol.member_name,
             parent=self.vol.parent,
-            native_layer_name=self.vol.native_layer_name,
+            native_layer_name=self.vol.native_layer_name or self.vol.layer_name,
             size=object_template.size,
         )
         return object_template(context=self._context, object_info=object_info)

--- a/volatility3/framework/objects/__init__.py
+++ b/volatility3/framework/objects/__init__.py
@@ -458,6 +458,7 @@ class Pointer(Integer):
                     offset=offset,
                     parent=self,
                     size=self.vol.subtype.size,
+                    native_layer_name=layer_name,
                 ),
             )
         return self._cache[layer_name]
@@ -811,7 +812,7 @@ class Array(interfaces.objects.ObjectInterface, collections.abc.Sequence):
                 layer_name=self.vol.layer_name,
                 offset=mask & (self.vol.offset + (self.vol.subtype.size * index)),
                 parent=self,
-                native_layer_name=self.vol.native_layer_name,
+                native_layer_name=self.vol.native_layer_name or self.vol.layer_name,
                 size=self.vol.subtype.size,
             )
             result += [self.vol.subtype(context=self._context, object_info=object_info)]
@@ -978,7 +979,7 @@ class AggregateType(interfaces.objects.ObjectInterface):
                 offset=mask & (self.vol.offset + relative_offset),
                 member_name=attr,
                 parent=self,
-                native_layer_name=self.vol.native_layer_name,
+                native_layer_name=self.vol.native_layer_name or self.vol.layer_name,
                 size=template.size,
             )
             member = template(context=self._context, object_info=object_info)


### PR DESCRIPTION
…apping

Take two at reducing memory usage.  Doesn't save quite as much, but reduces memory by about a fifth on a large mftscan run.  Still probably some work we can do to reduce dictionary use of the chainmaps, but it will require careful consideration to resolve them, so this is probably the best we can do at short notice...