### PR TITLE
Bugfix: Linux/Windows process traversal

### DIFF
--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -262,17 +262,27 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         init_task = vmlinux.object_from_symbol(symbol_name="init_task")
 
         # Note that the init_task itself is not yielded, since "ps" also never shows it.
-        for task in init_task.tasks:
-            if not task.is_valid():
-                continue
+        seen = set()
+        for forward in (True, False):
+            for task in init_task.tasks.to_list(
+                symbol_type=init_task.vol.type_name,
+                member="tasks",
+                forward=forward,
+            ):
+                if task.vol.offset in seen:
+                    continue
+                seen.add(task.vol.offset)
 
-            if filter_func(task):
-                continue
+                if not task.is_valid():
+                    continue
 
-            yield task
+                if filter_func(task):
+                    continue
 
-            if include_threads:
-                yield from task.get_threads()
+                yield task
+
+                if include_threads:
+                    yield from task.get_threads()
 
     def run(self):
         pids = self.config.get("pid")

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -34,7 +34,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists the processes present in a particular linux memory image."""
 
     _required_framework_version = (2, 13, 0)
-    _version = (4, 1, 0)
+    _version = (4, 1, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/windows/pslist.py
+++ b/volatility3/framework/plugins/windows/pslist.py
@@ -264,7 +264,9 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
         seen = set()
         for forward in (True, False):
             for proc in eproc.ActiveProcessLinks.to_list(
-                eproc.vol.type_name, "ActiveProcessLinks", forward=forward
+                symbol_type=eproc.vol.type_name,
+                member="ActiveProcessLinks",
+                forward=forward,
             ):
                 if proc.vol.offset in seen:
                     continue

--- a/volatility3/framework/plugins/windows/pslist.py
+++ b/volatility3/framework/plugins/windows/pslist.py
@@ -6,13 +6,13 @@ import datetime
 import logging
 from typing import Callable, Iterator, List, Optional, Type
 
-from volatility3.framework import renderers, interfaces, layers, exceptions, constants
+from volatility3.framework import constants, exceptions, interfaces, layers, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import intermed
-from volatility3.framework.symbols.windows.extensions import pe
 from volatility3.framework.symbols.windows import extensions
+from volatility3.framework.symbols.windows.extensions import pe
 from volatility3.plugins import timeliner
 
 vollog = logging.getLogger(__name__)
@@ -261,9 +261,16 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             absolute=True,
         )
 
-        for proc in eproc.ActiveProcessLinks:
-            if not filter_func(proc):
-                yield proc
+        seen = set()
+        for forward in (True, False):
+            for proc in eproc.ActiveProcessLinks.to_list(
+                eproc.vol.type_name, "ActiveProcessLinks", forward=forward
+            ):
+                if proc.vol.offset in seen:
+                    continue
+                seen.add(proc.vol.offset)
+                if not filter_func(proc):
+                    yield proc
 
     def _generator(self):
         kernel = self.context.modules[self.config["kernel"]]

--- a/volatility3/framework/plugins/windows/pslist.py
+++ b/volatility3/framework/plugins/windows/pslist.py
@@ -24,7 +24,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     _required_framework_version = (2, 0, 0)
 
     # 3.0.0 - changed signature for `list_processes`
-    _version = (3, 0, 0)
+    _version = (3, 0, 1)
     PHYSICAL_DEFAULT = False
 
     @classmethod


### PR DESCRIPTION
Both of these process listings were missing entries due to the lack of backwards traversal (`__iter__` for the `LIST_ENTRY`/`list_head` extension classes only goes forward). This updates both plugins to traverse the list backwards as well as forwards, tracking seen offsets to avoid duplicate entries.
