### PR TITLE
Hotfix/v2.26.1 - Resolve documentation not building for stable.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
 docs = [
     "volatility3[dev]",
     "sphinx>=4.0.0,<9",
-    "sphinx-autodoc-typehints>=2.0.0,<3",
+    "sphinx-autodoc-typehints>=3.0.0,<4",
     "sphinx-rtd-theme>=3.0.1,<4",
 ]
 

--- a/volatility3/framework/constants/_version.py
+++ b/volatility3/framework/constants/_version.py
@@ -1,7 +1,7 @@
 # We use the SemVer 2.0.0 versioning scheme
 VERSION_MAJOR = 2  # Number of releases of the library with a breaking change
 VERSION_MINOR = 26  # Number of changes that only add to the interface
-VERSION_PATCH = 0  # Number of changes that do not change the interface
+VERSION_PATCH = 1  # Number of changes that do not change the interface
 VERSION_SUFFIX = ""
 
 PACKAGE_VERSION = (

--- a/volatility3/framework/plugins/yarascan.py
+++ b/volatility3/framework/plugins/yarascan.py
@@ -31,7 +31,7 @@ except ImportError:
 
     except ImportError:
         vollog.info(
-            "Neither yara-x nor yara-python (>3.8.0) module not found, plugin (and dependent plugins) not available"
+            "Neither yara-x nor yara-python (>3.8.0) module was found, plugin (and dependent plugins) not available"
         )
         raise
 


### PR DESCRIPTION
This resolves the documentation failing to build for the past five months (including the stable release).