### PR TITLE
Tests: Fix Userassist and MFTScan testdata

### DIFF
--- a/test/plugins/windows/test_data/windows.registry.userassist.UserAssist.json
+++ b/test/plugins/windows/test_data/windows.registry.userassist.UserAssist.json
@@ -9,7 +9,7 @@
         "Last Write Time": "2025-03-06T17:57:09+00:00",
         "Name": null,
         "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-        "Raw Data": "",
+        "Raw Data": "N/A",
         "Time Focused": null,
         "Type": "Key",
         "__children": [
@@ -23,7 +23,7 @@
                 "Last Write Time": "2025-03-06T17:57:09+00:00",
                 "Name": "%ALLUSERSPROFILE%\\Microsoft\\Windows\\Start Menu\\Programs\\Accessories\\Paint.lnk",
                 "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-                "Raw Data": "\"\n00 00 00 00 07 00 00 00 00 00 00 00 07 00 00 00 ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf ff ff ff ff 90 86 6b 31 ..............k1\nfd 8d db 01 00 00 00 00                         ........        \"",
+                "Raw Data": "00 00 00 00 07 00 00 00 00 00 00 00 07 00 00 00 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ff ff ff ff 90 86 6b 31 fd 8d db 01 00 00 00 00",
                 "Time Focused": "0:00:00.507000",
                 "Type": "Value",
                 "__children": []
@@ -38,7 +38,7 @@
                 "Last Write Time": "2025-03-06T17:57:09+00:00",
                 "Name": "%ALLUSERSPROFILE%\\Microsoft\\Windows\\Start Menu\\Programs\\Administrative Tools\\Registry Editor.lnk",
                 "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-                "Raw Data": "\"\n00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf ff ff ff ff f0 82 cf ca ................\n95 8e db 01 00 00 00 00                         ........        \"",
+                "Raw Data": "00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ff ff ff ff f0 82 cf ca 95 8e db 01 00 00 00 00",
                 "Time Focused": "0:00:00.501000",
                 "Type": "Value",
                 "__children": []
@@ -53,7 +53,7 @@
                 "Last Write Time": "2025-03-06T17:57:09+00:00",
                 "Name": "%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Windows PowerShell\\Windows PowerShell.lnk",
                 "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-                "Raw Data": "\"\n00 00 00 00 04 00 00 00 00 00 00 00 04 00 00 00 ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf ff ff ff ff 10 67 cf 4d .............g.M\nbe 8e db 01 00 00 00 00                         ........        \"",
+                "Raw Data": "00 00 00 00 04 00 00 00 00 00 00 00 04 00 00 00 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ff ff ff ff 10 67 cf 4d be 8e db 01 00 00 00 00",
                 "Time Focused": "0:00:00.504000",
                 "Type": "Value",
                 "__children": []
@@ -68,7 +68,7 @@
                 "Last Write Time": "2025-03-06T17:57:09+00:00",
                 "Name": "%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\System Tools\\Command Prompt.lnk",
                 "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-                "Raw Data": "\"\n00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf ff ff ff ff d0 99 66 6c ..............fl\nc0 8e db 01 00 00 00 00                         ........        \"",
+                "Raw Data": "00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ff ff ff ff d0 99 66 6c c0 8e db 01 00 00 00 00",
                 "Time Focused": "0:00:00.501000",
                 "Type": "Value",
                 "__children": []
@@ -83,7 +83,7 @@
                 "Last Write Time": "2025-03-06T17:57:09+00:00",
                 "Name": "%ALLUSERSPROFILE%\\Microsoft\\Windows\\Start Menu\\Programs\\Accessories\\Notepad.lnk",
                 "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-                "Raw Data": "\"\n00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf ff ff ff ff 00 62 ba 89 .............b..\nc0 8e db 01 00 00 00 00                         ........        \"",
+                "Raw Data": "00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ff ff ff ff 00 62 ba 89 c0 8e db 01 00 00 00 00",
                 "Time Focused": "0:00:00.501000",
                 "Type": "Value",
                 "__children": []
@@ -98,7 +98,7 @@
                 "Last Write Time": "2025-03-06T17:57:09+00:00",
                 "Name": "%ALLUSERSPROFILE%\\Microsoft\\Windows\\Start Menu\\Programs\\Administrative Tools\\Task Scheduler.lnk",
                 "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-                "Raw Data": "\"\n00 00 00 00 02 00 00 00 00 00 00 00 02 00 00 00 ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf ff ff ff ff b0 24 49 23 .............$I#\nc1 8e db 01 00 00 00 00                         ........        \"",
+                "Raw Data": "00 00 00 00 02 00 00 00 00 00 00 00 02 00 00 00 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ff ff ff ff b0 24 49 23 c1 8e db 01 00 00 00 00",
                 "Time Focused": "0:00:00.502000",
                 "Type": "Value",
                 "__children": []
@@ -113,7 +113,7 @@
                 "Last Write Time": "2025-03-06T17:57:09+00:00",
                 "Name": "%ALLUSERSPROFILE%\\Microsoft\\Windows\\Start Menu\\Programs\\Microsoft Edge.lnk",
                 "Path": "ntuser.dat\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{F4E57C4B-2036-45F0-A9AB-443BCFE33D9F}\\Count",
-                "Raw Data": "\"\n00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ................\n00 00 80 bf 00 00 80 bf ff ff ff ff 60 3d 89 2e ............`=..\nc1 8e db 01 00 00 00 00                         ........        \"",
+                "Raw Data": "00 00 00 00 01 00 00 00 00 00 00 00 01 00 00 00 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf 00 00 80 bf ff ff ff ff 60 3d 89 2e c1 8e db 01 00 00 00 00",
                 "Time Focused": "0:00:00.501000",
                 "Type": "Value",
                 "__children": []

--- a/test/plugins/windows/windows.py
+++ b/test/plugins/windows/windows.py
@@ -1,10 +1,10 @@
-import json
-import hashlib
-import shutil
 import contextlib
-import tempfile
+import hashlib
+import json
 import os
-from test import test_volatility, WindowsSamples
+import shutil
+import tempfile
+from test import WindowsSamples, test_volatility
 
 
 class TestWindowsVolshell:
@@ -843,20 +843,22 @@ class TestWindowsMFTscan:
             {
                 "ADS Filename": "Zone.Identifier",
                 "Filename": "libby_hoeler_part1.wmv",
-                "Hexdump": '"\n5b 5a 6f 6e 65 54 72 61 6e 73 66 65 72 5d 0d 0a [ZoneTransfer]..\n5a 6f 6e 65 49 64 3d 33 0d 0a                   ZoneId=3..      "',
+                "Hexdump": "5b 5a 6f 6e 65 54 72 61 6e 73 66 65 72 5d 0d 0a 5a 6f 6e 65 49 64 3d 33 0d 0a",
                 "MFT Type": "DATA",
                 "Offset": 55926304,
                 "Record Number": 323,
                 "Record Type": "FILE",
+                "__children": [],
             },
             {
                 "ADS Filename": "Zone.Identifier",
                 "Filename": "NetZeroQuickHelpLite.exe",
-                "Hexdump": '"\n5b 5a 6f 6e 65 54 72 61 6e 73 66 65 72 5d 0d 0a [ZoneTransfer]..\n5a 6f 6e 65 49 64 3d 33 0d 0a                   ZoneId=3..      "',
+                "Hexdump": "5b 5a 6f 6e 65 54 72 61 6e 73 66 65 72 5d 0d 0a 5a 6f 6e 65 49 64 3d 33 0d 0a",
                 "MFT Type": "DATA",
                 "Offset": 56102400,
                 "Record Number": 347,
                 "Record Type": "FILE",
+                "__children": [],
             },
         ]
         for expected_row in expected_rows:
