### PR TITLE
Add dumping dirty pages to Linux Malfind

### DIFF
--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -68,7 +68,7 @@ class Malfind(interfaces.plugins.PluginInterface):
         # Dumping page defaults to off, as in case a whole r-xp region is dirty
         # this would likely dump 1000's of pages which might not always be wise nor necessary
 
-        dump_page = self.config.get("dump-page") or False
+        dump_page = self.config["dump-page"]
 
         for vma in task.mm.get_vma_iter():
             vma_name = vma.get_name(self.context, task)

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -38,12 +38,12 @@ class Malfind(interfaces.plugins.PluginInterface):
                 optional=True,
             ),
             requirements.IntRequirement(
-                name="dump_size",
+                name="dump-size",
                 description="Amount of bytes to dump for each dirty region/page found - Default 64 bytes",
                 optional=True,
             ),
             requirements.BooleanRequirement(
-                name="dump_page",
+                name="dump-page",
                 description="Dump each dirty page and content - Default off",
                 optional=True,
             ),
@@ -62,12 +62,12 @@ class Malfind(interfaces.plugins.PluginInterface):
         proc_layer = self.context.layers[proc_layer_name]
 
         # Allowing a dump_size of 0 (no dump)
-        dump_size = self.config.get("dump_size") if self.config.get("dump_size") is not None else 64
+        dump_size = self.config.get("dump-size") if self.config.get("dump-size") is not None else 64
 
         # Dumping page defaults to off, as in case a whole r-xp region is dirty
         # this would likely dump 1000's of pages which might not always be wise nor necessary
 
-        dump_page = self.config.get("dump_page") or False
+        dump_page = self.config.get("dump-page") or False
 
         for vma in task.mm.get_vma_iter():
             vma_name = vma.get_name(self.context, task)

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -47,6 +47,7 @@ class Malfind(interfaces.plugins.PluginInterface):
                 name="dump-page",
                 description="Dump each dirty page and content - Default off",
                 optional=True,
+                default=False,
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -61,12 +61,7 @@ class Malfind(interfaces.plugins.PluginInterface):
 
         proc_layer = self.context.layers[proc_layer_name]
 
-        # Allowing a dump_size of 0 (no dump)
-        dump_size = (
-            self.config.get("dump-size")
-            if self.config.get("dump-size") is not None
-            else 64
-        )
+        dump_size = self.config.get("dump-size", None) or 64
 
         # Dumping page defaults to off, as in case a whole r-xp region is dirty
         # this would likely dump 1000's of pages which might not always be wise nor necessary

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -63,7 +63,7 @@ class Malfind(interfaces.plugins.PluginInterface):
 
         proc_layer = self.context.layers[proc_layer_name]
 
-        dump_size = self.config.get("dump-size", None) or 64
+        dump_size = self.config["dump-size"]
 
         # Dumping page defaults to off, as in case a whole r-xp region is dirty
         # this would likely dump 1000's of pages which might not always be wise nor necessary

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -18,7 +18,7 @@ class Malfind(interfaces.plugins.PluginInterface):
     """Lists process memory ranges that potentially contain injected code."""
 
     _required_framework_version = (2, 0, 0)
-    _version = (1, 0, 3)
+    _version = (1, 0, 4)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -62,7 +62,11 @@ class Malfind(interfaces.plugins.PluginInterface):
         proc_layer = self.context.layers[proc_layer_name]
 
         # Allowing a dump_size of 0 (no dump)
-        dump_size = self.config.get("dump-size") if self.config.get("dump-size") is not None else 64
+        dump_size = (
+            self.config.get("dump-size")
+            if self.config.get("dump-size") is not None
+            else 64
+        )
 
         # Dumping page defaults to off, as in case a whole r-xp region is dirty
         # this would likely dump 1000's of pages which might not always be wise nor necessary
@@ -88,7 +92,7 @@ class Malfind(interfaces.plugins.PluginInterface):
                         yield vma, f"{vma_name}, page address: {page_addr:#x}, offset: {page_addr-vma.vm_start:#x}", data
                 else:
                     # Original behaviour - Dump the start of the region (not necessarily matching the dirty page)
-                    data = proc_layer.read(vma.vm_start,dump_size,pad=True)
+                    data = proc_layer.read(vma.vm_start, dump_size, pad=True)
                     yield vma, vma_name, data
 
     def _generator(self, tasks):

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -85,15 +85,17 @@ class Malfind(interfaces.plugins.PluginInterface):
 
             if vma.is_suspicious(proc_layer) and vma_name != "[vdso]":
                 malicious_pages = vma.get_malicious_pages(proc_layer)
