### PR TITLE
Lsof improvements (show deleted as in lsof output) + files_only argument

### DIFF
--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -137,6 +137,12 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 element_type=int,
                 optional=True,
             ),
+            requirements.BooleanRequirement(
+                name="files_only",
+                description="Include only file descriptors of type file",
+                optional=True,
+                default=False,
+            ),
         ]
 
     @classmethod
@@ -145,6 +151,7 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
         context: interfaces.context.ContextInterface,
         vmlinux_module_name: str,
         filter_func: Callable[[int], bool] = lambda _: False,
+        include_files_only: bool = False,
     ) -> Iterable[FDInternal]:
         """Enumerates open file descriptors in tasks
 
@@ -167,7 +174,7 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
                 linuxutils_symbol_table = task.vol.type_name.split(constants.BANG)[0]
 
             fd_generator = linux.LinuxUtilities.files_descriptors_for_process(
-                context, linuxutils_symbol_table, task
+                context, linuxutils_symbol_table, task, files_only=include_files_only
             )
 
             for fd_fields in fd_generator:
@@ -175,8 +182,12 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
 
     def _generator(self, pids, vmlinux_module_name):
         filter_func = pslist.PsList.create_pid_filter(pids)
+        include_files_only = self.config.get("files_only")
         for fd_internal in self.list_fds(
-            self.context, vmlinux_module_name, filter_func=filter_func
+            self.context,
+            vmlinux_module_name,
+            filter_func=filter_func,
+            include_files_only=include_files_only,
         ):
             fd_user = fd_internal.to_user()
             yield (0, dataclasses.astuple(fd_user))

--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -180,9 +180,9 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
             for fd_fields in fd_generator:
                 yield FDInternal(task=task, fd_fields=fd_fields)
 
-    def _generator(self, pids, vmlinux_module_name):
+    def _generator(self, pids, vmlinux_module_name, include_files_only):
         filter_func = pslist.PsList.create_pid_filter(pids)
-        include_files_only = self.config.get("files_only")
+
         for fd_internal in self.list_fds(
             self.context,
             vmlinux_module_name,
@@ -195,6 +195,7 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
     def run(self):
         pids = self.config.get("pid", None)
         vmlinux_module_name = self.config["kernel"]
+        include_files_only = self.config.get("files_only")
 
         tree_grid_args = [
             ("PID", int),
@@ -212,7 +213,10 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
             ("Size", int),
         ]
         return renderers.TreeGrid(
-            tree_grid_args, self._generator(pids, vmlinux_module_name)
+            tree_grid_args,
+            self._generator(
+                pids, vmlinux_module_name, include_files_only=include_files_only
+            ),
         )
 
     def generate_timeline(self):

--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -110,7 +110,7 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
     """Lists open files for each processes."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (2, 0, 2)
