### PR TITLE
Detect ETW Patching

### DIFF
--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -95,8 +95,7 @@ class EtwPatch(interfaces.plugins.PluginInterface):
                     try:
                         opcode = (
                             self.context.layers[proc_layer_name]
-                            .read(func_addr, 1)
-                            .hex()
+                            .read(func_addr, 1)[0]
                         )
                         if opcode in opcode_map:
                             instruction = opcode_map[opcode]

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -86,17 +86,16 @@ class EtwPatch(interfaces.plugins.PluginInterface):
 
             # Map of opcodes to their instruction names
             opcode_map = {
-                0xc3: "RET",
-                0xe9: "JMP",
+                0xC3: "RET",
+                0xE9: "JMP",
             }
 
             for dll_name, functions in found_symbols.items():
                 for func_name, func_addr in functions:
                     try:
-                        opcode = (
-                            self.context.layers[proc_layer_name]
-                            .read(func_addr, 1)[0]
-                        )
+                        opcode = self.context.layers[proc_layer_name].read(
+                            func_addr, 1
+                        )[0]
                         if opcode in opcode_map:
                             instruction = opcode_map[opcode]
                             yield (

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -107,7 +107,7 @@ class EtwPatch(interfaces.plugins.PluginInterface):
                                     dll_name,
                                     func_name,
                                     format_hints.Hex(func_addr),
-                                    f"{opcode} ({instruction})",
+                                    f"{opcode:02x} ({instruction})",
                                 ),
                             )
                     except exceptions.InvalidAddressException:

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -12,7 +12,13 @@ from volatility3.plugins.windows import pslist, pe_symbols
 vollog = logging.getLogger(__name__)
 
 class EtwPatch(interfaces.plugins.PluginInterface):
-    """Detects ETW patching by examining the first opcode of EtwEventWrite in ntdll.dll."""
+    """Identifies ETW (Event Tracing for Windows) patching techniques used by malware to evade detection.
+    
+    This plugin examines the first opcode of key ETW functions in ntdll.dll and advapi32.dll 
+    to detect common ETW bypass techniques such as return pointer manipulation (RET) or function 
+    redirection (JMP). Attackers often patch these functions to prevent security tools from 
+    receiving telemetry about process execution, API calls, and other system events.
+    """
 
     _version = (1, 0, 0)
     _required_framework_version = (2, 26, 0)

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -3,6 +3,7 @@
 #
 import contextlib
 import logging
+import pefile
 
 from volatility3.framework import exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -1,0 +1,142 @@
+# etwpatch.py
+# Plugin name: windows.etwpatch
+# Volatility 3 plugin to detect ETW patching via EtwEventWrite prologue
+
+import contextlib
+import logging
+
+from volatility3.framework import exceptions, interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.renderers import format_hints
+from volatility3.framework.symbols import intermed
+from volatility3.framework.symbols.windows.extensions import pe
+from volatility3.plugins.windows import pslist, pe_symbols 
+
+vollog = logging.getLogger(__name__)
+
+class EtwPatch(interfaces.plugins.PluginInterface):
+    """Detects ETW patching by examining the first opcode of EtwEventWrite in ntdll.dll."""
+
+    # Plugin metadata for auto-discovery
+    _version = (1, 0, 0)
+    _required_framework_version = (2, 26, 0)
+
+    @classmethod
+    def get_requirements(cls):
+        return [
+            requirements.ModuleRequirement(
+                name='kernel',
+                description='Windows kernel',
+                architectures=["Intel32", "Intel64"]
+            ),
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(3, 0, 0)
+            ),
+            requirements.VersionRequirement(
+                name="pe_symbols", component=pslist.PsList, version=(3, 0, 0)
+            ),
+            requirements.ListRequirement(
+                name='pid',
+                description='Filter on specific process IDs',
+                element_type=int,
+                optional=True
+            )
+        ]
+
+    def _generator(self):
+        pid_filter = self.config.get('pid', None)
+
+        for proc in pslist.PsList.list_processes(
+                context=self.context,
+                kernel_module_name=self.config['kernel']):
+            
+            # If the user passed --pid, only process those IDs
+            if pid_filter and proc.UniqueProcessId not in pid_filter:
+                continue
+
+            pid = int(proc.UniqueProcessId)
+            proc_name = proc.ImageFileName.cast(
+                "string",
+                max_length = proc.ImageFileName.vol.count,
+                errors = 'replace'
+            )
+
+            # Build a per-process memory layer
+            try:
+                proc_layer_name = proc.add_process_layer()
+            except Exception:
+                continue
+
+            proc_layer = self.context.layers[proc_layer_name]
+
+            # Find ntdll.dll module
+            for module in proc.load_order_modules():
+                BaseDllName = FullDllName = renderers.UnreadableValue()
+                with contextlib.suppress(exceptions.InvalidAddressException):
+                    BaseDllName = module.BaseDllName.get_string()
+                    FullDllName = module.FullDllName.get_string()
+                
+                if BaseDllName != 'ntdll.dll':
+                    continue
+
+                base = module.DllBase
+                size = module.SizeOfImage
+
+                pe_table_name = intermed.IntermediateSymbolTable.create(
+                    self.context, self.config_path, "windows", "pe", class_types=pe.class_types
+                )
+                
+                pe_obj = pe_symbols.PESymbols.get_pefile_obj(
+                    self.context, pe_table_name, proc_layer_name, base
+                )
+                
+                try:
+                    pe_obj.parse_data_directories(
+                        directories=[pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_EXPORT"]]
+                    )
+                except Exception as e:
+                    vollog.debug(f"Error parsing IMAGE_DIRECTORY_ENTRY_EXPORT with {e}")
+                    continue
+                
+                if not hasattr(pe_obj, "DIRECTORY_ENTRY_EXPORT"):
+                    return None
+                
+                for export in pe_obj.DIRECTORY_ENTRY_EXPORT.symbols:
+                    if export.name not in [b"EtwEventWrite", b"EtwEventWriteFull", b"NtTraceEvent"]:
+                        continue
+        
+                    function_start = base + export.address
+                    try:
+                        with contextlib.suppress(exceptions.InvalidAddressException):
+                            opcode = self.context.layers[proc_layer_name].read(
+                                function_start, 1
+                            ).hex()
+                        
+                            # 0xC3 = RET, 0xE9 = JMP (common ETW patches)
+                            if opcode in ('c3', 'e9'):
+                                yield (0, (
+                                    pid,
+                                    proc_name,
+                                    BaseDllName,
+                                    export.name.decode(),
+                                    format_hints.Hex(function_start),
+                                    opcode
+                                ))
+                    except Exception as e:
+                        vollog.debug(f"Error parsing IMAGE_DIRECTORY_ENTRY_EXPORT with {e}")
+                        continue
+                    finally:
+                      break
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("PID", int),
+                ("Process", str),
+                ("DLL", str),
+                ("Function", str),
+                ("Offset", format_hints.Hex),
+                ("Opcode", str)
+            ],
+            self._generator()
+        )

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -86,8 +86,8 @@ class EtwPatch(interfaces.plugins.PluginInterface):
 
             # Map of opcodes to their instruction names
             opcode_map = {
-                "c3": "RET",
-                "e9": "JMP",
+                0xc3: "RET",
+                0xe9: "JMP",
             }
 
             for dll_name, functions in found_symbols.items():

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -114,7 +114,8 @@ class EtwPatch(interfaces.plugins.PluginInterface):
                             proc_name,
                             dll_name,
                             symbol_name,