+                offset = 0
                 if dump_page:
                     # Dumping each dirty page
                     for page_addr in malicious_pages:
+                        offset = page_addr - vma.vm_start
                         data = proc_layer.read(page_addr, dump_size, pad=True)
-                        yield vma, f"{vma_name}, page address: {page_addr:#x}, offset: {page_addr-vma.vm_start:#x}", data
+                        yield vma, f"{vma_name}, page address: {page_addr:#x}, offset: {offset:#x}", data, offset
                 else:
                     # Original behaviour - Dump the start of the region (not necessarily matching the dirty page)
                     data = proc_layer.read(vma.vm_start, dump_size, pad=True)
-                    yield vma, vma_name, data
+                    yield vma, vma_name, data, offset
 
     def _generator(self, tasks):
         # determine if we're on a 32 or 64 bit kernel
@@ -105,13 +107,15 @@ class Malfind(interfaces.plugins.PluginInterface):
         for task in tasks:
             process_name = utility.array_to_string(task.comm)
 
-            for vma, vma_name, data in self._list_injections(task):
+            for vma, vma_name, data, offset in self._list_injections(task):
                 if is_32bit_arch:
                     architecture = "intel"
                 else:
                     architecture = "intel64"
 
-                disasm = renderers.Disassembly(data, vma.vm_start, architecture)
+                disasm = renderers.Disassembly(
+                    data, vma.vm_start + offset, architecture
+                )
 
                 yield (
                     0,

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -38,13 +38,13 @@ class Malfind(interfaces.plugins.PluginInterface):
                 optional=True,
             ),
             requirements.IntRequirement(
-                name="dumpsize",
-                description="Dump X bytes of each malicious region found",
+                name="dump_size",
+                description="Amount of bytes to dump for each dirty region/page found - Default 64 bytes",
                 optional=True,
             ),
             requirements.BooleanRequirement(
-                name="dumppage",
-                description="Dump dirty page content (for each dirty page)",
+                name="dump_page",
+                description="Dump each dirty page and content - Default off",
                 optional=True,
             ),
         ]
@@ -60,22 +60,35 @@ class Malfind(interfaces.plugins.PluginInterface):
             return None
 
         proc_layer = self.context.layers[proc_layer_name]
-        dumpsize = self.config.get("dumpsize") if self.config.get("dumpsize") is not None else 64
-        dumppage = self.config.get("dumppage") or False
+
+        # Allowing a dump_size of 0 (no dump)
+        dump_size = self.config.get("dump_size") if self.config.get("dump_size") is not None else 64
+
+        # Dumping page defaults to off, as in case a whole r-xp region is dirty
+        # this would likely dump 1000's of pages which might not always be wise nor necessary
+
+        dump_page = self.config.get("dump_page") or False
 
         for vma in task.mm.get_vma_iter():
             vma_name = vma.get_name(self.context, task)
             vollog.debug(
                 f"Injections : processing PID {task.pid} : VMA {vma_name} : {hex(vma.vm_start)}-{hex(vma.vm_end)}"
             )
+
+            # If is_suspicious returns true, this means at least one page
+            # in the region is dirty. If dump_page is true, then we dump
+            # all dirty pages
+
             if vma.is_suspicious(proc_layer) and vma_name != "[vdso]":
                 malicious_pages = vma.get_malicious_pages(proc_layer)
-                if dumppage:
+                if dump_page:
+                    # Dumping each dirty page
                     for page_addr in malicious_pages:
-                        data = proc_layer.read(page_addr, dumpsize, pad=True)
-                        yield vma, vma_name+f", page address: {page_addr:#x}, offset: {page_addr-vma.vm_start:#x}", data
+                        data = proc_layer.read(page_addr, dump_size, pad=True)
+                        yield vma, f"{vma_name}, page address: {page_addr:#x}, offset: {page_addr-vma.vm_start:#x}", data
                 else:
-                    data = proc_layer.read(vma.vm_start,dumpsize,pad=True)
+                    # Original behaviour - Dump the start of the region (not necessarily matching the dirty page)
+                    data = proc_layer.read(vma.vm_start,dump_size,pad=True)
                     yield vma, vma_name, data
 
     def _generator(self, tasks):

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -41,6 +41,7 @@ class Malfind(interfaces.plugins.PluginInterface):
                 name="dump-size",
                 description="Amount of bytes to dump for each dirty region/page found - Default 64 bytes",
                 optional=True,