+    _version = (2, 1, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -101,7 +101,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
     _version = (2, 4, 0)
     _required_framework_version = (2, 0, 0)
-    deleted = "<deleted>"
+    deleted = "(deleted)"
     smear = "<potentially smeared>"
 
     framework.require_interface_version(*_required_framework_version)
@@ -210,7 +210,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             return f"{LinuxUtilities.smear} {path}"
 
         if inode and inode.is_readable() and inode.is_valid() and inode.i_nlink == 0:
-            path = f"{LinuxUtilities.deleted} {path}"
+            path = f" {path} {LinuxUtilities.deleted}"
         return path
 
     @classmethod

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -99,7 +99,7 @@ class LinuxKernelIntermedSymbols(intermed.IntermediateSymbolTable):
 class LinuxUtilities(interfaces.configuration.VersionableInterface):
     """Class with multiple useful linux functions."""
 
-    _version = (2, 3, 1)
+    _version = (2, 4, 0)
     _required_framework_version = (2, 0, 0)
     deleted = "<deleted>"
 
@@ -307,7 +307,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         return f"{pre_name}:[{inode.i_ino:d}]"
 
     @classmethod
-    def path_for_file(cls, context, task, filp, files_only) -> str:
+    def path_for_file(cls, context, task, filp, files_only=False) -> str:
         """Returns a file (or sock pipe) pathname relative to the task's root directory.
 
         A 'file' structure doesn't have enough information to properly restore its

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -101,6 +101,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
     _version = (2, 3, 1)
     _required_framework_version = (2, 0, 0)
+    deleted = " (deleted)"
 
     framework.require_interface_version(*_required_framework_version)
 
@@ -168,6 +169,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             # vfsmnt can be the vfsmount object itself (>=3.3) or a vfsmount * (<3.3)
             return ""
 
+        inode = dentry.d_inode
         path_reversed = []
         smeared = False
         while (
@@ -191,6 +193,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
             parent = dentry.d_parent
             dname = dentry.d_name.name_as_str()
+
             # empty dentry names are most likely
             # the result of smearing
             if not dname:
@@ -204,6 +207,9 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             # path would be /foo/bar/baz, but bar is missing due to smear the results
             # returned here will show /foo//baz. Note the // for the missing dname.
             return f"<potentially smeared> {path}"
+        print(path, inode.i_nlink)
+        if inode and inode.is_readable() and inode.is_valid() and inode.i_nlink == 0:
+            path += LinuxUtilities.deleted
         return path
 
     @classmethod
@@ -260,7 +266,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
                     pre_name = name.dereference().cast(
                         "string", max_length=255, errors="replace"
                     )
-                    return "/" + pre_name + " (deleted)"
+                    return "/" + pre_name + LinuxUtilities.deleted
                 else:
                     pre_name = ""
 
@@ -301,7 +307,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         return f"{pre_name}:[{inode.i_ino:d}]"
 
     @classmethod
-    def path_for_file(cls, context, task, filp) -> str:
+    def path_for_file(cls, context, task, filp, files_only) -> str:
         """Returns a file (or sock pipe) pathname relative to the task's root directory.
 
         A 'file' structure doesn't have enough information to properly restore its
@@ -340,7 +346,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         except exceptions.InvalidAddressException:
             dname_is_valid = False
 
-        if dname_is_valid:
+        if dname_is_valid and not files_only:
             ret = LinuxUtilities._get_new_sock_pipe_path(context, task, filp)
         else:
             ret = LinuxUtilities._get_path_file(task, filp)
@@ -353,6 +359,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
         context: interfaces.context.ContextInterface,
         symbol_table: str,
         task: interfaces.objects.ObjectInterface,
+        files_only: bool = False,
     ):
         try:
             files = task.files
@@ -376,7 +383,9 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
         for fd_num, filp in enumerate(fds):
             if filp and filp.is_readable():
-                full_path = LinuxUtilities.path_for_file(context, task, filp)
+                full_path = LinuxUtilities.path_for_file(
+                    context, task, filp, files_only
+                )
 
                 yield fd_num, filp, full_path
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -102,6 +102,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
     _version = (2, 4, 0)
     _required_framework_version = (2, 0, 0)
     deleted = "<deleted>"
+    smear = "<potentially smeared>"
 
     framework.require_interface_version(*_required_framework_version)
 
@@ -206,7 +207,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             # if there is smear the missing dname will be empty. e.g. if the normal
             # path would be /foo/bar/baz, but bar is missing due to smear the results
             # returned here will show /foo//baz. Note the // for the missing dname.
-            return f"<potentially smeared> {path}"
+            return f"{LinuxUtilities.smear} {path}"
 
         if inode and inode.is_readable() and inode.is_valid() and inode.i_nlink == 0:
             path = f"{LinuxUtilities.deleted} {path}"

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -207,7 +207,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             # path would be /foo/bar/baz, but bar is missing due to smear the results
             # returned here will show /foo//baz. Note the // for the missing dname.
             return f"<potentially smeared> {path}"
