### PR TITLE
1780 dlllist loadcount missing

### DIFF
--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,7 +1,7 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
-VERSION_MINOR = 26  # Number of changes that only add to the interface
-VERSION_PATCH = 2  # Number of changes that do not change the interface
+VERSION_MINOR = 27  # Number of changes that only add to the interface
+VERSION_PATCH = 0  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 PACKAGE_VERSION = (

--- a/volatility3/framework/plugins/windows/dlllist.py
+++ b/volatility3/framework/plugins/windows/dlllist.py
@@ -173,6 +173,10 @@ class DllList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 except exceptions.InvalidAddressException:
                     size_of_image = renderers.NotAvailableValue()
 
+                LoadCount = entry.get_load_count()
+                if LoadCount is None:
+                    LoadCount = renderers.NotAvailableValue()
+
                 yield (
                     0,
                     (
@@ -186,6 +190,7 @@ class DllList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                         size_of_image,
                         BaseDllName,
                         FullDllName,
+                        LoadCount,
                         DllLoadTime,
                         file_output,
                     ),
@@ -232,6 +237,7 @@ class DllList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
                 ("Size", format_hints.Hex),
                 ("Name", str),
                 ("Path", str),
+                ("LoadCount", int),
                 ("LoadTime", datetime.datetime),
                 ("File output", str),
             ],

--- a/volatility3/framework/plugins/windows/dlllist.py
+++ b/volatility3/framework/plugins/windows/dlllist.py
@@ -22,7 +22,7 @@ class DllList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists the loaded DLLs in a particular windows memory image."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (3, 0, 0)
+    _version = (3, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/symbols/windows/__init__.py
+++ b/volatility3/framework/symbols/windows/__init__.py
@@ -41,6 +41,7 @@ class WindowsKernelIntermedSymbols(intermed.IntermediateSymbolTable):
         self.set_type_class("_POOL_TRACKER_BIG_PAGES", pool.POOL_TRACKER_BIG_PAGES)
         self.set_type_class("_IMAGE_DOS_HEADER", pe.IMAGE_DOS_HEADER)
         self.set_type_class("_KTIMER", extensions.KTIMER)
+        self.set_type_class("_LDR_DATA_TABLE_ENTRY", extensions.LDR_DATA_TABLE_ENTRY)
 
         # Might not necessarily defined in every version of windows
         self.optional_set_type_class("_IMAGE_NT_HEADERS", pe.IMAGE_NT_HEADERS)

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -1710,3 +1710,17 @@ class SHARED_CACHE_MAP(objects.StructType):
                     )
 
         return vacb_list
+
+class LDR_DATA_TABLE_ENTRY(objects.StructType):
+    def get_load_count(self) -> Optional[int]:
+        try:
+            LoadCount = self.LoadCount
+        except:
+            try:
+                LoadCount = self.ObsoleteLoadCount
+            except:
+                LoadCount = None
+        if LoadCount == 65535:
+            LoadCount = -1
+
+        return LoadCount

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -1711,14 +1711,15 @@ class SHARED_CACHE_MAP(objects.StructType):
 
         return vacb_list
 
+
 class LDR_DATA_TABLE_ENTRY(objects.StructType):
     def get_load_count(self) -> Optional[int]:
         try:
             LoadCount = self.LoadCount
-        except:
+        except Exception:
             try:
                 LoadCount = self.ObsoleteLoadCount
-            except:
+            except Exception:
                 LoadCount = None
         if LoadCount == 65535:
             LoadCount = -1

--- a/volatility3/framework/symbols/windows/extensions/__init__.py
+++ b/volatility3/framework/symbols/windows/extensions/__init__.py
@@ -1715,13 +1715,11 @@ class SHARED_CACHE_MAP(objects.StructType):
 class LDR_DATA_TABLE_ENTRY(objects.StructType):
     def get_load_count(self) -> Optional[int]:
         try:
-            LoadCount = self.LoadCount
+            LoadCount = self.LoadCount.cast("short")
         except Exception:
             try:
-                LoadCount = self.ObsoleteLoadCount
+                LoadCount = self.ObsoleteLoadCount.cast("short")
             except Exception:
                 LoadCount = None
-        if LoadCount == 65535:
-            LoadCount = -1
 
         return LoadCount


### PR DESCRIPTION
Add the LoadCount column with a symbol extension since it depends on OS version.

@ikelos Not sure if there's a better way of printing the -1. the actual data is a signed short as 0xffff.

Also would this need a version bump and if so which number?