### PR TITLE
Linux: Add comment for  explaining the behaviour with smear

### DIFF
--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -99,7 +99,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
 class LinuxUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful linux functions."""
 
-    _version = (2, 3, 0)
+    _version = (2, 3, 1)
     _required_framework_version = (2, 0, 0)
 
     framework.require_interface_version(*_required_framework_version)
@@ -200,6 +200,9 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
         path = "/" + "/".join(reversed(path_reversed))
         if smeared:
+            # if there is smear the missing dname will be empty. e.g. if the normal
+            # path would be /foo/bar/baz, but bar is missing due to smear the results
+            # returned here will show /foo//baz. Note the // for the missing dname.
             return f"<potentially smeared> {path}"
         return path
 


### PR DESCRIPTION
Hello :wave: 

Just a small continuation of https://github.com/volatilityfoundation/volatility3/pull/1795/ where @Abyss-W4tcher fixed an issue with smear with the linux util `do_get_path`. 

I've just added a comment to explain what the results mean as discussed in the comments on the original PR. It's the kind of thing I'd forget in the future so having a comment like this in the code is useful to me. 

However I don't want to clutter the code with unnecessary comments, so if you both @ikelos and @Abyss-W4tcher think this isn't needed that is okay with me. 

Thanks as always
:fox_face: 