### PR TITLE
Layers: remove duplication in LeechCoreFile

### DIFF
--- a/volatility3/framework/layers/leechcore.py
+++ b/volatility3/framework/layers/leechcore.py
@@ -32,7 +32,6 @@ if HAS_LEECHCORE:
             self._cursor = 0
             self._handle = None
             self._pad = True
-            self._chunk_size = 0x1000000
 
         @property
         def maxaddr(self):


### PR DESCRIPTION
Super simple one. 

I spotted some duplication of `_chunk_size` in the init for the leechcore layer.

```
        def __init__(self, leechcore_device):
            self._chunk_size = 0x1000000
            self._device = leechcore_device
            self._cursor = 0
            self._handle = None
            self._pad = True
            self._chunk_size = 0x1000000
```

This just removes one of the lines. 

Thanks
:fox_face: 