### PR TITLE
Update text_renderer.py

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -540,6 +540,11 @@ class JsonRenderer(CLIRenderer):
             if not isinstance(x, interfaces.renderers.BaseAbsentValue)
             else "N/A"
         ),
+        format_hints.Hex: lambda x: (
+            f"0x{x:x}"
+            if not isinstance(x, interfaces.renderers.BaseAbsentValue)
+            else None
+        ),
         renderers.Disassembly: quoted_optional(display_disassembly),
         format_hints.MultiTypeData: quoted_optional(multitypedata_as_text),
         renderers.LayerData: lambda x: (


### PR DESCRIPTION
Json Text renderer not properly rendering offset values.  

Command ```python .\vol.py -f memory.dmp -r json windows.registry.hivelist | ConvertFrom-Json | Format-List *```

Output:
```Volatility 3 Framework 2.26.2
Progress:  100.00               PDB scanning finished
File output  : Disabled
FileFullPath :
Offset       : 145708949291008
__children   : {}

File output  : Disabled
FileFullPath : \REGISTRY\MACHINE\SYSTEM
Offset       : 145708949430272
__children   : {}

File output  : Disabled
FileFullPath : \REGISTRY\MACHINE\HARDWARE
Offset       : 145708950167552
__children   : {}

File output  : Disabled
FileFullPath : \SystemRoot\System32\Config\SOFTWARE
Offset       : 145708958879744
__children   : {}
```

New output:

```Volatility 3 Framework 2.26.2
Progress:  100.00               PDB scanning finished
File output  : Disabled
FileFullPath :
Offset       : 0x84858229c000
__children   : {}

File output  : Disabled
FileFullPath : \REGISTRY\MACHINE\SYSTEM
Offset       : 0x8485822be000
__children   : {}

File output  : Disabled
FileFullPath : \REGISTRY\MACHINE\HARDWARE
Offset       : 0x848582372000
__children   : {}

File output  : Disabled
FileFullPath : \SystemRoot\System32\Config\SOFTWARE
Offset       : 0x848582bc1000
__children   : {}
```