### PR TITLE
Windows Handles: Refactor plugin

### DIFF
--- a/volatility3/framework/plugins/windows/callbacks.py
+++ b/volatility3/framework/plugins/windows/callbacks.py
@@ -48,7 +48,7 @@ class Callbacks(interfaces.plugins.PluginInterface):
                 name="driverirp", component=driverirp.DriverIrp, version=(1, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="handles", component=handles.Handles, version=(3, 0, 0)
+                name="handles", component=handles.Handles, version=(4, 0, 0)
             ),
         ]
 

--- a/volatility3/framework/plugins/windows/poolscanner.py
+++ b/volatility3/framework/plugins/windows/poolscanner.py
@@ -142,7 +142,7 @@ class PoolScanner(plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="handles", component=handles.Handles, version=(3, 0, 0)
+                name="handles", component=handles.Handles, version=(4, 0, 0)
             ),
             requirements.VersionRequirement(
                 name="pool_header_scanner",


### PR DESCRIPTION
A lot of functionality in the `Handles` plugin class was using instance methods instead of classmethods. This refactors the plugin to use classmethods instead of instance methods for consistency with the rest of the framework, and bumps the plugin major version to 4.0.0. It also updates plugins that depend on `Handles` with the correct required major version, and converts instances where an instance of the plugin is being constructed to uses of the new classmethods.

Also improves some docstrings and type-hinting in `handles.py`.
