### PR TITLE
Minor fix to Hashdump.get_user_keys()

### DIFF
--- a/volatility3/framework/plugins/windows/registry/hashdump.py
+++ b/volatility3/framework/plugins/windows/registry/hashdump.py
@@ -350,7 +350,7 @@ class Hashdump(interfaces.plugins.PluginInterface):
 
         if not user_key:
             return []
-        return [k for k in user_key.get_subkeys() if k.Name != "Names"]
+        return [k for k in user_key.get_subkeys() if k.get_name() != "Names"]
 
     @classmethod
     def get_bootkey(cls, syshive: registry_layer.RegistryHive) -> Optional[bytes]:


### PR DESCRIPTION
Fixed the if statement excluding the `Names` subkey