@@ -877,20 +879,22 @@ class TestWindowsMFTscan:
             {
                 "ADS Filename": "$Max",
                 "Filename": "$UsnJrnl",
-                "Hexdump": '"\n00 00 00 02 00 00 00 00 00 00 80 00 00 00 00 00 ................\nb9 dd f0 cc df 73 db 01 00 00 00 00 00 00 00 00 .....s.........."',
+                "Hexdump": "00 00 00 02 00 00 00 00 00 00 80 00 00 00 00 00 b9 dd f0 cc df 73 db 01 00 00 00 00 00 00 00 00",
                 "MFT Type": "DATA",
-                "Offset": 1058018088,
+                "Offset": 26235616,
                 "Record Number": 107240,
                 "Record Type": "FILE",
+                "__children": [],
             },
             {
-                "ADS Filename": "$Config",
-                "Filename": "$Repair",
-                "Hexdump": '"\n01 00 00 00 03 00 00 00                         ........        "',
+                "ADS Filename": "$SRAT",
+                "Filename": "$Bitmap",
+                "Hexdump": "a4 5f fd 60 38 00 01 03 10 00 0c 00 04 00 00 00 01 00 00 00 01 00 00 00 8d 4e 16 00 02 00 00 00 a0 00 00 00 00 00 06 00 03 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 4a 7b 01 00 00 00 00 00",
                 "MFT Type": "DATA",
-                "Offset": 5009678688,
-                "Record Number": 28,
+                "Offset": 1052277088,
+                "Record Number": 6,
                 "Record Type": "FILE",
+                "__children": [],
             },
         ]
         for expected_row in expected_rows:
@@ -924,7 +928,7 @@ class TestWindowsMFTscan:
         expected_rows = [
             {
                 "Filename": "index",
-                "Hexdump": '"\n30 5c 72 a7 1b 6d fb fc 09 00 00 00 00 00 00 00 0\\r..m..........\n00 00 00 00 00 00 00 00                         ........        "',
+                "Hexdump": "30 5c 72 a7 1b 6d fb fc 09 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00",
                 "MFT Type": "DATA",
                 "Offset": 4961536280,
                 "Record Number": 116474,
@@ -932,7 +936,7 @@ class TestWindowsMFTscan:
             },
             {
                 "Filename": "0.2.filtertrie.intermediate.txt",
-                "Hexdump": '"\n30 09 32 0d 0a                                  0.2..           "',
+                "Hexdump": "30 09 32 0d 0a",
                 "MFT Type": "DATA",
                 "Offset": 619242944,
                 "Record Number": 113013,
@@ -1411,4 +1415,3 @@ class TestWindowsVirtMap:
         )
         for expected_row in expected_rows:
             assert test_volatility.match_output_row(expected_row, json_out)
-

--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -228,10 +228,6 @@ class LayerDataRenderer(CLITypeRenderer):
             True,
         )
 
-        import pdb
-
-        pdb.set_trace()
-
         return specific_data, error_bytes
 
 


### PR DESCRIPTION
- **Windows Tests: Update userassist JSON output**
- **Windows Tests: Fix MFTScan testdata**

These two plugins needed to have their testdata fixed since the `LayerData` renderer present data differently. This PR also removes a call to `dbg.set_trace()` that was accidentally merged in with e2fb96a0d338109ddb9d2431ea7fb18ed8b20041.
