### PR TITLE
Make QEMU layer call parent's requirements

### DIFF
--- a/volatility3/framework/layers/qemu.py
+++ b/volatility3/framework/layers/qemu.py
@@ -115,7 +115,7 @@ class QemuSuspendLayer(segmented.NonLinearlySegmentedLayer):
         cls, base_layer: interfaces.layers.DataLayerInterface, name: str = ""
     ):
         header = base_layer.read(0, 8)
-        if header[:4] != b"\x51\x45\x56\x4D":
+        if header[:4] != b"\x51\x45\x56\x4d":
             raise exceptions.LayerException(name, "No QEMU magic bytes")
         if header[4:] != b"\x00\x00\x00\x03":
             raise exceptions.LayerException(name, "Unsupported QEMU version found")

--- a/volatility3/framework/layers/qemu.py
+++ b/volatility3/framework/layers/qemu.py
@@ -102,7 +102,7 @@ class QemuSuspendLayer(segmented.NonLinearlySegmentedLayer):
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
-        return [
+        return super().get_requirements() + [
             requirements.VersionRequirement(
                 name="regex_scanner",
                 component=scanners.RegExScanner,


### PR DESCRIPTION
Hi,

The QEMU suspend layer wasn't requiring the `segmented.NonLinearlySegmentedLayer` requirements, which resulted in failure in the automagic stage. This PR fixes this issue.