### PR TITLE
Added handling for non-ascii characters to QuickTextRenderer

### DIFF
--- a/volatility3/cli/text_renderer.py
+++ b/volatility3/cli/text_renderer.py
@@ -321,7 +321,11 @@ class QuickTextRenderer(CLIRenderer):
                 "*" * max(0, node.path_depth - 1)
                 + ("" if (node.path_depth <= 1) else " ")
             )
-            accumulator.write("{}".format("\t".join(line)))
+
+            accumulator_text = ""
+            for part in line:
+                accumulator_text += f"{part.encode('ascii', errors='backslashreplace').decode('ascii')}\t"
+            accumulator.write(accumulator_text.rstrip("\t"))
             accumulator.flush()
             return accumulator
 


### PR DESCRIPTION
Add handling to the render function in QuickTextRenderer to fix encoding errors when writing the output of volatility to a file on Windows.