### PR TITLE
Add user cache directory as fallback for downloaded symbols

### DIFF
--- a/volatility3/framework/constants/__init__.py
+++ b/volatility3/framework/constants/__init__.py
@@ -25,6 +25,18 @@ from volatility3.framework.constants._version import (
 
 REQUIRED_PYTHON_VERSION = (3, 8, 0)
 
+CACHE_PATH = os.path.join(
+    os.environ.get("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache"),
+    "volatility3",
+)
+"""Default path to store cached data"""
+
+if sys.platform == "win32":
+    CACHE_PATH = os.path.realpath(
+        os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3")
+    )
+os.makedirs(CACHE_PATH, exist_ok=True)
+
 PLUGINS_PATH = [
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "plugins")),
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "plugins")),
@@ -34,6 +46,9 @@ PLUGINS_PATH = [
 SYMBOL_BASEPATHS = [
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "symbols")),
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "symbols")),
+    os.path.abspath(
+        os.path.join(CACHE_PATH, "symbols")
+    ),  # User cache fallback for automatically downloaded temporary symbols
 ]
 """Default list of paths to load symbols from (volatility3/symbols and volatility3/framework/symbols)"""
 
@@ -71,20 +86,8 @@ LOGLEVEL_VVVV = 6
 """Logging level for four levels of detail: -vvvvvv"""
 
 
-CACHE_PATH = os.path.join(
-    os.environ.get("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache"),
-    "volatility3",
-)
-"""Default path to store cached data"""
-
 SQLITE_CACHE_PERIOD = "-3 days"
 """SQLite time modifier for how long each item is valid in the cache for"""
-
-if sys.platform == "win32":
-    CACHE_PATH = os.path.realpath(
-        os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "volatility3")
-    )
-os.makedirs(CACHE_PATH, exist_ok=True)
 
 IDENTIFIERS_FILENAME = "identifier.cache"
 """Default location to record information about available identifiers"""

--- a/volatility3/framework/symbols/windows/pdbutil.py
+++ b/volatility3/framework/symbols/windows/pdbutil.py
@@ -289,7 +289,7 @@ class PDBUtility(interfaces.configuration.VersionableInterface):
                         )
                 break
             except PermissionError:
-                vollog.warning(
+                vollog.debug(
                     f"Cannot write necessary symbol file, please check permissions on {potential_output_filename}"
                 )
                 continue


### PR DESCRIPTION
### Problem

Currently, `class PDBUtility()` writes downloaded Windows PDB symbols directly to the directories listed in `symbols.__path__`. When Volatility3 is installed in a system location (e.g., `/usr/lib/python3/dist-packages`), these directories are **not writable** by a regular user, causing warnings such as:

```
WARNING  volatility3.framework.symbols.windows.pdbutil: Cannot write necessary symbol file, please check permissions on /usr/lib/python3/dist-packages/volatility3/symbols/windows/ntkrnlmp.pdb/***.json.xz
WARNING  volatility3.framework.symbols.windows.pdbutil: Cannot write necessary symbol file, please check permissions on /usr/lib/python3/dist-packages/volatility3/framework/symbols/windows/ntkrnlmp.pdb/***.json.xz
WARNING  volatility3.framework.symbols.windows.pdbutil: Cannot write downloaded symbols, please add the appropriate symbols or add/modify a symbols directory that is writable
```

The documentation on [Windows symbol tables](https://volatility3.readthedocs.io/en/latest/symbol-tables.html#windows-symbol-tables) states:

> If such a symbol table cannot be found, then the associated PDB file will be downloaded from Microsoft’s Symbol Server and converted into the appropriate JSON format, and will be saved in the correct location.

On systems where Volatility3 is installed globally, these “correct locations” are not writable, and defining `--symbol-dirs` is currently the only way to avoid these errors.

### Solution

This PR appends the user cache directory (`$XDG_CACHE_HOME/volatility3/symbols` or `~/.cache/volatility3/symbols`) to `constants.SYMBOL_BASEPATHS`, which is used to construct `symbols.__path__`. The parent directory `~/.cache/volatility3` is already used for metadata such as `identifier.cache`, making it a natural location for cached symbols as well.

After this change, the symbol search order will be:

1. User-specified directories (`--symbol-dirs`)
2. Shipped framework symbols
3. User cache directory (`$XDG_CACHE_HOME/volatility3/symbols`)

This is a clean, minimal change to the constants, fully compatible with user-defined symbol directories (`--symbol-dirs`). It provides a writable fallback location for downloaded symbols, avoiding permission issues when the shipped framework directories are not writable; `download_pdb_isf()` in `class PDBUtility()` can write to the user cache directory if needed, ensuring symbols can still be saved even when earlier directories are read-only.

To reduce unnecessary noise during the search process, per-directory write failures are now logged at DEBUG level, while the existing warning remains if no writable directory can be found. This ensures the user is informed about permanent errors while possibly temporary failures remain silent.

In addition, this approach prevents similar permission problems for any future temporary symbol classes that may be added.