### PR TITLE
Fix traceback in volshell's `dt()`

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -629,7 +629,7 @@ class Volshell(interfaces.plugins.PluginInterface):
                             else:
                                 suffix = ""
                         except exceptions.SymbolError as exc:
-                            suffix = f" (pointer to {exc.symbol_name} - unknown size)"
+                            suffix = f" (unknown sized {exc.symbol_name})"
                         return f"{hex(value)}{suffix}"
                     elif isinstance(value, objects.PrimitiveObject):
                         return repr(value)

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -621,12 +621,15 @@ class Volshell(interfaces.plugins.PluginInterface):
                     if isinstance(value, objects.Pointer):
                         # show pointers in hex to match output for struct addrs
                         # highlight null or unreadable pointers
-                        if value == 0:
-                            suffix = " (null pointer)"
-                        elif not value.is_readable():
-                            suffix = " (unreadable pointer)"
-                        else:
-                            suffix = ""
+                        try:
+                            if value == 0:
+                                suffix = " (null pointer)"
+                            elif not value.is_readable():
+                                suffix = " (unreadable pointer)"
+                            else:
+                                suffix = ""
+                        except exceptions.SymbolError as exc:
+                            suffix = f" (pointer to {exc.symbol_name} - unknown size)"
                         return f"{hex(value)}{suffix}"
                     elif isinstance(value, objects.PrimitiveObject):
                         return repr(value)


### PR DESCRIPTION
A `SymbolError` can occur when a type contains a pointer to an opaque
type. For example, `_EPROCESS` can have a member that points to an
`_EPROCESS_QUOTA_BLOCK`, but there is no definition for that type, so
its size and readability can't be determined.

This wraps the block in a try/except, and reports that the type has an
unknown size in the suffix if a `SymbolError` occurs.