-        
+
         if inode and inode.is_readable() and inode.is_valid() and inode.i_nlink == 0:
             path += LinuxUtilities.deleted
         return path

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -207,7 +207,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             # path would be /foo/bar/baz, but bar is missing due to smear the results
             # returned here will show /foo//baz. Note the // for the missing dname.
             return f"<potentially smeared> {path}"
-        print(path, inode.i_nlink)
+        
         if inode and inode.is_readable() and inode.is_valid() and inode.i_nlink == 0:
             path += LinuxUtilities.deleted
         return path

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -266,7 +266,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
                     pre_name = name.dereference().cast(
                         "string", max_length=255, errors="replace"
                     )
-                    return f"{LinuxUtilities.deleted} /{pre_name}"
+                    return "/" + pre_name + " (deleted)"
                 else:
                     pre_name = ""
 

--- a/volatility3/framework/symbols/linux/__init__.py
+++ b/volatility3/framework/symbols/linux/__init__.py
@@ -101,7 +101,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
 
     _version = (2, 3, 1)
     _required_framework_version = (2, 0, 0)
-    deleted = " (deleted)"
+    deleted = "<deleted>"
 
     framework.require_interface_version(*_required_framework_version)
 
@@ -209,7 +209,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
             return f"<potentially smeared> {path}"
 
         if inode and inode.is_readable() and inode.is_valid() and inode.i_nlink == 0:
-            path += LinuxUtilities.deleted
+            path = f"{LinuxUtilities.deleted} {path}"
         return path
 
     @classmethod
@@ -266,7 +266,7 @@ class LinuxUtilities(interfaces.configuration.VersionableInterface):
                     pre_name = name.dereference().cast(
                         "string", max_length=255, errors="replace"
                     )
-                    return "/" + pre_name + LinuxUtilities.deleted
+                    return f"{LinuxUtilities.deleted} /{pre_name}"
                 else:
                     pre_name = ""
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1253,9 +1253,7 @@ class vm_area_struct(objects.StructType):
 
     def _do_get_name(self, context, task) -> str:
         if self.vm_file != 0:
-            fname = linux.LinuxUtilities.path_for_file(
-                context, task, self.vm_file, files_only=False
-            )
+            fname = linux.LinuxUtilities.path_for_file(context, task, self.vm_file)
         elif self.vm_start <= task.mm.start_brk and self.vm_end >= task.mm.brk:
             fname = "[heap]"
         elif self.vm_start <= task.mm.start_stack <= self.vm_end:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1253,7 +1253,7 @@ class vm_area_struct(objects.StructType):
 
     def _do_get_name(self, context, task) -> str:
         if self.vm_file != 0:
-            fname = linux.LinuxUtilities.path_for_file(context, task, self.vm_file)
+            fname = linux.LinuxUtilities.path_for_file(context, task, self.vm_file, files_only=False)
         elif self.vm_start <= task.mm.start_brk and self.vm_end >= task.mm.brk:
             fname = "[heap]"
         elif self.vm_start <= task.mm.start_stack <= self.vm_end:

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1253,7 +1253,9 @@ class vm_area_struct(objects.StructType):
 
     def _do_get_name(self, context, task) -> str:
         if self.vm_file != 0:
-            fname = linux.LinuxUtilities.path_for_file(context, task, self.vm_file, files_only=False)
+            fname = linux.LinuxUtilities.path_for_file(
+                context, task, self.vm_file, files_only=False
+            )
         elif self.vm_start <= task.mm.start_brk and self.vm_end >= task.mm.brk:
             fname = "[heap]"
         elif self.vm_start <= task.mm.start_stack <= self.vm_end:


### PR DESCRIPTION
Improvements for Lsof to show deleted files as in lsof output on live system. 
its probably shouldnt be in that function directly as its no longer mimic `prepend_path` kernel function 
this PR breaks commit 68b51e873fe99ffcbf1679f25a9767774b9da3e2 but it can easily be fixed if desired. 

