### PR TITLE
Rework where the banner output happens

### DIFF
--- a/volatility3/cli/__init__.py
+++ b/volatility3/cli/__init__.py
@@ -30,11 +30,10 @@ try:
 except ImportError:
     HAS_ARGCOMPLETE = False
 
-from volatility3.cli import text_filter
 import volatility3.plugins
 import volatility3.symbols
 from volatility3 import framework
-from volatility3.cli import text_renderer, volargparse
+from volatility3.cli import text_filter, text_renderer, volargparse
 from volatility3.framework import (
     automagic,
     configuration,
@@ -380,6 +379,17 @@ class CommandLine:
             )
             self.populate_requirements_argparse(plugin_parser, plugin_list[plugin])
 
+        # One last pass to get the renderer after we've loaded up plugins,
+        # so we can determine whether to show the banner on normal output or not...
+        known_args = [arg for arg in sys.argv[1:] if arg != "--help" and arg != "-h"]
+        partial_args, _ = parser.parse_known_args(known_args)
+
+        # Display banner - redirect to stderr if using structured output
+        banner_output = sys.stdout
+        if renderers[partial_args.renderer].structured_output:
+            banner_output = sys.stderr
+        banner_output.write(f"Volatility 3 Framework {constants.PACKAGE_VERSION}\n")
+
         ###
         # PASS TO UI
         ###
@@ -391,12 +401,6 @@ class CommandLine:
             # before all the plugins have been added
             argcomplete.autocomplete(parser)
         args = parser.parse_args()
-
-        # Display banner - redirect to stderr if using structured output
-        banner_output = sys.stdout
-        if renderers[args.renderer].structured_output:
-            banner_output = sys.stderr
-        banner_output.write(f"Volatility 3 Framework {constants.PACKAGE_VERSION}\n")
 
         if args.plugin is None:
             parser.error(


### PR DESCRIPTION
Ok, I think this sorts it, but it could do with testing to make sure pluggable renderers (such as arrow/parquet) get picked up and to make sure that structured output (such as csv format, etc) display the banner when being piped, but don't write it to the file (stderr, rather than stdout)...

Any chance you could check it out for me please @eve-mem ?

Closes #1979 