### PR TITLE
Windows MFTScan: Memory usage performance fixes

### DIFF
--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -20,7 +20,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     _required_framework_version = (2, 0, 0)
 
-    _version = (2, 0, 1)
+    _version = (3, 0, 0)
 
     class MFTScanResult(NamedTuple):
         offset: format_hints.Hex
@@ -266,7 +266,7 @@ class ADS(interfaces.plugins.PluginInterface):
 
     _required_framework_version = (2, 22, 0)
 
-    _version = (1, 0, 2)
+    _version = (2, 0, 0)
 
     class ADSResult(NamedTuple):
         offset: format_hints.Hex
@@ -366,7 +366,7 @@ class ResidentData(interfaces.plugins.PluginInterface):
 
     _required_framework_version = (2, 22, 0)
 
-    _version = (1, 0, 2)
+    _version = (2, 0, 0)
 
     class ResidentDataResult(NamedTuple):
         offset: format_hints.Hex

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -281,7 +281,7 @@ class ADS(interfaces.plugins.PluginInterface):
     def get_requirements(cls):
         return [
             requirements.VersionRequirement(
-                name="MFTScan", component=MFTScan, version=(2, 0, 0)
+                name="MFTScan", component=MFTScan, version=(3, 0, 0)
             ),
             requirements.TranslationLayerRequirement(
                 name="primary",
@@ -380,7 +380,7 @@ class ResidentData(interfaces.plugins.PluginInterface):
     def get_requirements(cls):
         return [
             requirements.VersionRequirement(
-                name="MFTScan", component=MFTScan, version=(2, 0, 0)
+                name="MFTScan", component=MFTScan, version=(3, 0, 0)
             ),
             requirements.TranslationLayerRequirement(
                 name="primary",

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -234,17 +234,24 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             )
 
     def generate_timeline(self):
-        for row in self._generator():
-            _depth, row_data = row
+        for record in self.enumerate_mft_records(
+            self.context, self.config_path, self.config["primary"]
+        ):
+            fname = record.longest_filename()
 
-            # Only Output FN Records
-            if row_data[6] in ("FILE_NAME", "STANDARD_INFORMATION"):
-                filename = row_data[-1]
-                description = f"MFT {row_data[6]} entry for {filename}"
-                yield (description, timeliner.TimeLinerType.CREATED, row_data[7])
-                yield (description, timeliner.TimeLinerType.MODIFIED, row_data[8])
-                yield (description, timeliner.TimeLinerType.CHANGED, row_data[9])
-                yield (description, timeliner.TimeLinerType.ACCESSED, row_data[10])
+            for _, item in self.parse_standard_information_records(record):
+                description = f"MFT {item.attribute_type} entry for {fname}"
+                yield (description, timeliner.TimeLinerType.CREATED, item.created)
+                yield (description, timeliner.TimeLinerType.MODIFIED, item.modified)
+                yield (description, timeliner.TimeLinerType.CHANGED, item.updated)
+                yield (description, timeliner.TimeLinerType.ACCESSED, item.accessed)
+
+            for _, item in self.parse_filename_records(record):
+                description = f"MFT {item.attribute_type} entry for {item.filename}"
+                yield (description, timeliner.TimeLinerType.CREATED, item.created)
+                yield (description, timeliner.TimeLinerType.MODIFIED, item.modified)
+                yield (description, timeliner.TimeLinerType.CHANGED, item.updated)
+                yield (description, timeliner.TimeLinerType.ACCESSED, item.accessed)
 
     def run(self):
         return renderers.TreeGrid(

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -112,7 +112,6 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 mft_object_type_name,
                 offset=offset,
                 layer_name=layer.name,
-                symbol_table_name=symbol_table_name,
             )
 
             yield mft_record

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -4,14 +4,7 @@
 import contextlib
 import datetime
 import logging
-from typing import (
-    Callable,
-    Iterator,
-    Optional,
-    Tuple,
-    DefaultDict,
-)
-
+from typing import Callable, DefaultDict, Iterator, Optional, Tuple
 
 from volatility3.framework import constants, exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
@@ -120,8 +113,8 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         )
 
         # get each of the individual Field Sets
-        mft_object_typ_name = symbol_table + constants.BANG + "MFT_ENTRY"
-        attribute_object_typ_name = symbol_table + constants.BANG + "ATTRIBUTE"
+        mft_object_type_name = symbol_table + constants.BANG + "MFT_ENTRY"
+        attribute_object_type_name = symbol_table + constants.BANG + "ATTRIBUTE"
 
         record_map: DefaultDict[str, MFTRecord] = DefaultDict(MFTRecord)
 
@@ -131,13 +124,13 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         ):
             with contextlib.suppress(exceptions.InvalidAddressException):
                 mft_record: mft.MFTEntry = context.object(
-                    mft_object_typ_name, offset=offset, layer_name=layer.name
+                    mft_object_type_name, offset=offset, layer_name=layer.name
                 )
 
                 # We will update this on each pass in the next loop and use it as the new offset.
                 attr_base_offset = mft_record.FirstAttrOffset
                 attr: mft.MFTAttribute = context.object(
-                    attribute_object_typ_name,
+                    attribute_object_type_name,
                     offset=offset + attr_base_offset,
                     layer_name=layer.name,
                 )
@@ -155,7 +148,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                     attr_base_offset += attr.Attr_Header.Length
                     # Get the next attribute
                     attr: mft.MFTAttribute = context.object(
-                        attribute_object_typ_name,
+                        attribute_object_type_name,
                         offset=offset + attr_base_offset,
                         layer_name=layer.name,
                     )

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -100,7 +100,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         )
 
         # Read in the Symbol File
