### PR TITLE
Linux pagecache.Files: Memory Usage

### DIFF
--- a/volatility3/framework/plugins/linux/mountinfo.py
+++ b/volatility3/framework/plugins/linux/mountinfo.py
@@ -279,7 +279,7 @@ class MountInfo(plugins.PluginInterface):
             if not (sb_ptr and sb_ptr.is_readable()):
                 continue
 
-            if int(sb_ptr) in seen_sb_ptr:
+            if sb_ptr in seen_sb_ptr:
                 continue
             seen_sb_ptr.add(int(sb_ptr))
 

--- a/volatility3/framework/plugins/linux/mountinfo.py
+++ b/volatility3/framework/plugins/linux/mountinfo.py
@@ -279,9 +279,9 @@ class MountInfo(plugins.PluginInterface):
             if not (sb_ptr and sb_ptr.is_readable()):
                 continue
 
-            if sb_ptr in seen_sb_ptr:
+            if int(sb_ptr) in seen_sb_ptr:
                 continue
-            seen_sb_ptr.add(sb_ptr)
+            seen_sb_ptr.add(int(sb_ptr))
 
             superblock = sb_ptr.dereference()
 

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -283,6 +283,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 continue
 
             # Inode already processed?
+            # Store a primitive int (instead of the pointer value) to track
+            # addresses we've already seen. Storing the full `objects.Pointer`
+            # uses too much memory, and we don't need all of the information
+            # that it contains.
             if int(root_inode_ptr) in seen_inodes:
                 continue
 
@@ -319,6 +323,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
                     continue
 
                 # Inode already processed?
+                # Store a primitive int (instead of the pointer value) to track
+                # addresses we've already seen. Storing the full `objects.Pointer`
+                # uses too much memory, and we don't need all of the information
+                # that it contains.
                 if int(file_inode_ptr) in seen_inodes:
                     continue
                 seen_inodes.add(int(file_inode_ptr))

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -204,10 +204,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             if dentry_addr == root_dentry.vol.offset:
                 continue
 
-            if dentry_addr in seen_dentries:
+            if int(dentry_addr) in seen_dentries:
                 continue
 
-            seen_dentries.add(dentry_addr)
+            seen_dentries.add(int(dentry_addr))
 
             inode_ptr = dentry.d_inode
             if not (inode_ptr and inode_ptr.is_readable()):
@@ -283,9 +283,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 continue
 
             # Inode already processed?
-            if root_inode_ptr in seen_inodes:
+            if int(root_inode_ptr) in seen_inodes:
                 continue
-            seen_inodes.add(root_inode_ptr)
+
+            seen_inodes.add(int(root_inode_ptr))
 
             root_path = mountpoint
 
@@ -318,9 +319,9 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
                     continue
 
                 # Inode already processed?
-                if file_inode_ptr in seen_inodes:
+                if int(file_inode_ptr) in seen_inodes:
                     continue
-                seen_inodes.add(file_inode_ptr)
+                seen_inodes.add(int(file_inode_ptr))
 
                 if follow_symlinks:
                     file_path = cls._follow_symlink(file_inode_ptr, file_path)

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -287,7 +287,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             # addresses we've already seen. Storing the full `objects.Pointer`
             # uses too much memory, and we don't need all of the information
             # that it contains.
-            if int(root_inode_ptr) in seen_inodes:
+            if root_inode_ptr in seen_inodes:
                 continue
 
             seen_inodes.add(int(root_inode_ptr))
@@ -327,7 +327,7 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 # addresses we've already seen. Storing the full `objects.Pointer`
                 # uses too much memory, and we don't need all of the information
                 # that it contains.
-                if int(file_inode_ptr) in seen_inodes:
+                if file_inode_ptr in seen_inodes:
                     continue
                 seen_inodes.add(int(file_inode_ptr))
 

--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -204,10 +204,10 @@ class Files(plugins.PluginInterface, timeliner.TimeLinerInterface):
             if dentry_addr == root_dentry.vol.offset:
                 continue
 
-            if int(dentry_addr) in seen_dentries:
+            if dentry_addr in seen_dentries:
                 continue
 
-            seen_dentries.add(int(dentry_addr))
+            seen_dentries.add(dentry_addr)
 
             inode_ptr = dentry.d_inode
             if not (inode_ptr and inode_ptr.is_readable()):


### PR DESCRIPTION
Converts `objects.Pointer` to `int` before storing them in the set. This
should have a substantial impact on memory, similar to those in #1758
