### PR TITLE
CLI QuickTextRender output utf-8

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -294,7 +294,10 @@ class QuickTextRenderer(CLIRenderer):
         """
         # TODO: Docstrings
         # TODO: Improve text output
-        outfd = sys.stdout
+
+        #Forces utf-8 encoding to prevent Windows powershell UnicodeEncodeError
+        from io import TextIOWrapper
+        outfd = TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
 
         line = []
         ignore_columns = self.ignored_columns(grid)


### PR DESCRIPTION
Volatility would running into an error when pipping Unicode output in Powershell (whether writing to file or terminal)

POC command:
`python .\vol.py -f C:\<path>\memdump.dmp windows.filescan.FileScan | Select-String -Pattern '\.\w{2}\b'`

```
Volatility 3 Framework 2.26.2
Traceback (most recent call last):
  File "C:\tools\volatility3\vol.py", line 11, in <module>
    volatility3.cli.main()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\tools\volatility3\volatility3\cli\__init__.py", line 927, in main
    CommandLine().run()
    ~~~~~~~~~~~~~~~~~^^
  File "C:\tools\volatility3\volatility3\cli\__init__.py", line 515, in run
    renderer.render(grid)
    ~~~~~~~~~~~~~~~^^^^^^
  File "C:\tools\volatility3\volatility3\cli\text_renderer.py", line 330, in render
    grid.populate(visitor, outfd)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "C:\tools\volatility3\volatility3\framework\renderers\__init__.py", line 323, in populate
    accumulator = function(treenode, accumulator)
  File "C:\tools\volatility3\volatility3\cli\text_renderer.py", line 325, in visitor
    accumulator.write("{}".format("\t".join(line)))
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python313\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode characters in position 15-22: character maps to <undefined>
```

The change that is implemented will force output text to be utf-8 encoded.