### PR TITLE
Add convenience method for YaraScanner

### DIFF
--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -102,8 +102,20 @@ class YaraScanner(interfaces.layers.ScannerInterface):
             return yara.compile(file=fp)
 
     @classmethod
-    def from_text(cls, rule):
-        formatted_rule = rule.replace("\n", "")
+    def from_text(cls, rule) -> yara.Rules:
+        """Initialize a Yara Rules object from one or more rules in string format.
+
+        You can provide rules in single-line or multi-line:
+        rule = "rule dummy { condition: true }"
+        rules = '''
+            rule dummy {
+                condition: true
+            }
+            rule dummy2 {
+                condition: true
+            }
+        '''
+        """
         if USE_YARA_X:
             return yara_x.compile(source=formatted_rule)
         return yara.compile(source=formatted_rule)

--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -101,6 +101,13 @@ class YaraScanner(interfaces.layers.ScannerInterface):
                 return yara_x.compile(fp.read().decode())
             return yara.compile(file=fp)
 
+    @classmethod
+    def from_text(cls, rule):
+        formatted_rule = rule.replace("\n", "")
+        if USE_YARA_X:
+            return yara_x.compile(source=formatted_rule)
+        return yara.compile(source=formatted_rule)
+
 
 class YaraScan(plugins.PluginInterface):
     """Scans kernel memory using yara rules (string or file)."""


### PR DESCRIPTION
This convenience method makes it easier to use the YaraScanner with a Python defined YARA rule. This makes one off, single file plugins easier to make because one can include the YARA rule directly in Python instead of having to include the rule in a separate YARA file. I.e.:

```python

RULE = """rule ExampleRule
{
    strings:
        $line = { 00 01 02 03 }

    condition:
        all of them
}
"""

class Plugin:
    [setup]
    
    def _generator(self, layer):
        rule = yarascan.YaraScanner.from_text(RULE)
        scanner = yarascan.YaraScanner(rules=rule)
        [...]
""""