+                default=64,
             ),
             requirements.BooleanRequirement(
                 name="dump-page",

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -37,6 +37,16 @@ class Malfind(interfaces.plugins.PluginInterface):
                 element_type=int,
                 optional=True,
             ),
+            requirements.IntRequirement(
+                name="dumpsize",
+                description="Dump X bytes of each malicious region found",
+                optional=True,
+            ),
+            requirements.BooleanRequirement(
+                name="dumppage",
+                description="Dump dirty page content (for each dirty page)",
+                optional=True,
+            ),
         ]
 
     def _list_injections(
@@ -50,6 +60,8 @@ class Malfind(interfaces.plugins.PluginInterface):
             return None
 
         proc_layer = self.context.layers[proc_layer_name]
+        dumpsize = self.config.get("dumpsize") if self.config.get("dumpsize") is not None else 64
+        dumppage = self.config.get("dumppage") or False
 
         for vma in task.mm.get_vma_iter():
             vma_name = vma.get_name(self.context, task)
@@ -57,8 +69,14 @@ class Malfind(interfaces.plugins.PluginInterface):
                 f"Injections : processing PID {task.pid} : VMA {vma_name} : {hex(vma.vm_start)}-{hex(vma.vm_end)}"
             )
             if vma.is_suspicious(proc_layer) and vma_name != "[vdso]":
-                data = proc_layer.read(vma.vm_start, 64, pad=True)
-                yield vma, vma_name, data
+                malicious_pages = vma.get_malicious_pages(proc_layer)
+                if dumppage:
+                    for page_addr in malicious_pages:
+                        data = proc_layer.read(page_addr, dumpsize, pad=True)
+                        yield vma, vma_name+f", page address: {page_addr:#x}, offset: {page_addr-vma.vm_start:#x}", data
+                else:
+                    data = proc_layer.read(vma.vm_start,dumpsize,pad=True)
+                    yield vma, vma_name, data
 
     def _generator(self, tasks):
         # determine if we're on a 32 or 64 bit kernel

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1273,6 +1273,32 @@ class vm_area_struct(objects.StructType):
         except exceptions.InvalidAddressException:
             return None
 
+    def get_malicious_pages(self,proclayer=None):
+        malicious_pages = []
+
+        flags_str = self.get_protection()
+
+        if flags_str == "rwx":
+            ret = True
+        elif flags_str == "r-x" and self.vm_file.dereference().vol.offset == 0:
+            ret = True
+        elif proclayer and "x" in flags_str:
+            for i in range(self.vm_start, self.vm_end, proclayer.page_size):
+                try:
+                    if proclayer.is_dirty(i):
+                        vollog.debug(
+                            f"Found malicious (dirty+exec) page at {hex(i)} !"
+                        )
+                        malicious_pages.append(i)
+                except (
+                    exceptions.PagedInvalidAddressException,
+                    exceptions.InvalidAddressException,
+                ) as excp:
+                    vollog.debug(f"Unable to translate address {hex(i)} : {excp}")
+                    # Abort as it is likely that other addresses in the same range will also fail
+                    break
+        return malicious_pages
+
     # used by malfind
     def is_suspicious(self, proclayer=None):
         ret = False
@@ -1288,7 +1314,7 @@ class vm_area_struct(objects.StructType):
                 try:
                     if proclayer.is_dirty(i):
                         vollog.warning(
-                            f"Found malicious (dirty+exec) page at {hex(i)} !"
+                            f"Found malicious page(s) inside (dirty+exec) region {hex(self.vm_start)} !"
                         )
                         # We do not attempt to find other dirty+exec pages once we have found one
                         ret = True
@@ -2733,6 +2759,7 @@ class page(objects.StructType):
         for name, value in self.pageflags_enum.items():
             if self.flags & (1 << value) != 0:
                 flags.append(name)
+                print(name,value)
 
         return flags
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1273,20 +1273,22 @@ class vm_area_struct(objects.StructType):
         except exceptions.InvalidAddressException:
             return None
 
-    def get_malicious_pages(self,proclayer=None):
+    def get_malicious_pages(self, proclayer=None):
         """
         This function will return a list of all malicious pages inside a given dirty region
         """
         malicious_pages = []
         flags_str = self.get_protection()
 
