### PR TITLE
ShimcacheMem: Various bugfixes

### DIFF
--- a/volatility3/framework/plugins/windows/shimcachemem.py
+++ b/volatility3/framework/plugins/windows/shimcachemem.py
@@ -174,6 +174,8 @@ class ShimcacheMem(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterf
                     vad.get_start() + SHIM_NUM_ENTRIES_OFFSET,
                 )
 
+                vollog.debug(f"Found {num_entries} shimcache entries")
+
                 if num_entries > SHIM_MAX_ENTRIES:
                     continue
 
@@ -204,7 +206,6 @@ class ShimcacheMem(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterf
 
                     if physical_addr in seen:
                         continue
-                    seen.add(physical_addr)
 
                     shim_entry = proc_layer.context.object(
                         shimcache_symbol_table + constants.BANG + "SHIM_CACHE_ENTRY",
@@ -215,6 +216,8 @@ class ShimcacheMem(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterf
                         continue
                     if not shim_entry.is_valid():
                         continue
+
+                    seen.add(physical_addr)
 
                     yield shim_entry
 

--- a/volatility3/framework/symbols/windows/extensions/shimcache.py
+++ b/volatility3/framework/symbols/windows/extensions/shimcache.py
@@ -136,7 +136,7 @@ class SHIM_CACHE_ENTRY(objects.StructType):
                 self._context,
                 self.Path.vol.layer_name,
                 self.Path.vol.offset,
-                520,
+                self.Path.vol.count,
                 encoding="utf-16le",
             )
 

--- a/volatility3/framework/symbols/windows/extensions/shimcache.py
+++ b/volatility3/framework/symbols/windows/extensions/shimcache.py
@@ -57,12 +57,14 @@ class SHIM_CACHE_ENTRY(objects.StructType):
                 blob_offset, blob_size
             ):
                 self._exec_flag = renderers.UnparsableValue()
+                return self._exec_flag
 
             raw_flag = self._context.layers[self.vol.native_layer_name].read(
                 blob_offset, blob_size
             )
             if not raw_flag:
                 self._exec_flag = renderers.UnparsableValue()
+                return self._exec_flag
 
             try:
                 self._exec_flag = bool(struct.unpack("<I", raw_flag)[0])
@@ -72,6 +74,7 @@ class SHIM_CACHE_ENTRY(objects.StructType):
         else:
             # Always set to true for XP/2K3
             self._exec_flag = renderers.NotApplicableValue()
+
         return self._exec_flag
 
     @property
@@ -118,6 +121,8 @@ class SHIM_CACHE_ENTRY(objects.StructType):
             )
         except AttributeError:
             self._last_updated = renderers.NotApplicableValue()
+        except exceptions.InvalidAddressException:
+            self._last_updated = renderers.UnreadableValue()
 
         return self._last_updated
 

--- a/volatility3/framework/symbols/windows/extensions/shimcache.py
+++ b/volatility3/framework/symbols/windows/extensions/shimcache.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Dict, Optional, Tuple, Union
 
 from volatility3.framework import constants, exceptions, interfaces, objects, renderers
+from volatility3.framework.objects.utility import address_to_string
 from volatility3.framework.symbols.windows.extensions import conversion
 
 vollog = logging.getLogger(__name__)
@@ -126,8 +127,12 @@ class SHIM_CACHE_ENTRY(objects.StructType):
             return self._file_path
 
         if not hasattr(self.Path, "Buffer"):
-            return self.Path.cast(
-                "string", max_length=self.Path.vol.count, encoding="utf-16le"
+            return address_to_string(
+                self._context,
+                self.Path.vol.layer_name,
+                self.Path.vol.offset,
+                520,
+                encoding="utf-16le",
             )
 
         try:

--- a/volatility3/framework/symbols/windows/shimcache/shimcache-xp-sp2-x86.json
+++ b/volatility3/framework/symbols/windows/shimcache/shimcache-xp-sp2-x86.json
@@ -331,23 +331,23 @@
                 "LastModified": {
                     "type": {
                         "kind": "union",
-                        "name": "LARGE_INTEGER"
+                        "name": "_LARGE_INTEGER"
                     },
-                    "offset": 4
+                    "offset": 528
                 },
                 "FileSize": {
                     "type": {
                         "kind": "base",
                         "name": "long long"
                     },
-                    "offset": 8
+                    "offset": 536
                 },
                 "LastUpdate": {
                     "type": {
                         "kind": "union",
-                        "name": "LARGE_INTEGER"
+                        "name": "_LARGE_INTEGER"
                     },
-                    "offset": 12
+                    "offset": 544
                 }
             },
             "kind": "struct",


### PR DESCRIPTION
Found a few things wrong with the shimcachemem plugin and extensions:

- WinXPSP2 symbol table: Bad references to `LARGE_INTEGER` instead of `_LARGE_INTEGER`, as well as bad offsets in the `SHIM_CACHE_ENTRY` type.
- `ShimcacheMem` plugin: Updates code to use `address_to_string` in order to deal with potentially truncated reads - this matters most in the XP entries, where the path field is an array of 520 bytes, but not all of them may be readable, and the file path is typically much shorter than the full buffer length.
- `ShimcacheMem` plugin: Fixes offset tracking. The offset was being added to the tracker before the validity of the entry was being checked, so it prevents potentially valid copies of invalid entries from being yielded from other process' address spaces in XP.
- `SHIM_CACHE_ENTRY` Extension: Fixes logic error in `exec_flag`. A couple of early returns were needed when the buffer containing the flag is not valid. This was leading to `InvalidAddressException`s being raised after the validity of the memory range had been checked, instead of returning the `renderers.UnreadableValue`.
