### PR TITLE
Make nocase accessible in yarascan.YaraScan yara_string

### DIFF
--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -182,7 +182,7 @@ class YaraScan(plugins.PluginInterface):
             rule = config["yara_string"]
             if rule[0] not in ["{", "/"]:
                 rule = f'"{rule}"'
-            if config.get("case", False):
+            if config.get("insensitive", False):
                 rule += " nocase"
             if config.get("wide", False):
                 rule += " wide ascii"


### PR DESCRIPTION
**Describe the bug**
`--insensitive` should make the search case insensitive, applying `nocase` to the rule.

The option flag `insensitive` is never evaluated when building the temporary rule. Instead the key "case" is used to determine if the search should use "nocase" or not.

**Context**
Volatility Version: #b3e770dd0c9a690b5c10b222fdd28ab8d878ff0b
Operating System: Linux
Python Version: Python 3.11
Suspected Operating System:  Windows
Command:  
`vol.py -r jsonl -f memdump.mem windows.vadyarascan.VadYaraScan --insensitive --yara-string "FindMe"`

**Fix**
```
diff --git a/volatility3/framework/plugins/yarascan.py b/volatility3/framework/plugins/yarascan.py
index 49db2af0..040a50c1 100644
--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -182,7 +182,7 @@ class YaraScan(plugins.PluginInterface):
             rule = config["yara_string"]
             if rule[0] not in ["{", "/"]:
                 rule = f'"{rule}"'
-            if config.get("case", False):
+            if config.get("insensitive", False):
                 rule += " nocase"
             if config.get("wide", False):
                 rule += " wide ascii"
```

**Expected behavior**
`--insensitive` should make the search use `nocase`
