### PR TITLE
Volshell breakpointing

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -3,6 +3,7 @@
 #
 import binascii
 import code
+import functools
 import io
 import random
 import string
@@ -187,6 +188,7 @@ class Volshell(interfaces.plugins.PluginInterface):
     def construct_locals(self) -> List[Tuple[List[str], Any]]:
         """Returns a listing of the functions to be added to the environment."""
         return [
+            (["bp", "breakpoint"], self.breakpoint),
             (["dt", "display_type"], self.display_type),
             (["db", "display_bytes"], self.display_bytes),
             (["dw", "display_words"], self.display_words),
@@ -796,6 +798,36 @@ class Volshell(interfaces.plugins.PluginInterface):
             self.context.symbol_space.append(constructed)
 
         return constructed
+
+    def breakpoint(self, address: int, layer_name: Optional[str] = None) -> None:
+        """Sets a breakpoint on a particular address (within a specific layer)"""
+        if layer_name is None:
+            if self.current_layer is None:
+                raise ValueError("Current layer must be set")
+            layer_name = self.current_layer
+
+        layer: interfaces.layers.DataLayerInterface = self.context.layers[layer_name]
+        # Check if the read value is already overloaded
+        if not hasattr(layer.read, "breakpoints"):
+            # Layer read is not yet wrapped
+            def wrapped_read(offset: int, length: int, pad: bool = False) -> bytes:
+                original_read = getattr(wrapped_read, "original_read")
+                for breakpoint in getattr(wrapped_read, "breakpoints"):
+                    if (offset <= breakpoint) and (breakpoint < offset + length):
+                        import pdb
+
+                        pdb.set_trace()
+                        print("Hit breakpoint")
+                return original_read(offset, length, pad)
+
+            setattr(wrapped_read, "breakpoints", set())
+            setattr(wrapped_read, "original_read", layer.read)
+            setattr(layer, "read", wrapped_read)
+
+        # Add the new breakpoint
+        breakpoints = getattr(layer.read, "breakpoints")
+        breakpoints.add(address)
+        setattr(layer.read, "breakpoints", breakpoints)
 
 
 class NullFileHandler(io.BytesIO, interfaces.plugins.FileHandlerInterface):

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -187,6 +187,8 @@ class Volshell(interfaces.plugins.PluginInterface):
     def construct_locals(self) -> List[Tuple[List[str], Any]]:
         """Returns a listing of the functions to be added to the environment."""
         return [
+            (["bc", "breakpoint_clear"], self.breakpoint_clear),
+            (["bl", "breakpoint_list"], self.breakpoint_list),
             (["bp", "breakpoint"], self.breakpoint),
             (["dt", "display_type"], self.display_type),
             (["db", "display_bytes"], self.display_bytes),
@@ -827,10 +829,13 @@ class Volshell(interfaces.plugins.PluginInterface):
                 original_read = getattr(wrapped_read, "original_read")
                 for breakpoint in getattr(wrapped_read, "breakpoints"):
                     if (offset <= breakpoint) and (breakpoint < offset + length):
+                        print(
+                            "Hit breakpoint, entering python debugger. To continue running without the debugger use the command continue"
+                        )
                         import pdb
 
                         pdb.set_trace()
-                        print("Hit breakpoint")
+                        _ = "First statement after the breakpoint, use u(p), d(own) and list to navigate through the execution frames"
                 return original_read(offset, length, pad)
 
             setattr(wrapped_read, "breakpoints", set())
@@ -838,10 +843,45 @@ class Volshell(interfaces.plugins.PluginInterface):
             setattr(layer, "read", wrapped_read)
 
         # Add the new breakpoint
-        print(f"Setting breakpoint {address:x} on {layer.name}")
+        print(f"Setting breakpoint {address:#x} on {layer.name}")
         breakpoints = getattr(layer.read, "breakpoints")
         breakpoints.add(address)
         setattr(layer.read, "breakpoints", breakpoints)
+
+    def breakpoint_list(self, layer_names: Optional[List[str]] = None):
+        """List available breakpoints for a set of layers"""
+        if not layer_names:
+            layer_names = [layer_name for layer_name in self.context.layers]
+
+        print("Listing breakpoints:")
+        for layer_name in layer_names:
+            print(f" {layer_name}")
+            layer = self.context.layers.get(layer_name, None)
+            if layer and hasattr(layer.read, "breakpoints"):
+                for breakpoint in layer.read.breakpoints:
+                    print(f"  {breakpoint:#x}")
+
+    def breakpoint_clear(
+        self, offset: Optional[int] = None, layer_name: Optional[str] = None
+    ):
+        """Clears a offset breakpoint on a layer (or all breakpoints if offset or layer not specified)
+
+        Args:
+            offset: Address of the breakpoint to clear (or all if None)
+            layer_name: Layer to clear breakpoints from (or all if None)
+        """
+        print("Clearing breakpoints:")
+        for candidate_layer_name in self.context.layers:
+            candidate_layer = self.context.layers[candidate_layer_name]
+            if layer_name is None or layer_name == candidate_layer_name:
+                print(f" {candidate_layer_name}")
+                if hasattr(candidate_layer.read, "breakpoints"):
+                    breakpoints_to_remove = set()
+                    for breakpoint in candidate_layer.read.breakpoints:
+                        if offset is None or offset == breakpoint:
+                            print(f"  clearing {breakpoint:#x}")
+                            breakpoints_to_remove.add(breakpoint)
+                    candidate_layer.read.breakpoints -= breakpoints_to_remove
 
 
 class NullFileHandler(io.BytesIO, interfaces.plugins.FileHandlerInterface):

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -799,7 +799,9 @@ class Volshell(interfaces.plugins.PluginInterface):
 
         return constructed
 
-    def breakpoint(self, address: int, layer_name: Optional[str] = None) -> None:
+    def breakpoint(
+        self, address: int, layer_name: Optional[str] = None, lowest: bool = False
+    ) -> None:
         """Sets a breakpoint on a particular address (within a specific layer)"""
         if layer_name is None:
             if self.current_layer is None:
@@ -807,6 +809,18 @@ class Volshell(interfaces.plugins.PluginInterface):
             layer_name = self.current_layer
 
         layer: interfaces.layers.DataLayerInterface = self.context.layers[layer_name]
+
+        if lowest:
+            while isinstance(layer, interfaces.layers.TranslationLayerInterface):
+                mapping = layer.mapping(address, 1)
+                if not mapping:
+                    raise ValueError(
+                        "Offset cannot be mapped lower, cannot break at lowest layer"
+                    )
+                _, _, mapped_offset, _, mapped_layer_name = next(mapping)
+                layer = self.context.layers[mapped_layer_name]
+                address = mapped_offset
+
         # Check if the read value is already overloaded
         if not hasattr(layer.read, "breakpoints"):
             # Layer read is not yet wrapped
@@ -825,6 +839,7 @@ class Volshell(interfaces.plugins.PluginInterface):
             setattr(layer, "read", wrapped_read)
 
         # Add the new breakpoint
+        print(f"Setting breakpoint {address:x} on {layer.name}")
         breakpoints = getattr(layer.read, "breakpoints")
         breakpoints.add(address)
         setattr(layer.read, "breakpoints", breakpoints)

--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -3,7 +3,6 @@
 #
 import binascii
 import code
-import functools
 import io
 import random
 import string


### PR DESCRIPTION
This is an initial implementation of breakpointing for volshell.  Breakpoints can be set on a specific layer directly, or on the lowest mapped layer of the offset (so that accesses through lower layers will still breakpoint).

Note: Volatility is very careful about only reading the data it requires, meaning that even creating an object at an offset won't necessarily trip the breakpoint.  