### PR TITLE
Linux: update PerfEvents plugin to use VersionRequirement for pslist

### DIFF
--- a/volatility3/framework/plugins/linux/tracing/perf_events.py
+++ b/volatility3/framework/plugins/linux/tracing/perf_events.py
@@ -18,7 +18,7 @@ class PerfEvents(plugins.PluginInterface):
     """Lists performance events for each process."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
@@ -28,8 +28,8 @@ class PerfEvents(plugins.PluginInterface):
                 description="Linux kernel",
                 architectures=["Intel32", "Intel64"],
             ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(4, 0, 0)
+            requirements.VersionRequirement(
+                name="pslist", component=pslist.PsList, version=(4, 0, 0)
             ),
         ]
 


### PR DESCRIPTION
Hello :wave: 

I spotted that the perf_events plugin for linux was still using a PluginRequirement. This PR just swaps that for a VersionRequirement. 

Thanks!
:fox_face: 