### PR TITLE
vadinfo: Add ability to filter processes by physical memory offset and display physical VAD offsets.

### DIFF
--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -79,6 +79,11 @@ class VadInfo(interfaces.plugins.PluginInterface):
                 default=cls.MAXSIZE_DEFAULT,
                 optional=True,
             ),
+            requirements.IntRequirement(
+                name="offset",
+                description="Process offset in the physical address space",
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -274,6 +279,24 @@ class VadInfo(interfaces.plugins.PluginInterface):
 
     def run(self) -> renderers.TreeGrid:
         filter_func = pslist.PsList.create_pid_filter(self.config.get("pid", None))
+        kernel = self.context.modules[self.config["kernel"]]
+
+        if self.config["offset"]:
+            procs = psscan.PsScan.scan_processes(
+                self.context,
+                self.config["kernel"],
+                filter_func=psscan.PsScan.create_offset_filter(
+                    self.context,
+                    kernel.layer_name,
+                    self.config["offset"],
+                ),
+            )
+        else:
+             procs = pslist.PsList.list_processes(
+                context=self.context,
+                kernel_module_name=self.config["kernel"],
+                filter_func=filter_func,
+            )
 
         return renderers.TreeGrid(
             [
@@ -290,11 +313,5 @@ class VadInfo(interfaces.plugins.PluginInterface):
                 ("File", str),
                 ("File output", str),
             ],
-            self._generator(
-                pslist.PsList.list_processes(
-                    context=self.context,
-                    kernel_module_name=self.config["kernel"],
-                    filter_func=filter_func,
-                )
-            ),
+            self._generator(procs=procs),
         )

--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -84,6 +84,11 @@ class VadInfo(interfaces.plugins.PluginInterface):
                 description="Process offset in the physical address space",
                 optional=True,
             ),
+            requirements.BooleanRequirement(
+                name="physical-offsets",
+                description="List processes with physical offsets instead of virtual offsets.",
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -203,6 +208,22 @@ class VadInfo(interfaces.plugins.PluginInterface):
 
         return file_handle
 
+    def _translate_offset(self, offset: int) -> int:
+        if not self.config["physical-offsets"]:
+            return offset
+
+        kernel = self.context.modules[self.config["kernel"]]
+        layer_name = kernel.layer_name
+
+        try:
+            _original_offset, _original_length, offset, _length, _layer_name = list(
+                self.context.layers[layer_name].mapping(offset=offset, length=0)
+            )[0]
+        except exceptions.PagedInvalidAddressException:
+            vollog.debug(f"Page fault: unable to translate {offset:0x}")
+
+        return offset
+
     def _generator(self, procs: List[interfaces.objects.ObjectInterface]) -> Generator[
         Tuple[
             int,
@@ -257,7 +278,7 @@ class VadInfo(interfaces.plugins.PluginInterface):
                     (
                         proc.UniqueProcessId,
                         process_name,
-                        format_hints.Hex(kernel_layer.canonicalize(vad.vol.offset)),
+                        format_hints.Hex(kernel_layer.canonicalize(self._translate_offset(vad.vol.offset))),
                         format_hints.Hex(vad.get_start()),
                         format_hints.Hex(vad.get_end()),
                         vad.get_tag(),

--- a/volatility3/framework/plugins/windows/vadinfo.py
+++ b/volatility3/framework/plugins/windows/vadinfo.py
@@ -9,7 +9,7 @@ from volatility3.framework import renderers, interfaces, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
-from volatility3.plugins.windows import pslist
+from volatility3.plugins.windows import pslist, psscan
 
 vollog = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request enhances the `vadinfo` plugin in Volatility3 by adding support for filtering processes by physical memory offset and displaying physical offsets in output. It introduces new configuration options, improves process selection flexibility, and ensures offsets are translated correctly when requested.

**New Features:**

* Added `offset` (process physical address offset) and `physical-offsets` (toggle for displaying physical offsets) as new configuration requirements in `vadinfo.py`, allowing users to filter processes based on physical memory offsets and display VADs physical-offsets.

**Process Selection Improvements:**

* Integrated `psscan.PsScan` for process scanning by offset, enabling process selection either by PID (using `pslist`) or by physical offset (using `psscan`), based on user configuration. [[1]](diffhunk://#diff-e4e627a541eac27f4fcc83bf2c9ed1252753ca68ed4bc866292bb5413ca46cdfL12-R12) [[2]](diffhunk://#diff-e4e627a541eac27f4fcc83bf2c9ed1252753ca68ed4bc866292bb5413ca46cdfR303-R320)

**Offset Handling Enhancements:**

* Implemented `_translate_offset` to convert virtual offsets to physical offsets when `physical-offsets` is enabled, ensuring correct offset display and handling page faults gracefully.
* Updated the output to use the translated offset when `physical-offsets` is set, so that the displayed offset matches user expectations.