### PR TITLE
fix ClassRequirement to import modules via importlib

### DIFF
--- a/volatility3/framework/interfaces/configuration.py
+++ b/volatility3/framework/interfaces/configuration.py
@@ -1,7 +1,7 @@
 # This file is Copyright 2019 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
 #
-"""The configuration module contains classes and functions for interacting with
+"""The configuration module_name contains classes and functions for interacting with
 the configuration and requirement trees.
 
 Volatility plugins can specify a list of requirements (which may have
@@ -14,9 +14,9 @@ those requirements.  Where the user does not provide sufficient
 configuration values, automagic modules may extend the configuration
 tree themselves.
 """
-
 import collections.abc
 import copy
+import importlib
 import json
 import logging
 import random
@@ -36,6 +36,7 @@ from typing import (
     Tuple,
     Set,
 )
+
 
 from volatility3 import classproperty, framework
 from volatility3.framework import constants, interfaces
@@ -535,10 +536,19 @@ class ClassRequirement(RequirementInterface):
         self._cls = None
         if value is not None and isinstance(value, str):
             if "." in value:
-                # TODO: consider importing the prefix
-                module = sys.modules.get(value[: value.rindex(".")], None)
+                module_name = value[: value.rindex(".")]
                 class_name = value[value.rindex(".") + 1 :]
-                if hasattr(module, class_name):
+                module = sys.modules.get(module_name, None)
+                if module is None:
+                    try:
+                        module = importlib.import_module(module_name)
+                    except ImportError:
+                        vollog.log(
+                            constants.LOGLEVEL_V,
+                            f"ImportError - Could not import module {module_name} for ClassRequirement: {repr(value)}",
+                        )
+                        module = None
+                if module is not None and hasattr(module, class_name):
                     self._cls = getattr(module, class_name)
             else:
                 if value in globals():


### PR DESCRIPTION
## What this fixes
Fixes a TODO comment in `ClassRequirement.unsatisfied()` 
(in `volatility3/framework/interfaces/configuration.py`).

## The problem
This function tries to find a Python class based on a string name 
(e.g. "mymodule.MyClass"). It only worked if that module was 
**already imported** somewhere else in the program. If the module 
hadn't been imported yet, it just returned `None` — even if the 
module and class were completely valid.

## The fix
Added a fallback: if the module isn't already loaded, the code now 
tries to import it directly using `importlib.import_module()`. 
If the import fails (invalid module name), it's caught safely so 
the program doesn't crash.


## How I tested it?
I tested this manually in a Python shell:
1. `json.decoder` is normally already loaded by Python (since it's 
   part of the standard library). I manually forced it out of 
   Python's list of loaded modules (`sys.modules`), to recreate the 
   situation where a module hasn't been imported yet.

2. I called the `unsatisfied()` function with the string 
   `"json.decoder.JSONDecoder"`.
   
3. Before my fix: the function couldn't find the class, and 
   returned `None`. This confirmed the bug.
   
4. After applying my fix: I ran the exact same steps again. This 
   time, the function successfully imported the module on its own 
   and correctly found the `JSONDecoder` class.
   
5. I also tested with a fake module name that doesn't exist, to 
   make sure the code doesn't crash. It handled the error properly 
   without breaking anything.