### PR TITLE
Linux: update extensions used by kallsyms plugin to use utility.pointer_to_string fix issue #1603

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -3065,7 +3065,9 @@ class kernel_symbol(objects.StructType):
         else:
             raise AttributeError("Unsupported kernel_symbol type implementation")
 
-        return utility.pointer_to_string(name_offset, linux_constants.KSYM_NAME_LEN)
+        return utility.pointer_to_string(
+            name_offset, linux_constants.KSYM_NAME_LEN, errors="ignore"
+        )
 
     def get_name(self) -> Optional[str]:
         try:
@@ -3102,7 +3104,7 @@ class kernel_symbol(objects.StructType):
             raise AttributeError("Unsupported kernel_symbol type implementation")
 
         return utility.pointer_to_string(
-            namespace_offset, linux_constants.KSYM_NAME_LEN
+            namespace_offset, linux_constants.KSYM_NAME_LEN, errors="ignore"
         )
 
     def get_namespace(self) -> Optional[str]:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -3065,14 +3065,7 @@ class kernel_symbol(objects.StructType):
         else:
             raise AttributeError("Unsupported kernel_symbol type implementation")
 
-        layer = self._context.layers[self.vol.layer_name]
-        name_bytes = layer.read(name_offset, linux_constants.KSYM_NAME_LEN)
-
-        idx = name_bytes.find(b"\x00")
-        if idx != -1:
-            name_bytes = name_bytes[:idx]
-
-        return name_bytes.decode("utf-8", errors="ignore")
+        return utility.pointer_to_string(name_offset, linux_constants.KSYM_NAME_LEN)
 
     def get_name(self) -> Optional[str]:
         try:
@@ -3108,14 +3101,9 @@ class kernel_symbol(objects.StructType):
         else:
             raise AttributeError("Unsupported kernel_symbol type implementation")
 
-        layer = self._context.layers[self.vol.layer_name]
-        namespace_bytes = layer.read(namespace_offset, linux_constants.KSYM_NAME_LEN)
-
-        idx = namespace_bytes.find(b"\x00")
-        if idx != -1:
-            namespace_bytes = namespace_bytes[:idx]
-
-        return namespace_bytes.decode("utf-8", errors="ignore")
+        return utility.pointer_to_string(
+            namespace_offset, linux_constants.KSYM_NAME_LEN
+        )
 
     def get_namespace(self) -> Optional[str]:
         try:


### PR DESCRIPTION
Hello :wave: 

This PR is to address this issue https://github.com/volatilityfoundation/volatility3/issues/1603 where @ikelos notes that the extensions used by kallsyms has two functions that manually construct strings rather than using the framework.

Here I've swapped them out to use `utility.pointer_to_string` instead. 

This doesn't change the plugin output at all as far as I can see:
```
eve@xps:~/Documents/volatility3$ git checkout develop 
Switched to branch 'develop'
Your branch is up-to-date with 'origin/develop'.
eve@xps:~/Documents/volatility3$ python3 vol.py -f linux-sample-1.dmp linux.kallsyms >pre.txt
eve@xps:~/Documents/volatility3$ git checkout linux_issue_1603 
Switched to branch 'linux_issue_1603'
eve@xps:~/Documents/volatility3$ python3 vol.py -f linux-sample-1.dmp linux.kallsyms >post.txt
eve@xps:~/Documents/volatility3$ diff pre.txt post.txt 
eve@xps:~/Documents/volatility3$ sha1sum pre.txt post.txt 
c23205fc5db7ab3ec613bdcede770b5af839373c  pre.txt
c23205fc5db7ab3ec613bdcede770b5af839373c  post.txt
```

Thanks
:fox_face: 