### PR TITLE
Layers: Fix exception message

### DIFF
--- a/volatility3/framework/interfaces/layers.py
+++ b/volatility3/framework/interfaces/layers.py
@@ -678,7 +678,7 @@ class LayerContainer(collections.abc.Mapping):
             if name in self._layers[layer].dependencies:
                 raise exceptions.LayerException(
                     self._layers[layer].name,
-                    f"Layer {self._layers[layer].name} is depended upon by {layer}",
+                    f"Layer {name} is depended upon by {layer}",
                 )
         # Otherwise, wipe out the layer
         self._layers[name].destroy()


### PR DESCRIPTION
Updates the exception message to report the correct dependency instead
of the layer name itself. Instead of reporting the actual dependency, it
was reporting, for example 'Layer layer_name is depended upon by
layer_name'.
