### PR TITLE
Linux: prevent "forward slashes only" dentry names

### DIFF
--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -190,9 +190,13 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
             parent = dentry.d_parent
             dname = dentry.d_name.name_as_str()
-            path_reversed.append(dname.strip("/"))
+            dname_stripped = dname.strip("/")
+            if dname_stripped:
+                path_reversed.append(dname_stripped)
             dentry = parent
 
+        if path_reversed == []:
+            return ""
         path = "/" + "/".join(reversed(path_reversed))
         return path
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -169,6 +169,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             return ""
 
         path_reversed = []
+        smeared = False
         while (
             dentry
             and dentry.is_readable()
@@ -190,14 +191,16 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
             parent = dentry.d_parent
             dname = dentry.d_name.name_as_str()
-            dname_stripped = dname.strip("/")
-            if dname_stripped:
-                path_reversed.append(dname_stripped)
+            # empty dentry names are most likely
+            # the result of smearing
+            if not dname:
+                smeared = True
+            path_reversed.append(dname.strip("/"))
             dentry = parent
 
-        if path_reversed == []:
-            return ""
         path = "/" + "/".join(reversed(path_reversed))
+        if smeared:
+            return f"<potentially smeared> {path}"
         return path
 
     @classmethod


### PR DESCRIPTION
Hi,

While performing mass testing we observed that many lsof entries had "/" or "//" names. This PR fixes the issue by ensuring that at least one non-empty entry was found in the dentry walk.