-                            format_hints.Hex(function_start), opcode
+                            format_hints.Hex(function_start),
+                            opcode
                         ))
 
     def run(self):

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -17,7 +17,6 @@ vollog = logging.getLogger(__name__)
 class EtwPatch(interfaces.plugins.PluginInterface):
     """Detects ETW patching by examining the first opcode of EtwEventWrite in ntdll.dll."""
 
-    # Plugin metadata for auto-discovery
     _version = (1, 0, 0)
     _required_framework_version = (2, 26, 0)
 

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -1,15 +1,11 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-import contextlib
 import logging
-import pefile
 
 from volatility3.framework import exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
-from volatility3.framework.symbols import intermed
-from volatility3.framework.symbols.windows.extensions import pe
 from volatility3.plugins.windows import pslist, pe_symbols 
 
 vollog = logging.getLogger(__name__)

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -1,7 +1,6 @@
-# etwpatch.py
-# Plugin name: windows.etwpatch
-# Volatility 3 plugin to detect ETW patching via EtwEventWrite prologue
-
+# This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
 import contextlib
 import logging
 

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -7,16 +7,17 @@ from volatility3.framework import exceptions, interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
-from volatility3.plugins.windows import pslist, pe_symbols 
+from volatility3.plugins.windows import pslist, pe_symbols
 
 vollog = logging.getLogger(__name__)
 
+
 class EtwPatch(interfaces.plugins.PluginInterface):
     """Identifies ETW (Event Tracing for Windows) patching techniques used by malware to evade detection.
-    
-    This plugin examines the first opcode of key ETW functions in ntdll.dll and advapi32.dll 
-    to detect common ETW bypass techniques such as return pointer manipulation (RET) or function 
-    redirection (JMP). Attackers often patch these functions to prevent security tools from 
+
+    This plugin examines the first opcode of key ETW functions in ntdll.dll and advapi32.dll
+    to detect common ETW bypass techniques such as return pointer manipulation (RET) or function
+    redirection (JMP). Attackers often patch these functions to prevent security tools from
     receiving telemetry about process execution, API calls, and other system events.
     """
 
@@ -28,13 +29,11 @@ class EtwPatch(interfaces.plugins.PluginInterface):
             pe_symbols.wanted_names_identifier: [
                 "EtwEventWrite",
                 "EtwEventWriteFull",
-                "NtTraceEvent"
+                "NtTraceEvent",
             ],
         },
         "advapi32.dll": {
-            pe_symbols.wanted_names_identifier:[
-                "EventWrite"
-            ],
+            pe_symbols.wanted_names_identifier: ["EventWrite"],
         },
     }
 
