### PR TITLE
Windows Shimcachemem: Fix tracebacks

### DIFF
--- a/volatility3/framework/plugins/windows/shimcachemem.py
+++ b/volatility3/framework/plugins/windows/shimcachemem.py
@@ -582,13 +582,19 @@ class ShimcacheMem(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterf
         :return: The offset and size of the module, if found; Otherwise, returns `None`
         """
 
-        try:
-            krnl_mod = next(
-                module
-                for module in modules.Modules.list_modules(context, kernel_module_name)
-                if module.BaseDllName.String in module_list
-            )
-        except StopIteration:
+        krnl_mod = None
+        for module in modules.Modules.list_modules(context, kernel_module_name):
+            try:
+                if module.BaseDllName.String in module_list:
+                    krnl_mod = module
+                    break
+            except exceptions.InvalidAddressException as exc:
+                vollog.warning(
+                    f"Failed to get kernel module due to {exc.__class__.__name__}: {exc.invalid_address:#x}"
+                )
+
+        if krnl_mod is None:
+            vollog.warning("Failed to find kernel module")
             return None
 
         kernel = context.modules[kernel_module_name]

--- a/volatility3/framework/symbols/windows/extensions/shimcache.py
+++ b/volatility3/framework/symbols/windows/extensions/shimcache.py
@@ -57,7 +57,7 @@ class SHIM_CACHE_ENTRY(objects.StructType):
                 if not self._context.layers[self.vol.native_layer_name].is_valid(
                     blob_offset, blob_size
                 ):
-                    self._exec_flag = renderers.UnparsableValue()
+                    self._exec_flag = renderers.UnreadableValue()
                     return self._exec_flag
 
                 raw_flag = self._context.layers[self.vol.native_layer_name].read(

--- a/volatility3/framework/symbols/windows/extensions/shimcache.py
+++ b/volatility3/framework/symbols/windows/extensions/shimcache.py
@@ -39,37 +39,44 @@ class SHIM_CACHE_ENTRY(objects.StructType):
         if self._exec_flag is not None:
             return self._exec_flag
 
-        if hasattr(self, "ListEntryDetail") and hasattr(
-            self.ListEntryDetail, "InsertFlags"
-        ):
-            self._exec_flag = self.ListEntryDetail.InsertFlags & 0x2 == 2
-
-        elif hasattr(self, "InsertFlags"):
-            self._exec_flag = self.InsertFlags & 0x2 == 2
-
-        elif hasattr(self, "ListEntryDetail") and hasattr(
-            self.ListEntryDetail, "BlobBuffer"
-        ):
-            blob_offset = self.ListEntryDetail.BlobBuffer
-            blob_size = self.ListEntryDetail.BlobSize
-
-            if not self._context.layers[self.vol.native_layer_name].is_valid(
-                blob_offset, blob_size
+        try:
+            if hasattr(self, "ListEntryDetail") and hasattr(
+                self.ListEntryDetail, "InsertFlags"
             ):
-                self._exec_flag = renderers.UnparsableValue()
-                return self._exec_flag
+                self._exec_flag = self.ListEntryDetail.InsertFlags & 0x2 == 2
 
-            raw_flag = self._context.layers[self.vol.native_layer_name].read(
-                blob_offset, blob_size
+            elif hasattr(self, "InsertFlags"):
+                self._exec_flag = self.InsertFlags & 0x2 == 2
+
+            elif hasattr(self, "ListEntryDetail") and hasattr(
+                self.ListEntryDetail, "BlobBuffer"
+            ):
+                blob_offset = self.ListEntryDetail.BlobBuffer
+                blob_size = self.ListEntryDetail.BlobSize
+
+                if not self._context.layers[self.vol.native_layer_name].is_valid(
+                    blob_offset, blob_size
+                ):
+                    self._exec_flag = renderers.UnparsableValue()
+                    return self._exec_flag
+
+                raw_flag = self._context.layers[self.vol.native_layer_name].read(
+                    blob_offset, blob_size
+                )
+                if not raw_flag:
+                    self._exec_flag = renderers.UnparsableValue()
+                    return self._exec_flag
+
+                try:
+                    self._exec_flag = bool(struct.unpack("<I", raw_flag)[0])
+                except struct.error:
+                    self._exec_flag = renderers.UnparsableValue()
+
+        except exceptions.InvalidAddressException:
+            vollog.debug(
+                "Failed to read SHIMCACHE_ENTRY exec flag due to invalid address exception"
             )
-            if not raw_flag:
-                self._exec_flag = renderers.UnparsableValue()
-                return self._exec_flag
-
-            try:
-                self._exec_flag = bool(struct.unpack("<I", raw_flag)[0])
-            except struct.error:
-                self._exec_flag = renderers.UnparsableValue()
+            self._exec_flag = renderers.UnreadableValue()
 
         else:
             # Always set to true for XP/2K3


### PR DESCRIPTION
This fixes a couple of uncaught exceptions in the shimcachemem plugin and extension classes - one when iterating over modules + checking their names, and the other when attempting to parse the exec flag. Also changes a return type from `renderers.UnparsableValue` to `renderers.UnreadableValue` which I think is more appropriate, since the underlying data could not be read from the address space.