### PR TITLE
cli: add debug log of plugin version when the plugin is successfully constructed

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -505,6 +505,9 @@ class CommandLine:
         try:
             # Construct and run the plugin
             if constructed:
+                vollog.debug(
+                    f"Successfully constructed {args.plugin} {constructed.version}"
+                )
                 grid = constructed.run()
                 renderer = renderers[args.renderer]()
                 renderer.filter = text_filter.CLIFilter(grid, args.filters)


### PR DESCRIPTION
Hello :wave: 

This PR aims to help with issue https://github.com/volatilityfoundation/volatility3/issues/1685.

It logs the version of a plugin to DEBUG just before it's run.

I'm using f-strings in the debug message because it makes it easier to read as suggested by @ikelos 

Thanks
:fox_face: 