@@ -42,22 +41,22 @@ class EtwPatch(interfaces.plugins.PluginInterface):
     def get_requirements(cls):
         return [
             requirements.ModuleRequirement(
-                name='kernel',
-                description='Windows kernel',
-                architectures=["Intel32", "Intel64"]
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(3, 0, 0)
             ),
             requirements.VersionRequirement(
-                name="pe_symbols", component=pslist.PsList, version=(3, 0, 0)
+                name="pe_symbols", component=pe_symbols.PESymbols, version=(3, 0, 0)
             ),
             requirements.ListRequirement(
-                name='pid',
-                description='Filter on specific process IDs',
+                name="pid",
+                description="Filter on specific process IDs",
                 element_type=int,
-                optional=True
-            )
+                optional=True,
+            ),
         ]
 
     def _generator(self):
@@ -68,15 +67,15 @@ class EtwPatch(interfaces.plugins.PluginInterface):
             kernel_module_name=self.config["kernel"],
             symbols=self.etw_functions,
         )
-        
+
         filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
 
         for proc in pslist.PsList.list_processes(
-                context=self.context,
-                kernel_module_name=self.config['kernel'],
-                filter_func=filter_func,
-            ):
-            
+            context=self.context,
+            kernel_module_name=self.config["kernel"],
+            filter_func=filter_func,
+        ):
+
             try:
                 proc_id = proc.UniqueProcessId
                 proc_name = utility.array_to_string(proc.ImageFileName)
@@ -87,16 +86,18 @@ class EtwPatch(interfaces.plugins.PluginInterface):
 
             # Map of opcodes to their instruction names
             opcode_map = {
-                'c3': 'RET',
-                'e9': 'JMP',
+                "c3": "RET",
+                "e9": "JMP",
             }
 
             for dll_name, functions in found_symbols.items():
                 for func_name, func_addr in functions:
                     try:
-                        opcode = self.context.layers[proc_layer_name].read(
-                            func_addr, 1
-                        ).hex()
+                        opcode = (
+                            self.context.layers[proc_layer_name]
+                            .read(func_addr, 1)
+                            .hex()
+                        )
                         if opcode in opcode_map:
                             instruction = opcode_map[opcode]
                             yield (
@@ -107,11 +108,13 @@ class EtwPatch(interfaces.plugins.PluginInterface):
                                     dll_name,
                                     func_name,
                                     format_hints.Hex(func_addr),
-                                    f"{opcode} ({instruction})"
+                                    f"{opcode} ({instruction})",
                                 ),
                             )
                     except exceptions.InvalidAddressException:
-                        vollog.debug(f"Invalid address when reading function {func_name} at {func_addr:#x} in process {proc_id}")
+                        vollog.debug(
+                            f"Invalid address when reading function {func_name} at {func_addr:#x} in process {proc_id}"
+                        )
 
     def run(self):
         return renderers.TreeGrid(

--- a/volatility3/framework/plugins/windows/etwpatch.py
+++ b/volatility3/framework/plugins/windows/etwpatch.py
@@ -18,8 +18,18 @@ class EtwPatch(interfaces.plugins.PluginInterface):
     _required_framework_version = (2, 26, 0)
 
     etw_functions = {
-        "ntdll.dll": ["EtwEventWrite", "EtwEventWriteFull", "NtTraceEvent"],
-        "advapi32.dll": ["EventWrite"],
+        "ntdll.dll": {
+            pe_symbols.wanted_names_identifier: [
+                "EtwEventWrite",
+                "EtwEventWriteFull",
+                "NtTraceEvent"
+            ],
+        },
+        "advapi32.dll": {
+            pe_symbols.wanted_names_identifier:[
+                "EventWrite"
+            ],
+        },
     }
 
     @classmethod
@@ -96,11 +106,6 @@ class EtwPatch(interfaces.plugins.PluginInterface):
                             )
                     except exceptions.InvalidAddressException:
                         vollog.debug(f"Invalid address when reading function {func_name} at {func_addr:#x} in process {proc_id}")
-                        continue
-                    except KeyError:
-                        # Layer may no longer exist
-                        vollog.debug(f"Layer {proc_layer_name} no longer exists for process {proc_id}")
-                        continue
 
     def run(self):
         return renderers.TreeGrid(


### PR DESCRIPTION
This plugin identifies ETW patching by inspecting the first opcode of the following functions:
- EtwEventWrite
- EtwEventWriteFull
- NtTraceEvent

If the initial opcode is 0xC3 (RET) or 0xE9 (JMP), the function is flagged as patched.

Below is a screenshot demonstrating when the detection is triggered:
![WhatsApp Image 2025-04-24 at 20 33 46_3972c8e1](https://github.com/user-attachments/assets/093b8698-a27e-46c6-beb4-7554a3e439b8)

Also, I've added support for scanning specific processes.

This method only checks the first opcode. If an attacker patches elsewhere in the function in a way that corrupts it - the modification will not be detected.

Note: This is my first plugin - any feedback is welcome!