### PR TITLE
Poolscanners: Fix symlink pool types

### DIFF
--- a/test/plugins/windows/windows.py
+++ b/test/plugins/windows/windows.py
@@ -746,6 +746,19 @@ class TestWindowsKPCRs:
         assert test_volatility.count_entries_flat(json.loads(out)) > 0
 
 
+class TestWindowsSymlinkScan:
+    def test_windows_generic_symlinkscan(self, volatility, python, image):
+        rc, out, _err = test_volatility.runvol_plugin(
+            "windows.symlinkscan.SymlinkScan",
+            image,
+            volatility,
+            python,
+            globalargs=("-r", "json"),
+        )
+        assert rc == 0
+        assert test_volatility.count_entries_flat(json.loads(out)) > 0
+
+
 class TestWindowsLdrModules:
     def test_windows_specific_ldrmodules(self, volatility, python):
         image = WindowsSamples.WINDOWSXP_GENERIC.value.path

--- a/test/plugins/windows/windows.py
+++ b/test/plugins/windows/windows.py
@@ -758,6 +758,38 @@ class TestWindowsSymlinkScan:
         assert rc == 0
         assert test_volatility.count_entries_flat(json.loads(out)) > 0
 
+    def test_windows_specific_symlinkscan(self, volatility, python):
+        image = WindowsSamples.WINDOWSXP_GENERIC.value.path
+        rc, out, _err = test_volatility.runvol_plugin(
+            "windows.symlinkscan.SymlinkScan",
+            image,
+            volatility,
+            python,
+            globalargs=("-r", "json"),
+        )
+        assert rc == 0
+        json_out = json.loads(out)
+        assert test_volatility.count_entries_flat(json_out) > 5
+        expected_rows = [
+            {
+              "CreateTime": "2005-06-25T16:47:28+00:00",
+              "From Name": "AUX",
+              "Offset": 453082584,
+              "To Name": "\\DosDevices\\COM1",
+              "__children": []
+            },
+            {
+              "CreateTime": "2005-06-25T16:47:28+00:00",
+              "From Name": "UNC",
+              "Offset": 453176664,
+              "To Name": "\\Device\\Mup",
+              "__children": []
+            }
+        ]
+
+        for expected_row in expected_rows:
+            assert test_volatility.match_output_row(expected_row, json_out)
+
 
 class TestWindowsLdrModules:
     def test_windows_specific_ldrmodules(self, volatility, python):

--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -343,7 +343,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_OBJECT_SYMBOLIC_LINK",
                 object_type="SymbolicLink",
                 size=(72, None),
-                page_type=PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.PAGED | PoolType.FREE,
             ),
             # symlinks on windows starting with windows 8
             PoolConstraint(
@@ -351,7 +351,7 @@ class PoolScanner(plugins.PluginInterface):
                 type_name=symbol_table + constants.BANG + "_OBJECT_SYMBOLIC_LINK",
                 object_type="SymbolicLink",
                 size=(72, None),
-                page_type=PoolType.NONPAGED | PoolType.FREE,
+                page_type=PoolType.PAGED | PoolType.FREE,
             ),
             # registry hives
             PoolConstraint(

--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -131,7 +131,7 @@ class PoolScanner(plugins.PluginInterface):
     """A generic pool scanner plugin."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (3, 0, 0)
+    _version = (3, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:


### PR DESCRIPTION
Fixes regression introduced in #1632

Symbolic links are allocated in the paged pools, not non-paged. This was
causing us to miss symlinks across both pre and post win8 samples.

closes #1775 