-        symbol_table = intermed.IntermediateSymbolTable.create(
+        symbol_table_name = intermed.IntermediateSymbolTable.create(
             context=context,
             config_path=config_path,
             sub_path="windows",
@@ -113,9 +113,9 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         )
 
         # get each of the individual Field Sets
-        mft_object_type_name = symbol_table + constants.BANG + "MFT_ENTRY"
 
         record_map: DefaultDict[str, MFTRecord] = DefaultDict(MFTRecord)
+        mft_object_type_name = symbol_table_name + constants.BANG + "MFT_ENTRY"
 
         # Scan the layer for Raw MFT records and parse the fields
         for offset, _rule_name, _name, _value in layer.scan(
@@ -123,12 +123,15 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         ):
             with contextlib.suppress(exceptions.InvalidAddressException):
                 mft_record: mft.MFTEntry = context.object(
-                    mft_object_type_name, offset=offset, layer_name=layer.name
+                    mft_object_type_name,
+                    offset=offset,
+                    layer_name=layer.name,
+                    symbol_table_name=symbol_table_name,
                 )
 
-                for attribute in mft_record.attributes(symbol_table):
+                for attribute in mft_record.attributes():
                     yield from attr_callback(
-                        record_map, mft_record, attribute, symbol_table
+                        record_map, mft_record, attribute, symbol_table_name
                     )
 
     @classmethod

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -224,11 +224,17 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             self.config_path,
             self.config["primary"],
         ):
+            # Convert all `objects.PrimitiveObject` to their simpler Python
+            # types. This is normally not something we would do, since it's
+            # lossy and prevents users from getting back to the data source,
+            # but in this case memory usage is so extreme due to the number of
+            # records that it becomes necessary. The rich types are still
+            # exposed through classmethods.
             yield level, (
                 record.offset,
                 record.record_type,
-                record.record_number,
-                record.link_count,
+                int(record.record_number),
+                int(record.link_count),
                 record.mft_type,
                 record.permissions,
                 record.attribute_type,
@@ -341,12 +347,16 @@ class ADS(interfaces.plugins.PluginInterface):
             self.config["primary"],
         ):
             for record in self.parse_ads_data_records(mft_entry):
