### PR TITLE
[Parity/modules] Adjust module alignment for scanners

### DIFF
--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -474,10 +474,9 @@ class Modules(interfaces.configuration.VersionableInterface):
         Returns:
             The struct module alignment
         """
-        # FIXME: When dwarf2json/ISF supports type alignments. Read it directly from the type metadata
-        # Additionally, while 'context' and 'vmlinux_module_name' are currently unused, they will be
-        # essential for retrieving type metadata in the future.
-        return 64
+        # Not L1 cache aligned, but compiler should naturally
+        # align to the referenced type as a minimum.
+        return context.modules[vmlinux_module_name].get_type("pointer").size
 
     @classmethod
     def list_modules(

--- a/volatility3/framework/symbols/linux/utilities/modules.py
+++ b/volatility3/framework/symbols/linux/utilities/modules.py
@@ -474,8 +474,6 @@ class Modules(interfaces.configuration.VersionableInterface):
         Returns:
             The struct module alignment
         """
-        # Not L1 cache aligned, but compiler should naturally
-        # align to the referenced type as a minimum.
         return context.modules[vmlinux_module_name].get_type("pointer").size
 
     @classmethod


### PR DESCRIPTION
Hi,

This PR adjusts the module alignment value for the module scanner interface. The reworked implementation does not provide a populated list of known module addresses now:

https://github.com/volatilityfoundation/volatility3/blob/842d0e77037cc26a08379145b928df98bd60fe87/volatility3/framework/symbols/linux/utilities/modules.py#L843-L849

Consequently `validate_alignment_patterns` isn't actually validating anything right now. We observed this when mass testing `modxview` on misaligned samples (32 bytes alignment). 

To solve this issue with a minimal impact on the codebase, we figured that scanning with pointer size alignment was a good compromise even if it impacts runtime a bit.

1-byte alignment was technically valid, but most compilers and allocators should naturally do allocation aligned to the object type at least. On other note, i think that even if all modules in `validate_alignment_patterns()` passed the 64 bytes check, it was not guaranteed that a one-off allocation on a 32 bytes alignment had happened (still an unlucky scenario).