### PR TITLE
Improve windows intel detection for Windows 11

### DIFF
--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -153,8 +153,7 @@ class DtbSelfRefPae(DtbSelfReferential):
             # Mask off the page bits of top level page map
             page_table_mask = b"\x00\xf0\xff\xff\xff\xff\xff\xff" * 4
             page_table = data[
-                top_pae_page
-                - data_offset : top_pae_page
+                top_pae_page - data_offset : top_pae_page
                 - data_offset
                 + (4 * self.ptr_size)
             ]
@@ -200,7 +199,7 @@ class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
         (
             "Detecting Self-referential pointer for recent windows",
             [DtbSelfRef64bit()],
-            [(0x150000, 0x150000), (0x650000, 0xA0000)],
+            [(0x150000, 0x150000), (0x550000, 0xA0000)],
         ),
         (
             "Older windows fixed location self-referential pointers",
@@ -305,9 +304,20 @@ class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
 
             hits = sorted(list(hits), key=sort_by_tests)
 
+            vollog.debug(f"WindowsIntelStacker hits: {hits}")
+
             for test, page_map_offset in hits:
                 # Turn the page tables into integers and find the largest one
                 page_table = base_layer.read(page_map_offset, 0x1000)
+
+                # Modern windows can have a dummy page table with only about 2 entries, so sanity check
+                null_count = sum([1 if page_table[x] else 0 for x in page_table])
+                if null_count > 0xFA0:
+                    vollog.debug(
+                        f"DTB {page_map_offset:x} contains less than 12 valid pointers, ignoring"
+                    )
+                    continue
+
                 ptr_size = struct.calcsize(test.ptr_struct)
                 max_pointer = get_max_pointer(page_table, test, ptr_size)
 

--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -200,7 +200,7 @@ class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
         (
             "Detecting Self-referential pointer for recent windows",
             [DtbSelfRef64bit()],
-            [(0x150000, 0x150000), (0x550000, 0xA0000)],
+            [(0x150000, 0x150000), (0x550000, 0x1A0000)],
         ),
         (
             "Older windows fixed location self-referential pointers",

--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -153,7 +153,8 @@ class DtbSelfRefPae(DtbSelfReferential):
             # Mask off the page bits of top level page map
             page_table_mask = b"\x00\xf0\xff\xff\xff\xff\xff\xff" * 4
             page_table = data[
-                top_pae_page - data_offset : top_pae_page
+                top_pae_page
+                - data_offset : top_pae_page
                 - data_offset
                 + (4 * self.ptr_size)
             ]


### PR DESCRIPTION
This slightly expands the range of likely addresses for DTBs (we've found some that start lower than 0x650000) and they also seem to have a dummy DTB with only a couple of entries, which are hit and accepted before the actual DTB is tested.  This patch ignores any potential DTBs that have very few entries (less than 96 changed bytes across the entire page).

Both these values may require tuning (lowering the false positive detector, or increasing the lower limit that likely DTBs live at).  Without a correct DTB, scanning for the kernel will likely always fail the sanity tests, which is why our backup plans weren't finding the kernel, they were working on a broken translation layer.