### PR TITLE
Windows Thrdscan: Fix broken tuple unpacking

### DIFF
--- a/test/plugins/windows/windows.py
+++ b/test/plugins/windows/windows.py
@@ -58,6 +58,14 @@ class TestWindowsPslist:
         }
         assert test_volatility.match_output_row(expected_row, json.loads(out))
 
+class TestWindowsTimeliner:
+    def test_windows_specific_timeliner(self, volatility, python):
+        image = WindowsSamples.WINDOWSXP_GENERIC.value.path
+        rc, out, _err = test_volatility.runvol_plugin(
+            "timeliner.Timeliner", image, volatility, python
+        )
+        assert rc == 0
+        assert out.count(b"\n") > 10
 
 class TestWindowsPsscan:
     def test_windows_specific_psscan(self, volatility, python):

--- a/volatility3/framework/plugins/windows/thrdscan.py
+++ b/volatility3/framework/plugins/windows/thrdscan.py
@@ -190,6 +190,9 @@ class ThrdScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
                 row_dict["PID"],
                 row_dict["TID"],
                 row_dict["StartAddress"],
+                row_dict["StartPath"],
+                row_dict["Win32StartAddress"],
+                row_dict["Win32StartPath"],
                 row_dict["CreateTime"],
                 row_dict["ExitTime"],
             ) = row_data


### PR DESCRIPTION
Timeliner fails due to an incorrect unpacking of this tuple, which needs
3 additional dictionary items for start path, win32 start path, and
win32 start address.
