### PR TITLE
netstat: add cycle detection to Next pointer walk

### DIFF
--- a/volatility3/framework/plugins/windows/netstat.py
+++ b/volatility3/framework/plugins/windows/netstat.py
@@ -220,7 +220,16 @@ class NetStat(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
 
             # if the same port is used on different interfaces multiple objects are created
             # those can be found by following the pointer within the object's `Next` field until it is empty
+            seen_addresses = set()
             while next_obj_address:
+                if next_obj_address in seen_addresses:
+                    vollog.warning(
+                        "Cycle detected in Next pointer at %#x, stopping walk",
+                        next_obj_address,
+                    )
+                    return
+                seen_addresses.add(next_obj_address)
+
                 try:
                     curr_obj = context.object(
                         obj_name,


### PR DESCRIPTION
## Summary

The `enumerate_structures_by_port` method walks a singly-linked list of network objects via the `Next` field without checking for cycles. A memory dump containing a self-referential `Next` pointer causes the plugin to loop indefinitely.

This adds a `seen_addresses` set to detect and break cycles, consistent with existing cycle detection patterns in the codebase:
- `LIST_ENTRY.to_list()` uses a `seen` set
- `pidhashtable._walk_upid()` uses `seen_upids`
- `pagecache._walk_dentry()` uses `seen_dentries`

## Change

One file, +9 lines. A `seen_addresses` set tracks visited pointer values. If a previously seen address is encountered, the walk logs a warning and stops.