### PR TITLE
Add Kernel Bitmap Dump (Type=6) Support

### DIFF
--- a/volatility3/framework/layers/crash.py
+++ b/volatility3/framework/layers/crash.py
@@ -127,7 +127,7 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
                 )
                 offset += run.PageCount
 
-        elif self.dump_type == 0x05:
+        elif self.dump_type == 0x05 or self.dump_type == 0x06:
             summary_header = self.get_summary_header()
             seg_first_bit = None  # First bit in a run
             seg_first_offset = 0  # File offset of first bit
@@ -254,14 +254,16 @@ class WindowsCrashDump32Layer(segmented.SegmentedLayer):
 
 class WindowsCrashDump64Layer(WindowsCrashDump32Layer):
     """A Windows crash format TranslationLayer.
-    This TranslationLayer supports Microsoft complete memory dump files.
-    It currently does not support kernel or small memory dump files.
+    This TranslationLayer supports Microsoft complete memory dump files
+    (DumpType=1), full bitmap dump files (DumpType=5), and kernel bitmap
+    dump files (DumpType=6). It does not support legacy summary kernel
+    dumps (DumpType=2) or small memory (triage) dumps (DumpType=4).
     """
 
     VALIDDUMP = 0x34365544
     crashdump_json = "crash64"
     dump_header_name = "_DUMP_HEADER64"
-    supported_dumptypes = [0x1, 0x05]
+    supported_dumptypes = [0x1, 0x05, 0x06]
     headerpages = 2
 
 

--- a/volatility3/framework/plugins/windows/cmdscan.py
+++ b/volatility3/framework/plugins/windows/cmdscan.py
@@ -152,6 +152,7 @@ class CmdScan(interfaces.plugins.PluginInterface):
 
             sections = cls.get_filtered_vads(conhost_proc)
             found_history_for_proc = False
+            command_history = None
             # scan for potential _COMMAND_HISTORY structures by using the CommandHistorySize
             for max_history_value in max_history:
                 max_history_bytes = struct.pack("H", max_history_value)

--- a/volatility3/framework/plugins/windows/crashinfo.py
+++ b/volatility3/framework/plugins/windows/crashinfo.py
@@ -36,11 +36,13 @@ class Crashinfo(interfaces.plugins.PluginInterface):
             dump_type = "Full Dump (0x1)"
         elif header.DumpType == 0x5:
             dump_type = "Bitmap Dump (0x5)"
+        elif header.DumpType == 0x6:
+            dump_type = "Kernel Bitmap Dump (0x6)"
         else:
-            # this should never happen since the crash layer only accepts 0x1 and 0x5
+            # this should never happen since the crash layer only accepts 0x1, 0x5, and 0x6
             dump_type = f"Unknown/Unsupported ({header.DumpType:#x})"
 
-        if header.DumpType == 0x5:
+        if header.DumpType in (0x5, 0x6):
             summary_header = layer.get_summary_header()
             bitmap_header_size = format_hints.Hex(summary_header.HeaderSize)
             bitmap_size = format_hints.Hex(summary_header.BitmapSize)

--- a/volatility3/framework/plugins/windows/memmap.py
+++ b/volatility3/framework/plugins/windows/memmap.py
@@ -57,6 +57,23 @@ class Memmap(interfaces.plugins.PluginInterface):
                 )
                 continue
 
+            # Kernel bitmap dumps (DumpType=6) may or may not include user-space
+            # physical pages depending on how the dump was created.  When user pages
+            # are absent, page tables are still present as kernel data so VA→PA
+            # translation succeeds, but every physical frame lookup fails — iterating
+            # O(mapped user pages) times at 4 KB/step is extremely slow.  Probe the
+            # PEB (a guaranteed user-space VA) to decide cheaply: if its physical
+            # backing is absent, the dump has no user pages and we can skip the walk.
+            phys_layer = self.context.layers.get(proc_layer._base_layer)
+            if getattr(phys_layer, "dump_type", None) == 6:
+                peb_va = int(proc.Peb)
+                if peb_va and not proc_layer.is_valid(peb_va):
+                    vollog.debug(
+                        f"Process {pid}: skipping memmap walk on kernel bitmap dump"
+                        f" (DumpType=6, user pages absent)"
+                    )
+                    continue
+
             if self.config["dump"]:
                 file_handle = self.open(f"pid.{pid}.dmp")
             else:

--- a/volatility3/framework/plugins/windows/mftscan.py
+++ b/volatility3/framework/plugins/windows/mftscan.py
@@ -126,6 +126,8 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             mft_flag = mft_record.Flags.lookup()
         except ValueError:
             mft_flag = hex(mft_record.Flags)
+        except exceptions.InvalidAddressException:
+            return
 
         # Standard Information Attribute
         try:
@@ -162,6 +164,8 @@ class MFTScan(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             mft_flag = mft_record.Flags.lookup()
         except ValueError:
             mft_flag = hex(mft_record.Flags)
+        except exceptions.InvalidAddressException:
+            return
 
         # File Name Attribute
         try:


### PR DESCRIPTION
Windows kernel bitmap dumps (DumpType=6) are becoming more and more prevalent, especially considering [you can request them directly from Task Manager now](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/task-manager-live-dump). 

DumpType=6 is encoded identically to DumpType=5 on disk.  The only difference is semantic — the kernel bitmap covers kernel pages only (and optionally user pages), where DumpType=5 typically covers everything. Adding `0x06` to the supported types list and extending the bitmap-parsing branch to handle it was all the layer needed.

Four plugins needed follow-up fixes once the dump actually loads:

-  `crashinfo` was showing "Unknown/Unsupported (0x6)" and leaving the bitmap statistics fields (HeaderSize, BitmapSize, Pages) as N/A

-  `memmap` would hang for many minutes on kernel-only dumps — page tables are kernel data, so VA-to-PA translation succeeds for user-space addresses, but the physical pages themselves aren't in the dump. Walking O(millions) of dead-end lookups per process was the result. A single PEB validity check before the walk detects the situation and skips the process cleanly. 

- `mftscan` would crash when a found MFT record signature straddled a present page and an absent adjacent page; the resulting `InvalidAddressException` on the `Flags` field was unhandled.

- `cmdscan` had a latent `UnboundLocalError` that wasn't being caught, that could surface when user-space heap is absent.


I tested this change against two Type 6 dumps, one with user pages, another without.  They were tested against all of the applicable windows plugins, and produced expected results