### PR TITLE
Replace crash with graceful error handling in ListRequirement.unsatis…

### DIFF
--- a/volatility3/framework/configuration/requirements.py
+++ b/volatility3/framework/configuration/requirements.py
@@ -148,8 +148,11 @@ class ListRequirement(interfaces.configuration.RequirementInterface):
         elif value is None:
             context.config[config_path] = []
         if not isinstance(value, list):
-            # TODO: Check this is the correct response for an error
-            raise TypeError(f"Unexpected config value found: {repr(value)}")
+            vollog.log(
+                constants.LOGLEVEL_V,
+                f"TypeError - Unexpected config value found, expected list: {repr(value)}",
+            )
+            return {config_path: self}
         if not (self.min_elements <= len(value)):
             vollog.log(
                 constants.LOGLEVEL_V,


### PR DESCRIPTION
## What this fixes

There's an old TODO in `ListRequirement.unsatisfied()` 
(`volatility3/framework/configuration/requirements.py`) about whether raising a TypeError is the right way to handle an invalid config value.

## The problem

Most checks in this method fail gracefully — they log a message and return, letting the program continue safely. But one check (when the value isn't a list at all) instead raises a `TypeError`, which crashes the whole program. It seemed inconsistent with every other check right next to it.

## The fix

Replaced the `raise TypeError(...)` with the same graceful pattern used elsewhere in the method — log it, then return `{config_path: self}` to mark the requirement as unsatisfied, instead of crashing.

## How I tested it

I tested it manually with a small script: passed in a string where a list was expected, and confirmed that before the fix it raised a TypeError, and after the fix it returned a normal "unsatisfied" result without crashing — same as the other checks in the function.

Happy to add a formal test if that's preferred.