### PR TITLE
Improve Win11 DTB detection

### DIFF
--- a/volatility3/framework/automagic/windows.py
+++ b/volatility3/framework/automagic/windows.py
@@ -200,7 +200,7 @@ class WindowsIntelStacker(interfaces.automagic.StackerLayerInterface):
         (
             "Detecting Self-referential pointer for recent windows",
             [DtbSelfRef64bit()],
-            [(0x150000, 0x150000), (0x550000, 0x1A0000)],
+            [(0x150000, 0x150000), (0x550000, 0x1A0000), (0x900000, 0x100000)],
         ),
         (
             "Older windows fixed location self-referential pointers",


### PR DESCRIPTION
It seems windows 11 has started moving the DTB further afield.  This change adds another region located empirically, so it might need extending for everything between the second and third regions potentially.  It may also be possible to shrink the third region, but that will need more example images (it's still not clear what causes the use of the higher DTB, although the image it was found in was 18Gb).