### PR TITLE
Timeliner output repeated lines and entries due to how it was constructed

### DIFF
--- a/volatility3/framework/plugins/timeliner.py
+++ b/volatility3/framework/plugins/timeliner.py
@@ -153,6 +153,8 @@ orders the results by time."""
                         )
                     times[timestamp_type] = timestamp
                     self.timeline[(plugin_name, item)] = times
+
+                for plugin_name, item in self.timeline:
                     data.append(
                         (
                             0,


### PR DESCRIPTION
Fixes #1940.