### PR TITLE
Support Cryptodome namespace when Crypto is unavailable

### DIFF
--- a/volatility3/framework/plugins/windows/registry/cachedump.py
+++ b/volatility3/framework/plugins/windows/registry/cachedump.py
@@ -5,8 +5,13 @@ import logging
 from struct import unpack
 from typing import Tuple
 
-from Crypto.Cipher import ARC4, AES
-from Crypto.Hash import HMAC
+try:
+    from Crypto.Cipher import ARC4, AES
+    from Crypto.Hash import HMAC
+except ImportError:
+    # Debian/Ubuntu ship pycryptodome under Cryptodome namespace
+    from Cryptodome.Cipher import ARC4, AES
+    from Cryptodome.Hash import HMAC
 
 from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements

--- a/volatility3/framework/plugins/windows/registry/hashdump.py
+++ b/volatility3/framework/plugins/windows/registry/hashdump.py
@@ -7,7 +7,11 @@ import logging
 from struct import pack, unpack
 from typing import List, Optional, Tuple
 
-from Crypto.Cipher import AES, ARC4, DES
+try:
+    from Crypto.Cipher import ARC4, DES, AES
+except ImportError:
+    # Debian/Ubuntu ship pycryptodome under Cryptodome namespace
+    from Cryptodome.Cipher import ARC4, DES, AES
 
 from volatility3.framework import interfaces, renderers, exceptions, constants
 from volatility3.framework.configuration import requirements

--- a/volatility3/framework/plugins/windows/registry/lsadump.py
+++ b/volatility3/framework/plugins/windows/registry/lsadump.py
@@ -6,7 +6,11 @@ from struct import unpack
 from typing import Optional
 import hashlib
 
-from Crypto.Cipher import ARC4, DES, AES
+try:
+    from Crypto.Cipher import ARC4, DES, AES
+except ImportError:
+    # Debian/Ubuntu ship pycryptodome under Cryptodome namespace
+    from Cryptodome.Cipher import ARC4, DES, AES
 
 from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements


### PR DESCRIPTION
### Problem

Some Linux distributions (notably Debian and Ubuntu) package PyCryptodome (`python3-pycryptodome`) without the legacy `Crypto` namespace in order to [avoid conflicts](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886291) with the deprecated PyCrypto package. In those environments, the library is only available under the `Cryptodome` namespace.

As a result, imports like:
```
from Crypto.Cipher import ARC4, DES, AES
```
fail with:
```
ModuleNotFoundError: No module named 'Crypto'
```
Example error:
```
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.registry.hashdump based on file: /usr/lib/python3/dist-packages/volatility3/framework/plugins/windows/registry/hashdump.py
DEBUG    volatility3.framework: Traceback (most recent call last):
  . . .
  File "/usr/lib/python3/dist-packages/volatility3/framework/plugins/windows/registry/lsadump.py", line 9, in <module>
    from Crypto.Cipher import ARC4, DES, AES
ModuleNotFoundError: No module named 'Crypto'
```

### Solution

This PR adds a fallback so that if `Crypto` is unavailable, the corresponding `Cryptodome` namespace is used. As no behavior changes occur on systems where `Crypto` is already available, this keeps compatibility with both:
- upstream pip-installed PyCryptodome (`Crypto` namespace)
- Debian/Ubuntu packaged PyCryptodome (`Cryptodome` namespace)