### PR TITLE
[issue #1889] Fix missing address increment in low stub scanner

### DIFF
--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -450,7 +450,7 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
             while (kernel_base + 0x2000000) > kernel_hint:
                 for i in range(0, 0x200000, 0x1000):
                     valid_kernel = self.check_kernel_offset(
-                        context, vlayer, kernel_base, progress_callback
+                        context, vlayer, kernel_base + i, progress_callback
                     )
                     if valid_kernel:
                         return valid_kernel


### PR DESCRIPTION
The base was not correctly incremented which resulted in a wrong kernel_base calculation, even if all other values were sane.

Fixes #1889 