### PR TITLE
Add Windows mini kernel dump support

### DIFF
--- a/volatility3/framework/automagic/pdbscan.py
+++ b/volatility3/framework/automagic/pdbscan.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Un
 
 from volatility3.framework import constants, exceptions, interfaces, layers
 from volatility3.framework.configuration import requirements
-from volatility3.framework.layers import intel, scanners
+from volatility3.framework.layers import crash, intel, scanners
 from volatility3.framework.symbols import native
 from volatility3.framework.symbols.windows import pdbutil
 
@@ -66,6 +66,20 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
             ),
         ]
 
+    @staticmethod
+    def _is_scannable_windows_kernel_layer(
+        layer: interfaces.layers.DataLayerInterface,
+    ) -> bool:
+        """Determines whether a layer can be scanned for a Windows kernel PDB."""
+
+        return isinstance(
+            layer,
+            (
+                intel.Intel,
+                crash.WindowsMiniKernelDump64Layer,
+            ),
+        )
+
     def find_virtual_layers_from_req(
         self,
         context: interfaces.context.ContextInterface,
@@ -98,9 +112,14 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
                 interfaces.configuration.path_join(sub_config_path, "memory_layer"),
                 None,
             )
+            if layer_name is None:
+                layer_name = context.config.get(
+                    interfaces.configuration.path_join(sub_config_path, "base_layer"),
+                    None,
+                )
             if layer_name and virtual_layer_name:
                 memlayer = context.layers[virtual_layer_name]
-                if isinstance(memlayer, intel.Intel):
+                if self._is_scannable_windows_kernel_layer(memlayer):
                     results = [virtual_layer_name]
         else:
             for subreq in requirement.requirements.values():
@@ -172,9 +191,15 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
                 vollog.debug(f"Setting kernel_virtual_offset to {hex(kvo)}")
 
     def get_physical_layer_name(self, context, vlayer):