-                # Convert to basic strings here __only__ because they'll use so
-                # much memory in the tree otherwise.
+                # Convert all `objects.PrimitiveObject` to their simpler Python
+                # types. This is normally not something we would do, since it's
+                # lossy and prevents users from getting back to the data source,
+                # but in this case memory usage is so extreme due to the number of
+                # records that it becomes necessary. The rich types are still
+                # exposed through classmethods.
                 yield 0, (
                     record.offset,
-                    record.signature,
-                    record.record_number,
+                    str(record.signature),
+                    int(record.record_number),
                     record.attribute_type,
                     (
                         str(record.filename)
@@ -447,7 +457,20 @@ class ResidentData(interfaces.plugins.PluginInterface):
         ):
             resident_data_entry = self.parse_resident_data(mft_record)
             if resident_data_entry:
-                yield 0, resident_data_entry
+                # Convert all `objects.PrimitiveObject` to their simpler Python
+                # types. This is normally not something we would do, since it's
+                # lossy and prevents users from getting back to the data source,
+                # but in this case memory usage is so extreme due to the number of
+                # records that it becomes necessary. The rich types are still
+                # exposed through classmethods.
+                yield 0, (
+                    resident_data_entry.offset,
+                    resident_data_entry.signature,
+                    int(resident_data_entry.record_number),
+                    resident_data_entry.attribute_type,
+                    str(resident_data_entry.filename),
+                    resident_data_entry.content,
+                )
 
     def run(self):
         return renderers.TreeGrid(

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -238,9 +238,9 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             _depth, row_data = row
 
             # Only Output FN Records
-            if row_data[6] == "FILE_NAME":
+            if row_data[6] in ("FILE_NAME", "STANDARD_INFORMATION"):
                 filename = row_data[-1]
-                description = f"MFT FILE_NAME entry for {filename}"
+                description = f"MFT {row_data[6]} entry for {filename}"
                 yield (description, timeliner.TimeLinerType.CREATED, row_data[7])
                 yield (description, timeliner.TimeLinerType.MODIFIED, row_data[8])
                 yield (description, timeliner.TimeLinerType.CHANGED, row_data[9])

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -131,7 +131,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         try:
             # There should only be one STANDARD_INFORMATION attribute, but we
             # do this just in case.
-            for std_information in mft_record.standard_information_attributes():
+            for std_information in mft_record.standard_information_entries():
                 yield 0, cls.MFTScanResult(
                     format_hints.Hex(std_information.vol.offset),
                     str(mft_record.get_signature()),
@@ -162,7 +162,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
         # File Name Attribute
         try:
-            for filename_info in mft_record.filename_attributes():
+            for filename_info in mft_record.filename_entries():
 
                 # If we don't have a valid enum, coerce to hex so we can keep the record
                 try:

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -25,8 +25,8 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     class MFTScanResult(NamedTuple):
         offset: format_hints.Hex
         record_type: str
-        record_number: int
-        link_count: int
+        record_number: objects.Integer
+        link_count: objects.Integer
         mft_type: str
         permissions: Union[str, interfaces.renderers.BaseAbsentValue]
         attribute_type: str
@@ -275,8 +275,8 @@ class ADS(interfaces.plugins.PluginInterface):
 
     class ADSResult(NamedTuple):
         offset: format_hints.Hex
-        signature: str
-        record_number: int
+        signature: objects.String
+        record_number: objects.Integer
         attribute_type: str
         filename: Union[objects.String, interfaces.renderers.BaseAbsentValue]
         stream_name: Union[objects.String, interfaces.renderers.BaseAbsentValue]
@@ -379,7 +379,7 @@ class ResidentData(interfaces.plugins.PluginInterface):
 
     class ResidentDataResult(NamedTuple):
         offset: format_hints.Hex
-        signature: str
+        signature: objects.String
         record_number: int
         attribute_type: str
         filename: Union[objects.String, interfaces.renderers.BaseAbsentValue]
@@ -426,7 +426,7 @@ class ResidentData(interfaces.plugins.PluginInterface):
 
         return cls.ResidentDataResult(
             format_hints.Hex(attr.Attr_Data.vol.offset),
-            str(mft_record.get_signature()),
+            mft_record.get_signature(),
             mft_record.RecordNumber,
             attr.Attr_Header.AttrType.lookup(),
             filename,
@@ -449,7 +449,7 @@ class ResidentData(interfaces.plugins.PluginInterface):
                 # exposed through classmethods.
                 yield 0, (
                     resident_data_entry.offset,
-                    resident_data_entry.signature,
+                    str(resident_data_entry.signature),
                     int(resident_data_entry.record_number),
                     resident_data_entry.attribute_type,
                     str(resident_data_entry.filename),

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -18,7 +18,7 @@ vollog = logging.getLogger(__name__)
 class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Scans for MFT FILE objects present in a particular windows memory image."""
 
-    _required_framework_version = (2, 0, 0)
+    _required_framework_version = (2, 26, 0)
 
     _version = (3, 0, 0)
 
@@ -269,7 +269,7 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 class ADS(interfaces.plugins.PluginInterface):
     """Scans for Alternate Data Stream"""
 
-    _required_framework_version = (2, 22, 0)
+    _required_framework_version = (2, 26, 0)
 
     _version = (2, 0, 0)
 
@@ -373,7 +373,7 @@ class ADS(interfaces.plugins.PluginInterface):
 class ResidentData(interfaces.plugins.PluginInterface):
     """Scans for MFT Records with Resident Data"""
 
-    _required_framework_version = (2, 22, 0)
+    _required_framework_version = (2, 26, 0)
 
     _version = (2, 0, 0)
 

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -50,6 +50,21 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 version=(1, 0, 0),
             ),
             requirements.VersionRequirement(
+                name="mft_entry",
+                component=mft.MFTEntry,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="mft_filename",
+                component=mft.MFTFileName,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="mft_attribute",
+                component=mft.MFTAttribute,
+                version=(1, 0, 0),
+            ),
+            requirements.VersionRequirement(
                 name="yarascanner", component=yarascan.YaraScanner, version=(2, 1, 0)
             ),
             requirements.VersionRequirement(

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -50,21 +50,6 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 version=(1, 0, 0),
             ),
             requirements.VersionRequirement(
-                name="mft_entry",
-                component=mft.MFTEntry,
-                version=(1, 0, 0),
-            ),
-            requirements.VersionRequirement(
-                name="mft_filename",
-                component=mft.MFTFileName,
-                version=(1, 0, 0),
-            ),
-            requirements.VersionRequirement(
-                name="mft_attribute",
-                component=mft.MFTAttribute,
-                version=(1, 0, 0),
-            ),
-            requirements.VersionRequirement(
                 name="yarascanner", component=yarascan.YaraScanner, version=(2, 1, 0)
             ),
             requirements.VersionRequirement(

--- a/volatility3/framework/symbols/windows/extensions/mft.py
+++ b/volatility3/framework/symbols/windows/extensions/mft.py
@@ -5,19 +5,13 @@
 import logging
 from typing import Dict, Iterator, List, Optional, Tuple
 
-from volatility3 import framework
 from volatility3.framework import constants, exceptions, interfaces, objects
 
 vollog = logging.getLogger(__name__)
 
 
-class MFTEntry(objects.StructType, interfaces.configuration.VersionableInterface):
+class MFTEntry(objects.StructType):
     """This represents the base MFT Record"""
-
-    _version = (1, 0, 0)
-    _required_framework_version = (2, 26, 0)
-
-    framework.require_interface_version(*_required_framework_version)
 
     def __init__(
         self,
@@ -150,14 +144,8 @@ class MFTEntry(objects.StructType, interfaces.configuration.VersionableInterface
                 yield attr
 
 
-class MFTFileName(objects.StructType, interfaces.configuration.VersionableInterface):
+class MFTFileName(objects.StructType):
     """This represents an MFT $FILE_NAME Attribute"""
-
-    _version = (1, 0, 0)
-
-    _required_framework_version = (2, 26, 0)
-
-    framework.require_interface_version(*_required_framework_version)
 
     def get_full_name(self) -> objects.String:
         output = self.Name.cast(
@@ -166,14 +154,8 @@ class MFTFileName(objects.StructType, interfaces.configuration.VersionableInterf
         return output
 
 
-class MFTAttribute(objects.StructType, interfaces.configuration.VersionableInterface):
+class MFTAttribute(objects.StructType):
     """This represents an MFT ATTRIBUTE"""
-
-    _version = (1, 0, 0)
-
-    _required_framework_version = (2, 26, 0)
-
-    framework.require_interface_version(*_required_framework_version)
 
     def get_resident_filename(self) -> Optional[objects.String]:
         # 4MB chosen as cutoff instead of 4KB to allow for recovery from format /L created file systems

--- a/volatility3/framework/symbols/windows/extensions/mft.py
+++ b/volatility3/framework/symbols/windows/extensions/mft.py
@@ -10,7 +10,7 @@ from volatility3.framework import objects, constants, exceptions
 class MFTEntry(objects.StructType):
     """This represents the base MFT Record"""
 
-    def get_signature(self) -> "objects.String":
+    def get_signature(self) -> objects.String:
         signature = self.Signature.cast("string", max_length=4, encoding="latin-1")
         return signature
 
@@ -18,7 +18,7 @@ class MFTEntry(objects.StructType):
 class MFTFileName(objects.StructType):
     """This represents an MFT $FILE_NAME Attribute"""
 
-    def get_full_name(self) -> "objects.String":
+    def get_full_name(self) -> objects.String:
         output = self.Name.cast(
             "string", encoding="utf16", max_length=self.NameLength * 2, errors="replace"
         )
@@ -28,7 +28,7 @@ class MFTFileName(objects.StructType):
 class MFTAttribute(objects.StructType):
     """This represents an MFT ATTRIBUTE"""
 
-    def get_resident_filename(self) -> Optional["objects.String"]:
+    def get_resident_filename(self) -> Optional[objects.String]:
         # 4MB chosen as cutoff instead of 4KB to allow for recovery from format /L created file systems
         # Length as 512 as its 256*2, which is the maximum size for an entire file path, so this is even generous
         if (
@@ -51,7 +51,7 @@ class MFTAttribute(objects.StructType):
         except exceptions.InvalidAddressException:
             return None
 
-    def get_resident_filecontent(self) -> Optional["objects.Bytes"]:
+    def get_resident_filecontent(self) -> Optional[objects.Bytes]:
         # smear observed in mass testing of samples
         # 4MB chosen as cutoff instead of 4KB to allow for recovery from format /L created file systems
         if (

--- a/volatility3/framework/symbols/windows/extensions/mft.py
+++ b/volatility3/framework/symbols/windows/extensions/mft.py
@@ -2,9 +2,12 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
+import logging
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from volatility3.framework import constants, exceptions, interfaces, objects
+
+vollog = logging.getLogger(__name__)
 
 
 class MFTEntry(objects.StructType):
@@ -88,7 +91,10 @@ class MFTEntry(objects.StructType):
                     offset=self.vol.offset + attr_base_offset,
                     layer_name=self.vol.layer_name,
                 )
-        except exceptions.InvalidAddressException:
+        except exceptions.InvalidAddressException as e:
+            vollog.debug(
+                f"Failed to read attribute at {attr.vol.offset:#x}: {e.__class__.__name__}"
+            )
             return
 
     def standard_information_attributes(self) -> Iterator[objects.StructType]:
@@ -110,7 +116,10 @@ class MFTEntry(objects.StructType):
 
                 fn_object = self.symbol_table_name + constants.BANG + "FILE_NAME_ENTRY"
                 attr_data = attr.Attr_Data.cast(fn_object)
-            except exceptions.InvalidAddressException:
+            except exceptions.InvalidAddressException as e:
+                vollog.debug(
+                    f"Failed to read attr at {attr.vol.offset:#x}: {e.__class__.__name__}"
+                )
                 continue
             yield attr_data
 
@@ -168,7 +177,10 @@ class MFTAttribute(objects.StructType):
                 encoding="utf16",
             )
             return name
-        except exceptions.InvalidAddressException:
+        except exceptions.InvalidAddressException as e:
+            vollog.debug(
+                f"Failed to get resident file content due to {e.__class__.__name__}"
+            )
             return None
 
     def get_resident_filecontent(self) -> Optional[objects.Bytes]:
@@ -190,5 +202,8 @@ class MFTAttribute(objects.StructType):
                 length=self.Attr_Header.ContentLength,
             )
             return bytesobj
-        except exceptions.InvalidAddressException:
+        except exceptions.InvalidAddressException as e:
+            vollog.debug(
+                f"Failed to get resident file content due to {e.__class__.__name__}"
+            )
             return None

--- a/volatility3/framework/symbols/windows/extensions/mft.py
+++ b/volatility3/framework/symbols/windows/extensions/mft.py
@@ -20,21 +20,15 @@ class MFTEntry(objects.StructType):
         object_info: interfaces.objects.ObjectInformation,
         size: int,
         members: Dict[str, Tuple[int, interfaces.objects.Template]],
-        **kwargs,
     ) -> None:
         super().__init__(context, type_name, object_info, size, members)
 
-        self._symbol_table_name = kwargs.get("symbol_table_name")
         self._attrs_loaded = False
         self._attrs: List[MFTAttribute] = []
 
     @property
     def symbol_table_name(self) -> str:
-        if self._symbol_table_name is None:
-            raise ValueError(
-                "MFTEntry was instantiated without an MFT symbol table name"
-            )
-        return self._symbol_table_name
+        return self.vol.type_name.split(constants.BANG)[0]
 
     def get_signature(self) -> objects.String:
         signature = self.Signature.cast("string", max_length=4, encoding="latin-1")

--- a/volatility3/framework/symbols/windows/extensions/mft.py
+++ b/volatility3/framework/symbols/windows/extensions/mft.py
@@ -10,7 +10,7 @@ from volatility3.framework import objects, constants, exceptions
 class MFTEntry(objects.StructType):
     """This represents the base MFT Record"""
 
-    def get_signature(self) -> str:
+    def get_signature(self) -> "objects.String":
         signature = self.Signature.cast("string", max_length=4, encoding="latin-1")
         return signature
 
@@ -18,7 +18,7 @@ class MFTEntry(objects.StructType):
 class MFTFileName(objects.StructType):
     """This represents an MFT $FILE_NAME Attribute"""
 
-    def get_full_name(self) -> str:
+    def get_full_name(self) -> "objects.String":
         output = self.Name.cast(
             "string", encoding="utf16", max_length=self.NameLength * 2, errors="replace"
         )
@@ -28,7 +28,7 @@ class MFTFileName(objects.StructType):
 class MFTAttribute(objects.StructType):
     """This represents an MFT ATTRIBUTE"""
 
-    def get_resident_filename(self) -> Optional[str]:
+    def get_resident_filename(self) -> Optional["objects.String"]:
         # 4MB chosen as cutoff instead of 4KB to allow for recovery from format /L created file systems
         # Length as 512 as its 256*2, which is the maximum size for an entire file path, so this is even generous
         if (
@@ -51,7 +51,7 @@ class MFTAttribute(objects.StructType):
         except exceptions.InvalidAddressException:
             return None
 
-    def get_resident_filecontent(self) -> Optional[bytes]:
+    def get_resident_filecontent(self) -> Optional["objects.Bytes"]:
         # smear observed in mass testing of samples
         # 4MB chosen as cutoff instead of 4KB to allow for recovery from format /L created file systems
         if (

--- a/volatility3/framework/symbols/windows/extensions/mft.py
+++ b/volatility3/framework/symbols/windows/extensions/mft.py
@@ -5,13 +5,19 @@
 import logging
 from typing import Dict, Iterator, List, Optional, Tuple
 
+from volatility3 import framework
 from volatility3.framework import constants, exceptions, interfaces, objects
 
 vollog = logging.getLogger(__name__)
 
 
-class MFTEntry(objects.StructType):
+class MFTEntry(objects.StructType, interfaces.configuration.VersionableInterface):
     """This represents the base MFT Record"""
+
+    _version = (1, 0, 0)
+    _required_framework_version = (2, 26, 0)
+
+    framework.require_interface_version(*_required_framework_version)
 
     def __init__(
         self,
@@ -144,8 +150,14 @@ class MFTEntry(objects.StructType):
                 yield attr
 
 
-class MFTFileName(objects.StructType):
+class MFTFileName(objects.StructType, interfaces.configuration.VersionableInterface):
     """This represents an MFT $FILE_NAME Attribute"""
+
+    _version = (1, 0, 0)
+
+    _required_framework_version = (2, 26, 0)
+
+    framework.require_interface_version(*_required_framework_version)
 
     def get_full_name(self) -> objects.String:
         output = self.Name.cast(
@@ -154,8 +166,14 @@ class MFTFileName(objects.StructType):
         return output
 
 
-class MFTAttribute(objects.StructType):
+class MFTAttribute(objects.StructType, interfaces.configuration.VersionableInterface):
     """This represents an MFT ATTRIBUTE"""
+
+    _version = (1, 0, 0)
+
+    _required_framework_version = (2, 26, 0)
+
+    framework.require_interface_version(*_required_framework_version)
 
     def get_resident_filename(self) -> Optional[objects.String]:
         # 4MB chosen as cutoff instead of 4KB to allow for recovery from format /L created file systems


### PR DESCRIPTION
This fixes a major memory performance issue in the `MFTScan` plugins. We had been struggling with large memory consumption in these plugins before, and I assumed that the issue was with the `TreeGrid` implementation. There ended up being a larger issue within the actual plugin, which was unconverted `object.String` objects being stored in the `record_map` that is populated and passed around to various classmethods. This resulted in a map that was far larger than it needed to be, since those values would only ever be converted to strings for the treegrid anyway. I discovered this by accident when implementing a simple SQLite cache as a replacement for the map - watching the SQLite database, I never saw it grow to more than a few dozen megabytes. 

```
[ins] In [5]: pympler.asizeof.asizeof(rec_name)
Out[5]: 312648

[ins] In [6]: pympler.asizeof.asizeof(str(rec_name))
Out[6]: 64
```

This PR:
- Properly converts values to strings before storing them in the map
- Fixes type hints in the MFT extension classes to reflect that they return `objects.String`, not `str`.
- Updates type hints throughout the MFTScan plugin classes for clarity.
- Reimplements the map as a typed `DefaultDict` for simplicity
- Adds a simple `MFTRecord` class that uses `__slots__` in place of the lists that were being used as map values before. This should result in some more (small) performance gains, and help with readability since values are no longer accessed by index.

You can see how much better it performs on an 8GB sample here - `sys` time that was presumably spent swapping dropped from ~47 seconds to ~8 seconds:
```
~/volatility3 (fix_tests|✚2) $ time vol -f ~/memory_samples/data.lime -r jsonl windows.mftscan.ResidentData > /dev/null
Volatility 3 Framework 2.26.0
Progress:  100.00		PDB scanning finished                  
________________________________________________________
Executed in  400.14 secs    fish           external
   usr time  340.85 secs    0.32 millis  340.85 secs
   sys time   47.16 secs    1.46 millis   47.16 secs
 
~/volatility3 (fix_tests|●1) $ time vol -f ~/memory_samples/data.lime -r jsonl windows.mftscan.ResidentData > /dev/null
Volatility 3 Framework 2.26.0
Progress:  100.00		PDB scanning finished                  
________________________________________________________
Executed in  321.45 secs    fish           external
   usr time  314.03 secs    0.29 millis  314.03 secs
   sys time    8.18 secs    1.21 millis    8.18 secs
```

closes #1725 