### PR TITLE
Fix format_hints.MultiTypeData representation in Parquet/Arrow renderers

### DIFF
--- a/volatility3/framework/plugins/renderers/parquet_renderer.py
+++ b/volatility3/framework/plugins/renderers/parquet_renderer.py
@@ -52,7 +52,7 @@ class ArrowRenderer(text_renderer.CLIRenderer):
             datetime.datetime: lambda: pa.timestamp("ms"),
             format_hints.Bin: pa.uint64,
             format_hints.Hex: pa.uint64,
-            format_hints.MultiTypeData: pa.utf8,
+            format_hints.MultiTypeData: pa.binary,
             format_hints.HexBytes: pa.binary,
             renderers.LayerData: pa.binary,
             bytes: pa.binary,


### PR DESCRIPTION
This maps `format_hints.MultiTypeData` to `pa.binary` and fixes #1931

Changes `pa.utf8` → `pa.binary` to handle binary content in registry values and other `format_hints.MultiTypeData` fields.