-        if proclayer and "r-x" in flags_str and self.vm_file.dereference().vol.offset !=0:
+        if (
+            proclayer
+            and "r-x" in flags_str
+            and self.vm_file.dereference().vol.offset != 0
+        ):
             for i in range(self.vm_start, self.vm_end, proclayer.page_size):
                 try:
                     if proclayer.is_dirty(i):
-                        vollog.debug(
-                            f"Found malicious (dirty+exec) page at {hex(i)} !"
-                        )
+                        vollog.debug(f"Found malicious (dirty+exec) page at {hex(i)} !")
                         malicious_pages.append(i)
                 except (
                     exceptions.PagedInvalidAddressException,

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1274,19 +1274,17 @@ class vm_area_struct(objects.StructType):
             return None
 
     def get_malicious_pages(self,proclayer=None):
+        """
+        This function will return a list of all malicious pages inside a given dirty region
+        """
         malicious_pages = []
-
         flags_str = self.get_protection()
 
-        if flags_str == "rwx":
-            ret = True
-        elif flags_str == "r-x" and self.vm_file.dereference().vol.offset == 0:
-            ret = True
-        elif proclayer and "x" in flags_str:
+        if proclayer and "r-x" in flags_str and self.vm_file.dereference().vol.offset !=0:
             for i in range(self.vm_start, self.vm_end, proclayer.page_size):
                 try:
                     if proclayer.is_dirty(i):
-                        vollog.debug(
+                        vollog.warning(
                             f"Found malicious (dirty+exec) page at {hex(i)} !"
                         )
                         malicious_pages.append(i)

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1273,10 +1273,20 @@ class vm_area_struct(objects.StructType):
         except exceptions.InvalidAddressException:
             return None
 
-    def get_malicious_pages(self, proclayer=None):
+    def get_malicious_pages(self, proclayer) -> List[int]:
+        """Identifies and returns a list of potentially malicious memory pages.
+
+        A page is considered malicious if it is:
+            - Executable (protection flags match 'r-x')
+            - Dirty (modified since process start, according to proclayer.is_dirty())
+
+        Args:
+            proclayer: The process's memory layer
+
+        Returns:
+            List[int]: A list of virtual addresses for pages flagged as potentially malicious.
         """
-        This function will return a list of all malicious pages inside a given dirty region
-        """
+
         malicious_pages = []
         flags_str = self.get_protection()
 

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1284,7 +1284,7 @@ class vm_area_struct(objects.StructType):
             for i in range(self.vm_start, self.vm_end, proclayer.page_size):
                 try:
                     if proclayer.is_dirty(i):
-                        vollog.warning(
+                        vollog.debug(
                             f"Found malicious (dirty+exec) page at {hex(i)} !"
                         )
                         malicious_pages.append(i)
@@ -2757,7 +2757,6 @@ class page(objects.StructType):
         for name, value in self.pageflags_enum.items():
             if self.flags & (1 << value) != 0:
                 flags.append(name)
-                print(name,value)
 
         return flags
 


### PR DESCRIPTION
This PR is for adding `--dump-page` and `--dump-size` options to `linux.malware.Malfind` plugin. 

What does it do?

When supplied to `Malfind`, the `--dump-page` argument will dump each dirty page for the given process, instead of the default behaviour which will only dump the memory region inside which the dirty page(s) is/are located. Prior to this MR, Volatility will also stop at the first hit it finds, instead of looking for all dirty pages. 

This allows to precisely identify the location and content of the dirty memory sections. This is helpful in scenarios for which there are only a few dirty pages out of the whole memory region. 

The `--dump-size` argument allows to change the length of the disassembly for each page. The default is 64 bytes. 
It can be set to 0 (no disassembly printed, useful for a summary view). 

Why not making `--dump-page` default ? 

In scenarios where the whole binary executable region has been made dirty, `--dump-page` will list 1000's of dirty pages, which is not helpful.

This PR does not change the default behaviour of the Malfind plugin: 

Summary: 

| `--dump-page` supplied ? | `--dump-size` supplied ? | Behaviour|
| --- | ---| ---| 
| N | N | Dumps the first 64 bytes of the dirty memory *region* (default behaviour prior to this PR)| 
| Y | N | Dumps the first 64 bytes of each dirty page of each dirty region | 
| Y | Y | Dumps the first X bytes of each dirty pages of each dirty region (can be set to 0 to disable disassembly printout)| 
| N | Y | Dumps the first X bytes of the dirty memory *region*| 
 