```
(venv) ubuntu@ubuntuPC:~/Dev/volatility3$ vol -f ~/dumps/deleted_proc_fd_dump.raw -r json linux.lsof --pid 8321
Volatility 3 Framework 2.26.2
/home/ubuntu/Dev/volatility3/volatility3/framework/deprecation.py:105: FutureWarning: This plugin (PluginRequirement) has been renamed and will be removed in the first release after 2026-06-01. PluginRequirement is to be deprecated. Use VersionRequirement instead.
  warnings.warn(
Progress:  100.00               Stacking attempts finished           
[
...
...
  {
    "Accessed": "2025-06-04T18:18:04.438000+00:00",
    "Changed": "2025-06-04T18:15:11.438000+00:00",
    "Device": "0:23",
    "FD": 2,
    "Inode": 4,
    "Mode": "crw--w----",
    "Modified": "2025-06-04T18:18:04.438000+00:00",
    "PID": 8321,
    "Path": "/dev/pts/1",
    "Process": "copied_bash",
    "Size": 0,
    "TID": 8321,
    "Type": "CHR",
    "__children": []
  },
  {
    "Accessed": "2025-06-04T17:49:01.296000+00:00",
    "Changed": "2025-06-04T18:17:41.693000+00:00",
    "Device": "253:0",
    "FD": 255,
    "Inode": 201866930,
    "Mode": "-rw-r--r--",
    "Modified": "2025-06-04T17:48:56.399000+00:00",
    "PID": 8321,
    "Path": "/tmp/evil.sh (deleted)",
    "Process": "copied_bash",
    "Size": 19,
    "TID": 8321,
    "Type": "REG",
    "__children": []
  }
]
```

```
(venv) ubuntu@ubuntuPC:~/Dev/volatility3$ vol -f ~/dumps/deleted_proc_fd_dump.raw linux.lsof --files-only | grep deleted
/home/ubuntu/Dev/volatility3/volatility3/framework/deprecation.py:105: FutureWarning: This plugin (PluginRequirement) has been renamed and will be removed in the first release after 2026-06-01. PluginRequirement is to be deprecated. Use VersionRequirement instead.
  warnings.warn(
799gress799100.0systemd-udevd   8tacking/var/lib/sss/mc/group (deleted) 253:0   201339099       REG     -rw-rw-r--      2025-06-04 17:46:02.113000 UTC  2025-06-04 17:46:02.113000 UTC   2025-06-04 17:46:01.736000 UTC  6940392
799     799     systemd-udevd   9       /var/lib/sss/mc/passwd (deleted)        253:0   201866915       REG     -rw-rw-r--      2025-06-04 17:46:02.109000 UTC  2025-06-04 17:46:02.109000 UTC   2025-06-04 17:46:01.724000 UTC  9253600
906     906     auditd  4       /var/lib/sss/mc/group (deleted) 253:0   201339099       REG     -rw-rw-r--      2025-06-04 17:46:02.113000 UTC  2025-06-04 17:46:02.113000 UTC  2025-06-04 17:46:01.736000 UTC   6940392
906     907     auditd  4       /var/lib/sss/mc/group (deleted) 253:0   201339099       REG     -rw-rw-r--      2025-06-04 17:46:02.113000 UTC  2025-06-04 17:46:02.113000 UTC  2025-06-04 17:46:01.736000 UTC   6940392
...
960     1218    gmain   9       / (deleted)     0:1     26770   REG     -rwxrwxrwx      2025-06-04 17:46:02.397000 UTC  2025-06-04 17:46:02.397000 UTC  2025-06-04 17:46:02.397000 UTC   4096
961     961     sssd_nss        6       /var/lib/sss/mc/passwd (deleted)        253:0   201866915       REG     -rw-rw-r--      2025-06-04 17:46:02.109000 UTC  2025-06-04 17:46:02.109000 UTC   2025-06-04 17:46:01.724000 UTC  9253600
```