-        return context.config.get(
+        physical_layer_name = context.config.get(
             interfaces.configuration.path_join(vlayer.config_path, "memory_layer"), None
         )
+        if physical_layer_name is None:
+            physical_layer_name = context.config.get(
+                interfaces.configuration.path_join(vlayer.config_path, "base_layer"),
+                None,
+            )
+        return physical_layer_name
 
     def method_slow_scan(
         self,
@@ -493,6 +518,15 @@ class KernelPDBScanner(interfaces.automagic.AutomagicInterface):
             vlayer = context.layers.get(virtual_layer_name, None)
             if isinstance(vlayer, layers.intel.Intel):
                 for method in self.methods:
+                    valid_kernel = method(self, context, vlayer, progress_callback)
+                    if valid_kernel:
+                        break
+            elif vlayer is not None and self._is_scannable_windows_kernel_layer(vlayer):
+                for method in [
+                    KernelPDBScanner.method_kdbg_offset,
+                    KernelPDBScanner.method_module_offset,
+                    KernelPDBScanner.method_slow_scan,
+                ]:
                     valid_kernel = method(self, context, vlayer, progress_callback)
                     if valid_kernel:
                         break

--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -3,7 +3,7 @@
 #
 import logging
 import struct
-from typing import Tuple, Optional
+from typing import Dict, Iterable, Optional, Tuple
 
 from volatility3.framework import constants, exceptions, interfaces
 from volatility3.framework.layers import segmented
@@ -265,6 +265,321 @@ class WindowsCrashDump64Layer(WindowsCrashDump32Layer):
     headerpages = 2
 
 
+class WindowsMiniKernelDump64Layer(segmented.SegmentedLayer):
+    """A sparse Windows mini kernel dump translation layer.
+
+    Mini kernel dumps do not contain a complete physical memory image.  They
+    contain selected virtual memory ranges such as the crashing stack,
+    debugger data, loaded-driver metadata, and pages selected by the crash dump
+    writer.  This layer maps only the captured virtual ranges and raises
+    InvalidAddressException for all uncaptured addresses.
+
+    The on-disk layout is:
+      - ``_DUMP_HEADER64`` at offset 0 (size 0x2000)
+      - ``_MINI_KERNEL_DUMP_SECONDARY`` at offset 0x2000
+      - variable-length string table, module table, captured range table,
+        and captured data
+    """
+
+    SIGNATURE = 0x45474150
+    VALIDDUMP = 0x34365544
+    DUMP_TYPE = 0x4
+    crashdump_json = "crash64"
+    crashmini_json = "crash_mini"
+    dump_header_name = "_DUMP_HEADER64"
+    secondary_header_name = "_MINI_KERNEL_DUMP_SECONDARY"
+    secondary_header_offset = 0x2000
+    _module_entry_size = 0x90
+
+    _magic_struct = struct.Struct("<II")
+    _u32_struct = struct.Struct("<I")
+    _entry_struct = struct.Struct("<QQ")
+
+    provides = {"type": "virtual"}
+    page_size = 0x1000
+    bits_per_register = 64
+
+    def __init__(
+        self, context: interfaces.context.ContextInterface, config_path: str, name: str
+    ) -> None:
+        self._context = context
+        self._config_path = config_path
+        self._base_layer = self.config["base_layer"]
+
+        self._crash_table_name = intermed.IntermediateSymbolTable.create(
+            context, self._config_path, "windows", self.crashdump_json
+        )
+        self._crash_mini_table_name = intermed.IntermediateSymbolTable.create(
+            context, self._config_path, "windows", self.crashmini_json
+        )
+
+        hdr_layer = self._context.layers[self._base_layer]
+        self.check_header(hdr_layer)
+
+        header = self.get_header()
+        self.dump_type = int(header.DumpType)
+        if self.dump_type != self.DUMP_TYPE:
+            raise WindowsCrashDumpFormatException(
+                name, f"unsupported mini kernel dump format 0x{self.dump_type:x}"
+            )
+
+        self._secondary = self._get_secondary_header()
+
+        super().__init__(
+            context,
+            config_path,
+            name,
+            metadata={"os": "Windows", "architecture": "Intel64"},
+        )
+
+    def get_header(self) -> interfaces.objects.ObjectInterface:
+        return self.context.object(
+            self._crash_table_name + constants.BANG + self.dump_header_name,
+            offset=0,
+            layer_name=self._base_layer,
+        )
+
+    def _get_secondary_header(self) -> interfaces.objects.ObjectInterface:
+        return self.context.object(
+            self._crash_mini_table_name
+            + constants.BANG
+            + self.secondary_header_name,
+            offset=self.secondary_header_offset,
+            layer_name=self._base_layer,
+        )
+
+    def _read_base_u32(self, offset: int) -> int:
+        return self._u32_struct.unpack(
+            self._context.layers[self._base_layer].read(offset, self._u32_struct.size)
+        )[0]
+
+    def _read_base_u64(self, offset: int) -> int:
+        return struct.unpack(
+            "<Q", self._context.layers[self._base_layer].read(offset, 8)
+        )[0]
+
+    def _read_module_strings(self) -> Dict[int, str]:
+        base_layer = self._context.layers[self._base_layer]
+        string_offset = int(self._secondary.StringTableOffset)
+        string_size = int(self._secondary.StringTableSize)
+        strings: Dict[int, str] = {}
+
+        cursor = string_offset
+        string_end = min(string_offset + string_size, base_layer.maximum_address + 1)
+        while cursor + self._u32_struct.size <= string_end:
+            length = self._read_base_u32(cursor)
+            if length == 0 or length > 0x1000:
+                break
+
+            string_data_offset = cursor + self._u32_struct.size
+            string_data_size = length * 2
+            if string_data_offset + string_data_size > string_end:
+                break
+
+            raw_string = base_layer.read(string_data_offset, string_data_size)
+            strings[cursor] = raw_string.decode("utf-16le", errors="replace")
+
+            cursor += (self._u32_struct.size + string_data_size + 2 + 7) & ~7
+
+        return strings
+
+    def get_mini_kernel_module_count(self) -> int:
+        return int(self._secondary.ModuleCount)
+
+    def iter_mini_kernel_modules(self) -> Iterable[Tuple[int, int, int, str, int, int]]:
+        """Lists modules from the mini kernel dump secondary module table.
+
+        Returns tuples of table offset, image base, image size, path, checksum,
+        and timestamp.  This table is stored in the dump file itself and does
+        not require kernel symbols.
+
+        Each module entry is 0x90 bytes with the following layout:
+          +0x00: u32  PathOffset (into string table)
+          +0x38: u64  ImageBase
+          +0x48: u64  ImageSize
+          +0x80: u32  CheckSum
+          +0x88: u32  TimeDateStamp
+        """
+
+        base_layer = self._context.layers[self._base_layer]
+        module_table_offset = int(self._secondary.ModuleTableOffset)
+        module_count = self.get_mini_kernel_module_count()
+        strings = self._read_module_strings()
+
+        for index in range(module_count):
+            entry_offset = module_table_offset + index * self._module_entry_size
+            if (
+                entry_offset + self._module_entry_size
+                > base_layer.maximum_address + 1
+            ):
+                break
+
+            path_offset = self._read_base_u32(entry_offset)
+            image_base = self._read_base_u64(entry_offset + 0x38)
+            image_size = self._read_base_u64(entry_offset + 0x48)
+            checksum = self._read_base_u32(entry_offset + 0x80)
+            timestamp = self._read_base_u32(entry_offset + 0x88)
+            path = strings.get(path_offset, "")
+
+            if path and image_base and image_size:
+                yield entry_offset, image_base, image_size, path, checksum, timestamp
+
+    @staticmethod
+    def mini_kernel_module_name(path: str) -> str:
+        return path.replace("/", "\\").rsplit("\\", 1)[-1]
+
+    def find_mini_kernel_module(
+        self, address: int
+    ) -> Optional[Tuple[int, int, int, str, int, int]]:
+        for module in self.iter_mini_kernel_modules():
+            _entry_offset, image_base, image_size, _path, _checksum, _timestamp = module
+            if image_base <= address < image_base + image_size:
+                return module
+        return None
+
+    def get_mini_kernel_bugcheck_data_range(self) -> Tuple[int, int]:
+        return (
+            int(self._secondary.BugCheckDataOffset),
+            int(self._secondary.BugCheckDataSize),
+        )
+
+    def iter_mini_kernel_module_references(
+        self, module_filter: Optional[str] = None
+    ) -> Iterable[Tuple[int, int, int, str, int]]:
+        """Scans captured virtual ranges for qwords that point into modules.
+
+        Returns tuples of source virtual address, referenced address, module
+        base, module path, and displacement.  This is intentionally symbol-free:
+        mini dumps often lack the kernel CodeView record, but the module table
+        still allows useful module+offset triage.
+        """
+
+        modules = list(self.iter_mini_kernel_modules())
+        module_filter_lower = module_filter.lower() if module_filter else None
+
+        for segment_address, _file_offset, length, _mapped_length in self._segments:
+            try:
+                segment_data = self.read(segment_address, length)
+            except exceptions.InvalidAddressException:
+                continue
+
+            for offset in range(0, len(segment_data) - 7, 8):
+                source_address = segment_address + offset
+                candidate = struct.unpack_from("<Q", segment_data, offset)[0]
+
+                for (
+                    _entry_offset,
+                    image_base,
+                    image_size,
+                    path,
+                    _checksum,
+                    _timestamp,
+                ) in modules:
+                    if image_base <= candidate < image_base + image_size:
+                        module_name = self.mini_kernel_module_name(path)
+                        if (
+                            module_filter_lower
+                            and module_filter_lower not in module_name.lower()
+                            and module_filter_lower not in path.lower()
+                        ):
+                            continue
+                        yield (
+                            source_address,
+                            candidate,
+                            image_base,
+                            path,
+                            candidate - image_base,
+                        )
+                        break
+
+    @classmethod
+    def check_header(
+        cls, base_layer: interfaces.layers.DataLayerInterface, offset: int = 0
+    ) -> Tuple[int, int]:
+        try:
+            header_data = base_layer.read(offset, cls._magic_struct.size)
+        except exceptions.InvalidAddressException:
+            raise WindowsCrashDumpFormatException(
+                base_layer.name, f"Crashdump header not found at offset {offset}"
+            )
+
+        signature, validdump = cls._magic_struct.unpack(header_data)
+        if signature != cls.SIGNATURE:
+            raise WindowsCrashDumpFormatException(
+                base_layer.name,
+                f"Bad signature 0x{signature:x} at file offset 0x{offset:x}",
+            )
+        if validdump != cls.VALIDDUMP:
+            raise WindowsCrashDumpFormatException(
+                base_layer.name,
+                f"Invalid dump 0x{validdump:x} at file offset 0x{offset:x}",
+            )
+        return signature, validdump
+
+    def _load_segments(self) -> None:
+        base_layer = self._context.layers[self._base_layer]
+        table_offset = int(self._secondary.RangeTableOffset)
+        table_count = int(self._secondary.RangeTableCount)
+        self.range_table_offset = table_offset
+        self.range_table_count = table_count
+
+        if table_offset == 0 or table_count == 0:
+            raise WindowsCrashDumpFormatException(
+                self.name, "Mini kernel dump captured range table is empty"
+            )
+
+        max_file_offset = base_layer.maximum_address + 1
+        segments = []
+        for index in range(table_count):
+            entry_offset = table_offset + index * self._entry_struct.size
+            try:
+                virtual_address, packed = self._entry_struct.unpack(
+                    base_layer.read(entry_offset, self._entry_struct.size)
+                )
+            except exceptions.InvalidAddressException:
+                break
+
+            file_offset = packed & 0xFFFFFFFF
+            length = packed >> 32
+            if (
+                virtual_address == 0
+                or file_offset == 0
+                or length == 0
+                or file_offset >= max_file_offset
+            ):
+                continue
+
+            length = min(length, max_file_offset - file_offset)
+            segments.append((virtual_address, file_offset, length, length))
+
+        if not segments:
+            raise WindowsCrashDumpFormatException(
+                self.name, "No captured mini kernel dump ranges found"
+            )
+
+        self._segments = sorted(segments)
+
+
+class MiniKernelDumpMixin:
+    """Mixin for plugins that require a WindowsMiniKernelDump64Layer."""
+
+    @staticmethod
+    def _get_crash_layer(
+        context: interfaces.context.ContextInterface,
+        primary_layer_name: Optional[str] = None,
+    ) -> Optional[WindowsMiniKernelDump64Layer]:
+        if primary_layer_name:
+            layer = context.layers.get(primary_layer_name)
+            if isinstance(layer, WindowsMiniKernelDump64Layer):
+                return layer
+
+        for layer in context.layers.values():
+            if isinstance(layer, WindowsMiniKernelDump64Layer):
+                return layer
+
+        return None
+
+
 class WindowsCrashDumpStacker(interfaces.automagic.StackerLayerInterface):
     stack_order = 11
 
@@ -275,7 +590,11 @@ class WindowsCrashDumpStacker(interfaces.automagic.StackerLayerInterface):
         layer_name: str,
         progress_callback: constants.ProgressCallback = None,
     ) -> Optional[interfaces.layers.DataLayerInterface]:
-        for layer in [WindowsCrashDump32Layer, WindowsCrashDump64Layer]:
+        for layer in [
+            WindowsCrashDump32Layer,
+            WindowsCrashDump64Layer,
+            WindowsMiniKernelDump64Layer,
+        ]:
             try:
                 layer.check_header(context.layers[layer_name])
                 new_name = context.layers.free_layer_name(layer.__name__)

--- a/volatility3/framework/plugins/windows/crashcontext.py
+++ b/volatility3/framework/plugins/windows/crashcontext.py
@@ -1,0 +1,104 @@
+# This file is Copyright 2026 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List
+
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.layers import crash
+
+vollog = logging.getLogger(__name__)
+
+
+class CrashContext(interfaces.plugins.PluginInterface, crash.MiniKernelDumpMixin):
+    """Reports Windows mini kernel dump crash context without kernel symbols."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    BUGCHECK_NAMES = {
+        0x1E: "KMODE_EXCEPTION_NOT_HANDLED",
+        0x3B: "SYSTEM_SERVICE_EXCEPTION",
+        0x7E: "SYSTEM_THREAD_EXCEPTION_NOT_HANDLED",
+        0x9F: "DRIVER_POWER_STATE_FAILURE",
+        0xA: "IRQL_NOT_LESS_OR_EQUAL",
+        0xD1: "DRIVER_IRQL_NOT_LESS_OR_EQUAL",
+        0xEA: "THREAD_STUCK_IN_DEVICE_DRIVER",
+        0xEF: "CRITICAL_PROCESS_DIED",
+        0xF7: "DRIVER_OVERRAN_STACK_BUFFER",
+        0x133: "DPC_WATCHDOG_VIOLATION",
+        0x139: "KERNEL_SECURITY_CHECK_FAILURE",
+        0x13A: "KERNEL_MODE_HEAP_CORRUPTION",
+    }
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.TranslationLayerRequirement(
+                name="primary",
+                description="Memory layer for the kernel",
+                architectures=["Intel64"],
+            ),
+        ]
+
+    @staticmethod
+    def _exception_code(header: interfaces.objects.ObjectInterface) -> int:
+        return int(header.Exception.ExceptionCode) & 0xFFFFFFFF
+
+    def _generator(self):
+        crash_layer = self._get_crash_layer(
+            self.context, self.config.get("primary", None)
+        )
+        if crash_layer is None:
+            vollog.error("This plugin requires a Windows mini kernel crash dump")
+            raise ValueError("This plugin requires a Windows mini kernel crash dump")
+
+        header = crash_layer.get_header()
+        bugcheck_code = int(header.BugCheckCode)
+        bugcheck_params = [int(param) for param in header.BugCheckCodeParameter]
+        bugcheck_data_offset, bugcheck_data_size = (
+            crash_layer.get_mini_kernel_bugcheck_data_range()
+        )
+
+        rows = [
+            ("BugCheckCode", f"{bugcheck_code:#x}"),
+            (
+                "BugCheckName",
+                self.BUGCHECK_NAMES.get(bugcheck_code, "UNKNOWN"),
+            ),
+            (
+                "BugCheckParameters",
+                ", ".join(f"{parameter:#x}" for parameter in bugcheck_params),
+            ),
+            ("ExceptionCode", f"{self._exception_code(header):#x}"),
+            (
+                "ExceptionAddress",
+                f"{int(header.Exception.ExceptionAddress):#x}",
+            ),
+            (
+                "KdDebuggerDataBlock",
+                f"{int(header.KdDebuggerDataBlock):#x}",
+            ),
+            (
+                "PsLoadedModuleList",
+                f"{int(header.PsLoadedModuleList):#x}",
+            ),
+            ("CapturedRangeCount", str(crash_layer.range_table_count)),
+            ("ModuleCount", str(crash_layer.get_mini_kernel_module_count())),
+            ("BugCheckDataOffset", f"{bugcheck_data_offset:#x}"),
+            ("BugCheckDataSize", f"{bugcheck_data_size:#x}"),
+        ]
+
+        for key, value in rows:
+            yield (0, (key, value))
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Key", str),
+                ("Value", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -36,8 +36,10 @@ class Crashinfo(interfaces.plugins.PluginInterface):
             dump_type = "Full Dump (0x1)"
         elif header.DumpType == 0x5:
             dump_type = "Bitmap Dump (0x5)"
+        elif header.DumpType == 0x4:
+            dump_type = "Mini Kernel Dump (0x4)"
         else:
-            # this should never happen since the crash layer only accepts 0x1 and 0x5
+            # this should never happen since the crash layers only accept known dump types
             dump_type = f"Unknown/Unsupported ({header.DumpType:#x})"
 
         if header.DumpType == 0x5:
@@ -77,7 +79,10 @@ class Crashinfo(interfaces.plugins.PluginInterface):
         crash_layer = None
         for layer_name in self._context.layers:
             layer = self._context.layers[layer_name]
-            if isinstance(layer, crash.WindowsCrashDump32Layer):
+            if isinstance(
+                layer,
+                (crash.WindowsCrashDump32Layer, crash.WindowsMiniKernelDump64Layer),
+            ):
                 crash_layer = layer
                 break
 

--- a/volatility3/framework/plugins/windows/crashmodules.py
+++ b/volatility3/framework/plugins/windows/crashmodules.py
@@ -1,0 +1,73 @@
+# This file is Copyright 2026 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List
+
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.layers import crash
+from volatility3.framework.renderers import format_hints
+
+vollog = logging.getLogger(__name__)
+
+
+class CrashModules(interfaces.plugins.PluginInterface, crash.MiniKernelDumpMixin):
+    """Lists modules recorded in a Windows mini kernel dump."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.TranslationLayerRequirement(
+                name="primary",
+                description="Memory layer for the kernel",
+                architectures=["Intel64"],
+            ),
+        ]
+
+    def _generator(self):
+        crash_layer = self._get_crash_layer(
+            self.context, self.config.get("primary", None)
+        )
+        if crash_layer is None:
+            vollog.error("This plugin requires a Windows mini kernel crash dump")
+            raise ValueError("This plugin requires a Windows mini kernel crash dump")
+
+        for (
+            entry_offset,
+            image_base,
+            image_size,
+            path,
+            checksum,
+            timestamp,
+        ) in crash_layer.iter_mini_kernel_modules():
+            yield (
+                0,
+                (
+                    format_hints.Hex(entry_offset),
+                    format_hints.Hex(image_base),
+                    format_hints.Hex(image_size),
+                    crash_layer.mini_kernel_module_name(path),
+                    path,
+                    format_hints.Hex(checksum),
+                    format_hints.Hex(timestamp),
+                ),
+            )
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Offset", format_hints.Hex),
+                ("Base", format_hints.Hex),
+                ("Size", format_hints.Hex),
+                ("Name", str),
+                ("Path", str),
+                ("CheckSum", format_hints.Hex),
+                ("TimeDateStamp", format_hints.Hex),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/plugins/windows/crashstack.py
+++ b/volatility3/framework/plugins/windows/crashstack.py
@@ -1,0 +1,95 @@
+# This file is Copyright 2026 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import logging
+from typing import List, Optional, Set, Tuple
+
+from volatility3.framework import interfaces, renderers
+from volatility3.framework.configuration import requirements
+from volatility3.framework.layers import crash
+from volatility3.framework.renderers import format_hints
+
+vollog = logging.getLogger(__name__)
+
+
+class CrashStack(interfaces.plugins.PluginInterface, crash.MiniKernelDumpMixin):
+    """Scans a Windows mini kernel dump for module-relative stack references."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.TranslationLayerRequirement(
+                name="primary",
+                description="Memory layer for the kernel",
+                architectures=["Intel64"],
+            ),
+            requirements.StringRequirement(
+                name="name",
+                description="module name/sub string",
+                optional=True,
+                default=None,
+            ),
+            requirements.IntRequirement(
+                name="limit",
+                description="maximum number of references to show",
+                optional=True,
+                default=256,
+            ),
+        ]
+
+    def _generator(self):
+        crash_layer = self._get_crash_layer(
+            self.context, self.config.get("primary", None)
+        )
+        if crash_layer is None:
+            vollog.error("This plugin requires a Windows mini kernel crash dump")
+            raise ValueError("This plugin requires a Windows mini kernel crash dump")
+
+        seen: Set[Tuple[int, int]] = set()
+        emitted = 0
+        limit = self.config.get("limit", 256)
+
+        for (
+            source,
+            target,
+            module_base,
+            path,
+            displacement,
+        ) in crash_layer.iter_mini_kernel_module_references(self.config.get("name")):
+            dedupe_key = (source, target)
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+
+            yield (
+                0,
+                (
+                    format_hints.Hex(source),
+                    format_hints.Hex(target),
+                    crash_layer.mini_kernel_module_name(path),
+                    format_hints.Hex(module_base),
+                    format_hints.Hex(displacement),
+                    path,
+                ),
+            )
+
+            emitted += 1
+            if limit and emitted >= limit:
+                break
+
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("Source", format_hints.Hex),
+                ("Target", format_hints.Hex),
+                ("Module", str),
+                ("ModuleBase", format_hints.Hex),
+                ("Displacement", format_hints.Hex),
+                ("Path", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/framework/symbols/windows/crash_mini.json
+++ b/volatility3/framework/symbols/windows/crash_mini.json
@@ -1,0 +1,123 @@
+{
+  "symbols": {
+  },
+  "user_types": {
+    "_MINI_KERNEL_DUMP_SECONDARY": {
+      "fields": {
+        "StackOffset": {
+          "offset": 12,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long long"
+          }
+        },
+        "BugCheckDataOffset": {
+          "offset": 40,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "BugCheckDataSize": {
+          "offset": 44,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "ModuleTableOffset": {
+          "offset": 48,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "ModuleCount": {
+          "offset": 52,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "StringTableOffset": {
+          "offset": 56,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "StringTableSize": {
+          "offset": 60,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "RangeTableOffset": {
+          "offset": 120,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "RangeTableCount": {
+          "offset": 124,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        }
+      },
+      "kind": "struct",
+      "size": 128
+    }
+  },
+  "enums": {
+  },
+  "base_types": {
+    "unsigned char": {
+      "endian": "little",
+      "kind": "char",
+      "signed": false,
+      "size": 1
+    },
+    "unsigned short": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 2
+    },
+    "long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": true,
+      "size": 4
+    },
+    "unsigned long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 4
+    },
+    "long long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": true,
+      "size": 8
+    },
+    "unsigned long long": {
+      "endian": "little",
+      "kind": "int",
+      "signed": false,
+      "size": 8
+    }
+  },
+  "metadata": {
+    "producer": {
+      "version": "0.0.1",
+      "name": "kreijstal-by-hand",
+      "datetime": "2026-04-29T00:00:00"
+    },
+    "format": "6.2.0"
+  }
+}


### PR DESCRIPTION
- New WindowsMiniKernelDump64Layer for parsing mini kernel dumps (PAGEDU64)
- ISF symbol table (crash_mini.json) for the secondary dump header
- MiniKernelDumpMixin shared by all mini-dump plugins
- Plugins: crashcontext, crashmodules, crashstack (work without kernel symbols)
- crashinfo: recognize dump type 0x4 (mini kernel dump)
- pdbscan: scan WindowsMiniKernelDump64Layer for kernel PDB signatures