### PR TITLE
Update Registry plugin expiry date

### DIFF
--- a/test/plugins/windows/test_scheduled_tasks.py
+++ b/test/plugins/windows/test_scheduled_tasks.py
@@ -4,7 +4,7 @@ import traceback
 import unittest
 
 sys.path.insert(0, "../../volatility3")
-from volatility3.plugins.windows import scheduled_tasks
+from volatility3.plugins.windows.registry import scheduled_tasks
 
 
 class TestActionsDecoding(unittest.TestCase):

--- a/test/plugins/windows/windows.py
+++ b/test/plugins/windows/windows.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import tempfile
+
 from test import WindowsSamples, test_volatility
 
 
@@ -437,7 +438,7 @@ class TestWindowsVadyarascan:
 class TestWindowsAmcache:
     def test_windows_generic_amcache(self, volatility, python, image):
         rc, out, _err = test_volatility.runvol_plugin(
-            "windows.amcache.Amcache",
+            "windows.registry.amcache.Amcache",
             image,
             volatility,
             python,
@@ -492,7 +493,7 @@ class TestWindowsBigPools:
 # class TestWindowsCachedump:
 #     def test_windows_generic_cachedump(self, volatility, python, image):
 #         rc, out, _err = test_volatility.runvol_plugin(
-#             "windows.cachedump.Cachedump",
+#             "windows.registry.cachedump.Cachedump",
 #             image,
 #             volatility,
 #             python,
@@ -820,7 +821,7 @@ class TestWindowsLsadump:
     def test_windows_specific_lsadump(self, volatility, python):
         image = WindowsSamples.WINDOWSXP_GENERIC.value.path
         rc, out, _err = test_volatility.runvol_plugin(
-            "windows.lsadump.Lsadump",
+            "windows.registry.lsadump.Lsadump",
             image,
             volatility,
             python,

--- a/volatility3/framework/plugins/linux/lsmod.py
+++ b/volatility3/framework/plugins/linux/lsmod.py
@@ -4,10 +4,10 @@
 """A module containing a plugin that lists loaded kernel modules."""
 
 import logging
-from typing import List, Iterable
+from typing import Iterable, List
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
-from volatility3.framework import interfaces, deprecation
+from volatility3.framework import deprecation, interfaces
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 
@@ -38,7 +38,7 @@ class Lsmod(plugins.PluginInterface):
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.list_modules,
         replacement_version=(3, 0, 0),
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
     )
     def list_modules(
         cls, context: interfaces.context.ContextInterface, vmlinux_module_name: str

--- a/volatility3/framework/plugins/linux/malware/check_modules.py
+++ b/volatility3/framework/plugins/linux/malware/check_modules.py
@@ -3,14 +3,14 @@
 #
 
 import logging
-from typing import List, Dict, Generator
+from typing import Dict, Generator, List
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
-from volatility3.framework import interfaces, deprecation
+from volatility3.framework import deprecation, interfaces
 from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols.linux import extensions
-from volatility3.framework.interfaces import plugins
 
 vollog = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class Check_modules(plugins.PluginInterface):
     @classmethod
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_kset_modules,
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
         replacement_version=(3, 0, 0),
     )
     def get_kset_modules(

--- a/volatility3/framework/plugins/linux/malware/hidden_modules.py
+++ b/volatility3/framework/plugins/linux/malware/hidden_modules.py
@@ -2,14 +2,15 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from typing import List, Set, Tuple, Iterable
+from typing import Iterable, List, Set, Tuple
+
+from volatility3.framework import deprecation, exceptions, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.interfaces import plugins
+from volatility3.framework.symbols.linux import extensions
 from volatility3.framework.symbols.linux.utilities import (
     modules as linux_utilities_modules,
 )
-from volatility3.framework import interfaces, exceptions, deprecation
-from volatility3.framework.configuration import requirements
-from volatility3.framework.symbols.linux import extensions
-from volatility3.framework.interfaces import plugins
 
 vollog = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ class Hidden_modules(plugins.PluginInterface):
     @staticmethod
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_modules_memory_boundaries,
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
         replacement_version=(3, 0, 0),
     )
     def get_modules_memory_boundaries(
@@ -116,7 +117,7 @@ class Hidden_modules(plugins.PluginInterface):
 
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_module_address_alignment,
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
         replacement_version=(3, 0, 0),
     )
     @classmethod
@@ -144,13 +145,13 @@ class Hidden_modules(plugins.PluginInterface):
 
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.get_hidden_modules,
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
         replacement_version=(3, 0, 0),
     )
     @staticmethod
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.validate_alignment_patterns,
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
         replacement_version=(3, 0, 0),
     )
     def _validate_alignment_patterns(

--- a/volatility3/framework/plugins/linux/malware/modxview.py
+++ b/volatility3/framework/plugins/linux/malware/modxview.py
@@ -2,15 +2,14 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from typing import List, Dict, Iterator
+from typing import Dict, Iterator, List
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
-
-from volatility3.framework import interfaces, deprecation, renderers
+from volatility3.framework import deprecation, interfaces, renderers
 from volatility3.framework.configuration import requirements
+from volatility3.framework.constants import architectures
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols.linux import extensions
-from volatility3.framework.constants import architectures
 from volatility3.framework.symbols.linux.utilities import tainting
 
 vollog = logging.getLogger(__name__)
@@ -66,7 +65,7 @@ spot modules presence and taints."""
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.flatten_run_modules_results,
         replacement_version=(3, 0, 0),
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
     )
     def flatten_run_modules_results(
         cls, run_results: Dict[str, List[extensions.module]], deduplicate: bool = True
@@ -89,7 +88,7 @@ spot modules presence and taints."""
     @deprecation.deprecated_method(
         replacement=linux_utilities_modules.Modules.run_modules_scanners,
         replacement_version=(3, 0, 0),
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
     )
     def run_modules_scanners(
         cls,

--- a/volatility3/framework/plugins/linux/malware/netfilter.py
+++ b/volatility3/framework/plugins/linux/malware/netfilter.py
@@ -1,22 +1,22 @@
 # This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-from dataclasses import dataclass, field
-from abc import ABC, abstractmethod
 import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Iterator, List, Optional, Tuple
 
 import volatility3.framework.symbols.linux.utilities.modules as linux_utilities_modules
-from typing import Iterator, List, Tuple, Optional
 from volatility3 import framework
 from volatility3.framework import (
     constants,
+    deprecation,
+    exceptions,
     interfaces,
     renderers,
-    exceptions,
-    deprecation,
 )
-from volatility3.framework.renderers import format_hints
 from volatility3.framework.configuration import requirements
+from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols.linux import network
 
 vollog = logging.getLogger(__name__)
@@ -223,7 +223,16 @@ class AbstractNetfilter(ABC):
                         )
                         hooked = module_info is None
 
-                        yield netns, proto_name, hook_name, priority, hook_ops_hook, module_info, symbol_name, hooked
+                        yield (
+                            netns,
+                            proto_name,
+                            hook_name,
+                            priority,
+                            hook_ops_hook,
+                            module_info,
+                            symbol_name,
+                            hooked,
+                        )
 
     @classmethod
     @abstractmethod
@@ -304,7 +313,7 @@ class AbstractNetfilter(ABC):
         return ("IPV4", "ARP", "BRIDGE", "IPV6", "DECNET")
 
     @deprecation.method_being_removed(
-        removal_date="2025-09-25",
+        removal_date="2026-03-25",
         message="Callers to this method should adapt `linux_utilities_modules.Modules.run_module_scanners`",
     )
     def get_module_name_for_address(self, addr) -> str:

--- a/volatility3/framework/plugins/windows/amcache.py
+++ b/volatility3/framework/plugins/windows/amcache.py
@@ -2,7 +2,8 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from volatility3.framework import interfaces, deprecation
+
+from volatility3.framework import deprecation, interfaces
 from volatility3.plugins.windows.registry import amcache
 
 vollog = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ class Amcache(
     interfaces.plugins.PluginInterface,
     deprecation.PluginRenameClass,
     replacement_class=amcache.Amcache,
-    removal_date="2025-09-25",
+    removal_date="2026-09-25",
 ):
     """Extract information on executed applications from the AmCache (deprecated)."""
 

--- a/volatility3/framework/plugins/windows/cachedump.py
+++ b/volatility3/framework/plugins/windows/cachedump.py
@@ -2,7 +2,8 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from volatility3.framework import interfaces, deprecation
+
+from volatility3.framework import deprecation, interfaces
 from volatility3.plugins.windows.registry import cachedump
 
 vollog = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ class Cachedump(
     interfaces.plugins.PluginInterface,
     deprecation.PluginRenameClass,
     replacement_class=cachedump.Cachedump,
-    removal_date="2025-09-25",
+    removal_date="2026-09-25",
 ):
     """Dumps lsa secrets from memory (deprecated)"""
 

--- a/volatility3/framework/plugins/windows/hashdump.py
+++ b/volatility3/framework/plugins/windows/hashdump.py
@@ -2,7 +2,8 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from volatility3.framework import interfaces, deprecation
+
+from volatility3.framework import deprecation, interfaces
 from volatility3.plugins.windows.registry import hashdump
 
 vollog = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ class Hashdump(
     interfaces.plugins.PluginInterface,
     deprecation.PluginRenameClass,
     replacement_class=hashdump.Hashdump,
-    removal_date="2025-09-25",
+    removal_date="2026-09-25",
 ):
     """Dumps user hashes from memory (deprecated)"""
 

--- a/volatility3/framework/plugins/windows/lsadump.py
+++ b/volatility3/framework/plugins/windows/lsadump.py
@@ -2,7 +2,8 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from volatility3.framework import interfaces, deprecation
+
+from volatility3.framework import deprecation, interfaces
 from volatility3.plugins.windows.registry import lsadump
 
 vollog = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ class Lsadump(
     interfaces.plugins.PluginInterface,
     deprecation.PluginRenameClass,
     replacement_class=lsadump.Lsadump,
-    removal_date="2025-09-25",
+    removal_date="2026-09-25",
 ):
     """Dumps lsa secrets from memory (deprecated)"""
 

--- a/volatility3/framework/plugins/windows/scheduled_tasks.py
+++ b/volatility3/framework/plugins/windows/scheduled_tasks.py
@@ -2,7 +2,8 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 import logging
-from volatility3.framework import interfaces, deprecation
+
+from volatility3.framework import deprecation, interfaces
 from volatility3.plugins.windows.registry import scheduled_tasks
 
 vollog = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ class ScheduledTasks(
     interfaces.plugins.PluginInterface,
     deprecation.PluginRenameClass,
     replacement_class=scheduled_tasks.ScheduledTasks,
-    removal_date="2025-09-25",
+    removal_date="2026-09-25",
 ):
     """Decodes scheduled task information from the Windows registry, including
     information about triggers, actions, run times, and creation times (deprecated)."""


### PR DESCRIPTION
Ensure plugins have at least a year from their deprecation release to when they're actually removed.  Bump the methods for a little longer too (6 months at best is barely one release with the deprecation notice)...