### PR TITLE
Avoid trying to lookup child nodes that have been filtered

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -464,9 +464,9 @@ class PrettyTextRenderer(CLIRenderer):
             accumulator.append((node.path_depth, line))
             return accumulator
 
-        final_output: List[
-            Tuple[int, Dict[interfaces.renderers.Column, list[str]]]
-        ] = []
+        final_output: List[Tuple[int, Dict[interfaces.renderers.Column, list[str]]]] = (
+            []
+        )
         if not grid.populated:
             grid.populate(visitor, final_output)
         else:

--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -10,8 +10,8 @@ import string
 import sys
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union
-from volatility3.cli import text_filter
 
+from volatility3.cli import text_filter
 from volatility3.framework import exceptions, interfaces, renderers
 from volatility3.framework.renderers import format_hints
 
@@ -464,9 +464,9 @@ class PrettyTextRenderer(CLIRenderer):
             accumulator.append((node.path_depth, line))
             return accumulator
 
-        final_output: List[Tuple[int, Dict[interfaces.renderers.Column, list[str]]]] = (
-            []
-        )
+        final_output: List[
+            Tuple[int, Dict[interfaces.renderers.Column, list[str]]]
+        ] = []
         if not grid.populated:
             grid.populate(visitor, final_output)
         else:
@@ -598,7 +598,8 @@ class JsonRenderer(CLIRenderer):
             if self.filter and self.filter.filter(line):
                 return accumulator
 
-            if node.parent:
+            # Only add if the parent hasn't been filtered out
+            if node.parent and node.parent.path in acc_map:
                 acc_map[node.parent.path]["__children"].append(node_dict)
             else:
                 final_tree.append(node_dict)


### PR DESCRIPTION
Fixes #1309

I went with the "only show results that have been filtered" rather than all parents because, as mentioned, it would require determining the entire tree before output could happen.