### PR TITLE
Set default encoding to utf-8

### DIFF
--- a/vol.py
+++ b/vol.py
@@ -5,7 +5,12 @@
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
 
+import sys
+
 import volatility3.cli
 
 if __name__ == "__main__":
+    # Ensure stdout/stderr use UTF-8 to avoid output encoding errors on Windows systems
+    sys.stderr.reconfigure(encoding="utf-8")
+    sys.stdout.reconfigure(encoding="utf-8")
     volatility3.cli.main()


### PR DESCRIPTION
Sets the default encoding to utf-8 to fix issues on windows where python defaults to non-utf-8 encoding which can in turn cause crashes when writing the output of volatility to a file