### PR TITLE
Feature/windows clipboard plugin

### DIFF
--- a/volatility3/framework/symbols/windows/extensions/gui.py
+++ b/volatility3/framework/symbols/windows/extensions/gui.py
@@ -304,7 +304,7 @@ class GUIExtensions(interfaces.configuration.VersionableInterface):
 
     # This is copy/paste from UNICODE_STRING in `symbols/windows/extensions/__init__.py`
     # The versioning of modules would get very ugly if we let different modules share implementations
-    # across different data structure
+    # across different data structures
     class LARGE_UNICODE_STRING(objects.StructType):
         """A class for Windows unicode string structures."""
 
@@ -324,36 +324,10 @@ class GUIExtensions(interfaces.configuration.VersionableInterface):
                 encoding="utf16",
             )
 
-    class tagCLIPDATA(objects.StructType):
-        """A class for clipboard data objects stored in Windows memory"""
-
-        def get_data(self) -> Optional[bytes]:
-            """Returns the raw clipboard data as bytes"""
-            try:
-                size = self.cbData
-                if size == 0 or size > 0x100000:
-                    return None
-                return bytes(bytearray(self.abData))
-            except exceptions.InvalidAddressException:
-                return None
-
-        def get_text(self, fmt: str) -> Optional[str]:
-            """Returns clipboard data as readable text if format is text-based"""
-            data = self.get_data()
-            if data is None:
-                return None
-            try:
-                if "UNICODE" in fmt:
-                    return data.decode("utf-16-le", errors="replace").rstrip("\x00")
-                else:
-                    return data.decode("latin-1", errors="replace").rstrip("\x00")
-            except Exception:
-                return None
-
     class tagCLIP(objects.StructType):
         """A class for clipboard format entries (one per clipboard item)"""
 
-        # Common Windows clipboard format constants
+        # TODO: Extend clipboard format mapping if needed.
         CF_FORMATS = {
             1: "CF_TEXT",
             2: "CF_BITMAP",
@@ -375,12 +349,52 @@ class GUIExtensions(interfaces.configuration.VersionableInterface):
             except exceptions.InvalidAddressException:
                 return "CF_UNKNOWN"
 
+    class tagCLIPDATA(objects.StructType):
+        """A class for clipboard data objects stored in Windows memory"""
+
+        def get_data(self) -> Optional[bytes]:
+            """Returns the raw clipboard data as bytes"""
+
+            # TODO: Verify abData consistency; future Windows may change tagCLIPDATA layout.
+            try:
+                size = int(self.cbData)
+
+                # TODO: Improve clipboard size validation if needed.
+                MAX_CLIPBOARD_SIZE = 50 * 1024 * 1024  # 50 MiB
+                if size == 0 or size > MAX_CLIPBOARD_SIZE:
+                    return None
+
+                layer = self._context.layers[self.vol.layer_name]
+                return layer.read(self.abData.vol.offset, size, pad=True)
+
+            except exceptions.InvalidAddressException:
+                return None
+
+        def get_text(self, fmt: str) -> Optional[str]:
+            """Returns clipboard data as readable text if format is text-based"""
+            data = self.get_data()
+
+            if data is None:
+                return None
+
+            # TODO: Extend support for more clipboard formats as needed.
+
+            if fmt == "CF_UNICODETEXT":
+                return data.decode("utf-16-le", errors="replace").rstrip("\x00")
+            elif fmt in ("CF_TEXT", "CF_OEMTEXT"):
+                return data.decode("latin-1", errors="replace").rstrip("\x00")
+
+            elif fmt == "CF_HDROP":
+                # File paths stored as null-separated UTF-16 list
+                return data.decode("utf-16-le", errors="replace").rstrip("\x00")
+            return None
 
     class_types = {
         "tagWINDOWSTATION": tagWINDOWSTATION,
         "tagDESKTOP": tagDESKTOP,
         "tagWND": tagWND,
         "_LARGE_UNICODE_STRING": LARGE_UNICODE_STRING,
+        # Clipboard plugin extensions
         "tagCLIPDATA": tagCLIPDATA,
         "tagCLIP": tagCLIP,
     }

--- a/volatility3/framework/symbols/windows/extensions/gui.py
+++ b/volatility3/framework/symbols/windows/extensions/gui.py
@@ -381,4 +381,6 @@ class GUIExtensions(interfaces.configuration.VersionableInterface):
         "tagDESKTOP": tagDESKTOP,
         "tagWND": tagWND,
         "_LARGE_UNICODE_STRING": LARGE_UNICODE_STRING,
+        "tagCLIPDATA": tagCLIPDATA,
+        "tagCLIP": tagCLIP,
     }

--- a/volatility3/framework/symbols/windows/extensions/gui.py
+++ b/volatility3/framework/symbols/windows/extensions/gui.py
@@ -304,7 +304,7 @@ class GUIExtensions(interfaces.configuration.VersionableInterface):
 
     # This is copy/paste from UNICODE_STRING in `symbols/windows/extensions/__init__.py`
     # The versioning of modules would get very ugly if we let different modules share implementations
-    # across different data structures
+    # across different data structure
     class LARGE_UNICODE_STRING(objects.StructType):
         """A class for Windows unicode string structures."""
 
@@ -323,6 +323,58 @@ class GUIExtensions(interfaces.configuration.VersionableInterface):
                 errors="replace",
                 encoding="utf16",
             )
+
+    class tagCLIPDATA(objects.StructType):
+        """A class for clipboard data objects stored in Windows memory"""
+
+        def get_data(self) -> Optional[bytes]:
+            """Returns the raw clipboard data as bytes"""
+            try:
+                size = self.cbData
+                if size == 0 or size > 0x100000:
+                    return None
+                return bytes(bytearray(self.abData))
+            except exceptions.InvalidAddressException:
+                return None
+
+        def get_text(self, fmt: str) -> Optional[str]:
+            """Returns clipboard data as readable text if format is text-based"""
+            data = self.get_data()
+            if data is None:
+                return None
+            try:
+                if "UNICODE" in fmt:
+                    return data.decode("utf-16-le", errors="replace").rstrip("\x00")
+                else:
+                    return data.decode("latin-1", errors="replace").rstrip("\x00")
+            except Exception:
+                return None
+
+    class tagCLIP(objects.StructType):
+        """A class for clipboard format entries (one per clipboard item)"""
+
+        # Common Windows clipboard format constants
+        CF_FORMATS = {
+            1: "CF_TEXT",
+            2: "CF_BITMAP",
+            3: "CF_METAFILEPICT",
+            7: "CF_OEMTEXT",
+            8: "CF_DIB",
+            13: "CF_UNICODETEXT",
+            14: "CF_ENHMETAFILE",
+            15: "CF_HDROP",
+            16: "CF_LOCALE",
+            17: "CF_DIBV5",
+        }
+
+        def get_format_name(self) -> str:
+            """Returns the clipboard format as a human-readable string"""
+            try:
+                fmt_val = int(self.fmt)
+                return self.CF_FORMATS.get(fmt_val, f"CF_UNKNOWN({fmt_val:#x})")
+            except exceptions.InvalidAddressException:
+                return "CF_UNKNOWN"
+
 
     class_types = {
         "tagWINDOWSTATION": tagWINDOWSTATION,

--- a/volatility3/framework/symbols/windows/gui/gui-win10-10586-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-10586-x64.json
@@ -13653,18 +13653,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18043,11 +18039,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/framework/symbols/windows/gui/gui-win10-10586-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-10586-x64.json
@@ -18027,6 +18027,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-15063-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-15063-x64.json
@@ -13653,18 +13653,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18043,11 +18039,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/framework/symbols/windows/gui/gui-win10-15063-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-15063-x64.json
@@ -18027,6 +18027,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-16299-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-16299-x64.json
@@ -13653,18 +13653,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18043,11 +18039,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/framework/symbols/windows/gui/gui-win10-16299-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-16299-x64.json
@@ -18027,6 +18027,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-17134-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-17134-x64.json
@@ -18070,6 +18070,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-17134-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-17134-x64.json
@@ -13696,18 +13696,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18086,11 +18082,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/framework/symbols/windows/gui/gui-win10-17763-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-17763-x64.json
@@ -18070,6 +18070,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-17763-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-17763-x64.json
@@ -13696,18 +13696,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18086,11 +18082,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/framework/symbols/windows/gui/gui-win10-18362-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-18362-x64.json
@@ -18070,6 +18070,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-18362-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-18362-x64.json
@@ -13696,18 +13696,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18086,11 +18082,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/framework/symbols/windows/gui/gui-win10-19041-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-19041-x64.json
@@ -18070,6 +18070,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-19041-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-19041-x64.json
@@ -13696,18 +13696,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18086,11 +18082,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/framework/symbols/windows/gui/gui-win10-19577-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-19577-x64.json
@@ -18070,6 +18070,30 @@
       },
       "kind": "struct",
       "size": 6
+    },
+    "tagCLIPDATA": {
+      "kind": "struct",
+      "size": 24,
+      "fields": {
+        "cbData": {
+          "offset": 16,
+          "type": {
+            "kind": "base",
+            "name": "unsigned long"
+          }
+        },
+        "abData": {
+          "offset": 20,
+          "type": {
+            "kind": "array",
+            "count": 0,
+            "subtype": {
+              "kind": "base",
+              "name": "unsigned char"
+            }
+          }
+        }
+      }
     }
   },
   "base_types": {

--- a/volatility3/framework/symbols/windows/gui/gui-win10-19577-x64.json
+++ b/volatility3/framework/symbols/windows/gui/gui-win10-19577-x64.json
@@ -13696,18 +13696,14 @@
     "tagWINDOWSTATION": {
       "fields": {
         "pClipBase": {
+          "offset": 96,
           "type": {
+            "kind": "pointer",
             "subtype": {
-              "count": 104,
-              "subtype": {
-                "kind": "struct",
-                "name": "tagCLIP"
-              },
-              "kind": "array"
-            },
-            "kind": "pointer"
-          },
-          "offset": 96
+              "kind": "struct",
+              "name": "tagCLIP"
+            }
+          }
         },
         "dwSessionId": {
           "type": {
@@ -18086,11 +18082,11 @@
           "offset": 20,
           "type": {
             "kind": "array",
-            "count": 0,
             "subtype": {
               "kind": "base",
               "name": "unsigned char"
-            }
+            },
+            "count": 0
           }
         }
       }

--- a/volatility3/plugins/windows/clipboard.py
+++ b/volatility3/plugins/windows/clipboard.py
@@ -9,7 +9,7 @@ from typing import List
 from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
-from volatility3.plugins.windows import pslist, vadinfo
+from volatility3.plugins.windows import windowstations
 
 vollog = logging.getLogger(__name__)
 
@@ -29,132 +29,75 @@ class Clipboard(interfaces.plugins.PluginInterface):
                 architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
-                name="pslist",
-                component=pslist.PsList,
-                version=(3, 0, 0),
-            ),
-            requirements.VersionRequirement(
-                name="vadinfo",
-                component=vadinfo.VadInfo,
-                version=(2, 0, 0),
+                name="windowstations",
+                component=windowstations.WindowStations,
+                version=(1, 0, 0),
             ),
         ]
 
     def _generator(self):
-        """Scan csrss.exe VADs for clipboard data."""
+        """Walk window stations and extract clipboard data."""
         kernel_name = self.config["kernel"]
-        kernel = self.context.modules[kernel_name]
 
-        for proc in pslist.PsList.list_processes(
-            context=self.context,
-            kernel_module_name=kernel_name,
+        for winsta, station_name, session_id in windowstations.WindowStations.scan_window_stations(
+            self.context, self.config_path, kernel_name
         ):
             try:
-                proc_name = proc.ImageFileName.cast(
-                    "string",
-                    max_length=proc.ImageFileName.vol.count,
-                    errors="replace",
-                ).lower()
+                clip_count = int(winsta.cNumClipFormats)
+                if clip_count == 0 or clip_count > 512:
+                    continue
+
+                clip_array = winsta.pClipBase.dereference()
+
             except exceptions.InvalidAddressException:
+                vollog.debug(
+                    f"Could not read clipboard base for station {station_name}"
+                )
                 continue
 
-            if proc_name not in ("csrss.exe", "rdpclip.exe"):
-                continue
-
-            try:
-                proc_id = int(proc.UniqueProcessId)
-                proc_layer_name = proc.add_process_layer()
-            except exceptions.InvalidAddressException:
-                continue
-
-            proc_layer = self.context.layers[proc_layer_name]
-
-            protect_values = vadinfo.VadInfo.protect_values(
-                self.context,
-                kernel.layer_name,
-                kernel.symbol_table_name,
-            )
-
-            for vad in vadinfo.VadInfo.list_vads(proc):
+            for i in range(clip_count):
                 try:
-                    vad_start = vad.get_start()
-                    vad_size = vad.get_size()
-                    protection = vad.get_protection(
-                        protect_values,
-                        vadinfo.winnt_protections,
-                    )
-                    tag = vad.get_tag()
+                    clip = clip_array[i]
+                    fmt_name = clip.get_format_name()
+                    handle_val = int(clip.hData)
+
+                    clip_data_ptr = clip.hData.dereference()
+                    data = clip_data_ptr.get_data()
+
+                    if data is None:
+                        data_display = renderers.NotAvailableValue()
+                    else:
+                        text = clip_data_ptr.get_text(fmt_name)
+                        if text:
+                            data_display = text
+                        else:
+                            data_display = data.hex()
+
                 except exceptions.InvalidAddressException:
-                    continue
+                    fmt_name = renderers.NotAvailableValue()
+                    handle_val = 0
+                    data_display = renderers.NotAvailableValue()
 
-                if vad_size == 0 or vad_size > 0x200000:
-                    continue
+                yield (
+                    0,
+                    (
+                        session_id,
+                        station_name,
+                        fmt_name,
+                        format_hints.Hex(handle_val),
+                        data_display,
+                    ),
+                )
 
-                if protection not in (
-                    "PAGE_READWRITE",
-                    "PAGE_READONLY",
-                    "PAGE_EXECUTE_READ",
-                    "PAGE_EXECUTE_READWRITE",
-                ):
-                    continue
-
-                try:
-                    data = proc_layer.read(vad_start, vad_size, pad=True)
-                except exceptions.InvalidAddressException:
-                    continue
-
-                if not data:
-                    continue
-
-                # Try UTF-16-LE (most Windows clipboard text)
-                try:
-                    text = data.decode("utf-16-le", errors="ignore")
-                    text = text.strip("\x00").strip()
-                    if len(text) >= 4:
-                        printable = "".join(
-                            c for c in text if c.isprintable() or c in "\n\r\t"
-                        )
-                        if len(printable) >= 4:
-                            yield (
-                                0,
-                                (
-                                    proc_id,
-                                    proc_name,
-                                    format_hints.Hex(vad_start),
-                                    "UTF16: " + printable[:256],
-                                ),
-                            )
-                            continue
-                except Exception:
-                    pass
-
-                # Try UTF-8 / ASCII
-                try:
-                    text = data.decode("utf-8", errors="ignore").strip("\x00").strip()
-                    if len(text) >= 4:
-                        printable = "".join(
-                            c for c in text if c.isprintable() or c in "\n\r\t"
-                        )
-                        if len(printable) >= 4:
-                            yield (
-                                0,
-                                (
-                                    proc_id,
-                                    proc_name,
-                                    format_hints.Hex(vad_start),
-                                    "ASCII: " + printable[:256],
-                                ),
-                            )
-                except Exception:
-                    pass
-                
     def run(self):
         return renderers.TreeGrid(
             [
-                ("PID", int),
-                ("Process", str),
-                ("Offset", format_hints.Hex),
+                ("Session", int),
+                ("WindowStation", str),
+                ("Format", str),
+                ("Handle", format_hints.Hex),
                 ("Data", str),
             ],
             self._generator(),
         )
+

--- a/volatility3/plugins/windows/clipboard.py
+++ b/volatility3/plugins/windows/clipboard.py
@@ -1,0 +1,160 @@
+# This file is Copyright 2025 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+"""Plugin to extract clipboard data from Windows memory dumps."""
+
+import logging
+from typing import List
+
+from volatility3.framework import interfaces, renderers, exceptions
+from volatility3.framework.configuration import requirements
+from volatility3.framework.renderers import format_hints
+from volatility3.plugins.windows import pslist, vadinfo
+
+vollog = logging.getLogger(__name__)
+
+
+class Clipboard(interfaces.plugins.PluginInterface):
+    """Extracts clipboard data from a Windows memory image."""
+
+    _required_framework_version = (2, 0, 0)
+    _version = (1, 0, 0)
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.ModuleRequirement(
+                name="kernel",
+                description="Windows kernel",
+                architectures=["Intel32", "Intel64"],
+            ),
+            requirements.VersionRequirement(
+                name="pslist",
+                component=pslist.PsList,
+                version=(3, 0, 0),
+            ),
+            requirements.VersionRequirement(
+                name="vadinfo",
+                component=vadinfo.VadInfo,
+                version=(2, 0, 0),
+            ),
+        ]
+
+    def _generator(self):
+        """Scan csrss.exe VADs for clipboard data."""
+        kernel_name = self.config["kernel"]
+        kernel = self.context.modules[kernel_name]
+
+        for proc in pslist.PsList.list_processes(
+            context=self.context,
+            kernel_module_name=kernel_name,
+        ):
+            try:
+                proc_name = proc.ImageFileName.cast(
+                    "string",
+                    max_length=proc.ImageFileName.vol.count,
+                    errors="replace",
+                ).lower()
+            except exceptions.InvalidAddressException:
+                continue
+
+            if proc_name not in ("csrss.exe", "rdpclip.exe"):
+                continue
+
+            try:
+                proc_id = int(proc.UniqueProcessId)
+                proc_layer_name = proc.add_process_layer()
+            except exceptions.InvalidAddressException:
+                continue
+
+            proc_layer = self.context.layers[proc_layer_name]
+
+            protect_values = vadinfo.VadInfo.protect_values(
+                self.context,
+                kernel.layer_name,
+                kernel.symbol_table_name,
+            )
+
+            for vad in vadinfo.VadInfo.list_vads(proc):
+                try:
+                    vad_start = vad.get_start()
+                    vad_size = vad.get_size()
+                    protection = vad.get_protection(
+                        protect_values,
+                        vadinfo.winnt_protections,
+                    )
+                    tag = vad.get_tag()
+                except exceptions.InvalidAddressException:
+                    continue
+
+                if vad_size == 0 or vad_size > 0x200000:
+                    continue
+
+                if protection not in (
+                    "PAGE_READWRITE",
+                    "PAGE_READONLY",
+                    "PAGE_EXECUTE_READ",
+                    "PAGE_EXECUTE_READWRITE",
+                ):
+                    continue
+
+                try:
+                    data = proc_layer.read(vad_start, vad_size, pad=True)
+                except exceptions.InvalidAddressException:
+                    continue
+
+                if not data:
+                    continue
+
+                # Try UTF-16-LE (most Windows clipboard text)
+                try:
+                    text = data.decode("utf-16-le", errors="ignore")
+                    text = text.strip("\x00").strip()
+                    if len(text) >= 4:
+                        printable = "".join(
+                            c for c in text if c.isprintable() or c in "\n\r\t"
+                        )
+                        if len(printable) >= 4:
+                            yield (
+                                0,
+                                (
+                                    proc_id,
+                                    proc_name,
+                                    format_hints.Hex(vad_start),
+                                    "UTF16: " + printable[:256],
+                                ),
+                            )
+                            continue
+                except Exception:
+                    pass
+
+                # Try UTF-8 / ASCII
+                try:
+                    text = data.decode("utf-8", errors="ignore").strip("\x00").strip()
+                    if len(text) >= 4:
+                        printable = "".join(
+                            c for c in text if c.isprintable() or c in "\n\r\t"
+                        )
+                        if len(printable) >= 4:
+                            yield (
+                                0,
+                                (
+                                    proc_id,
+                                    proc_name,
+                                    format_hints.Hex(vad_start),
+                                    "ASCII: " + printable[:256],
+                                ),
+                            )
+                except Exception:
+                    pass
+                
+    def run(self):
+        return renderers.TreeGrid(
+            [
+                ("PID", int),
+                ("Process", str),
+                ("Offset", format_hints.Hex),
+                ("Data", str),
+            ],
+            self._generator(),
+        )

--- a/volatility3/plugins/windows/clipboard.py
+++ b/volatility3/plugins/windows/clipboard.py
@@ -1,12 +1,13 @@
 # This file is Copyright 2025 Volatility Foundation and licensed under the Volatility Software License 1.0
 # which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
-#
+
+
 """Plugin to extract clipboard data from Windows memory dumps."""
 
 import logging
 from typing import List
 
-from volatility3.framework import interfaces, renderers, exceptions
+from volatility3.framework import interfaces, renderers, exceptions, constants
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.windows import windowstations
@@ -15,7 +16,13 @@ vollog = logging.getLogger(__name__)
 
 
 class Clipboard(interfaces.plugins.PluginInterface):
-    """Extracts clipboard data from a Windows memory image."""
+    """Reads clipboard data from a Windows memory dump.
+    It looks at the tagCLIP list inside each WindowStation (pClipBase)
+    and shows the clipboard formats and data stored there.
+
+    Note: This is just a prototype. Right now it only works through
+    WindowStation. In the future, support for USER handle table
+    (tagSHAREDINFO) can be added when pClipBase is missing or zero"""
 
     _required_framework_version = (2, 0, 0)
     _version = (1, 0, 0)
@@ -36,58 +43,84 @@ class Clipboard(interfaces.plugins.PluginInterface):
         ]
 
     def _generator(self):
-        """Walk window stations and extract clipboard data."""
+        """
+        TODO: Later add USER handle table (tagSHAREDINFO) support
+        to recover clipboard data when pClipBase is missing.
+        """
+
         kernel_name = self.config["kernel"]
 
-        for winsta, station_name, session_id in windowstations.WindowStations.scan_window_stations(
+        for (
+            winsta,
+            station_name,
+            session_id,
+        ) in windowstations.WindowStations.scan_window_stations(
             self.context, self.config_path, kernel_name
         ):
+            gui_table_name = winsta.vol.type_name.split(constants.BANG)[0]
+            layer_name = winsta.vol.layer_name
+
             try:
                 clip_count = int(winsta.cNumClipFormats)
-                if clip_count == 0 or clip_count > 512:
-                    continue
-
-                clip_array = winsta.pClipBase.dereference()
-
+                clip_base_ptr = int(winsta.pClipBase)
             except exceptions.InvalidAddressException:
-                vollog.debug(
-                    f"Could not read clipboard base for station {station_name}"
-                )
+                vollog.debug(f"Cannot read clipboard fields for station {station_name}")
+                continue
+
+            vollog.debug(
+                f"Station={station_name} Session={session_id} "
+                f"cNumClipFormats={clip_count} pClipBase={clip_base_ptr:#x}"
+            )
+
+            if clip_count == 0 or clip_count > 512:
+                continue
+
+            if clip_base_ptr <= 0xFFFF:
+                continue
+
+            try:
+                tagclip_size = self.context.symbol_space.get_type(
+                    gui_table_name + constants.BANG + "tagCLIP"
+                ).size
+            except exceptions.InvalidAddressException:
+                vollog.debug(f"Cannot get tagCLIP size for {station_name}")
                 continue
 
             for i in range(clip_count):
                 try:
-                    clip = clip_array[i]
+                    clip = self.context.object(
+                        gui_table_name + constants.BANG + "tagCLIP",
+                        layer_name=layer_name,
+                        offset=clip_base_ptr + i * tagclip_size,
+                    )
+
                     fmt_name = clip.get_format_name()
                     handle_val = int(clip.hData)
 
-                    clip_data_ptr = clip.hData.dereference()
-                    data = clip_data_ptr.get_data()
+                    vollog.debug(f"  clip[{i}]: fmt={fmt_name} hData={handle_val:#x}")
 
-                    if data is None:
-                        data_display = renderers.NotAvailableValue()
-                    else:
-                        text = clip_data_ptr.get_text(fmt_name)
-                        if text:
-                            data_display = text
-                        else:
-                            data_display = data.hex()
+                    # hData is a USER handle — not a direct pointer.
+                    # Resolving it requires walking tagSHAREDINFO.aheList
+                    # which is not yet implemented (see TODO above).
+                    # For now we report format and handle without data.
+                    data_display: interfaces.renderers.BaseAbsentValue | str = (
+                        renderers.NotAvailableValue()
+                    )
 
-                except exceptions.InvalidAddressException:
-                    fmt_name = renderers.NotAvailableValue()
-                    handle_val = 0
-                    data_display = renderers.NotAvailableValue()
+                    yield (
+                        0,
+                        (
+                            session_id,
+                            station_name,
+                            fmt_name,
+                            format_hints.Hex(handle_val),
+                            data_display,
+                        ),
+                    )
 
-                yield (
-                    0,
-                    (
-                        session_id,
-                        station_name,
-                        fmt_name,
-                        format_hints.Hex(handle_val),
-                        data_display,
-                    ),
-                )
+                except exceptions.InvalidAddressException as e:
+                    vollog.debug(f"  clip[{i}]: {e}")
+                    continue
 
     def run(self):
         return renderers.TreeGrid(
@@ -100,4 +133,3 @@ class Clipboard(interfaces.plugins.PluginInterface):
             ],
             self._generator(),
         )
-


### PR DESCRIPTION
## Summary

Adds a prototype for Windows clipboard support to Volatility 3, addressing issue #710.

Volatility 2 included a clipboard plugin, but there is currently no equivalent in Volatility 3. This PR adds the required GUI structures together with an initial plugin implementation.

## Changes

### New file: `volatility3/plugins/windows/clipboard.py`

* Enumerates clipboard entries from `tagWINDOWSTATION.pClipBase`
* Reports clipboard formats and their associated USER handles
* Includes placeholders for future handle resolution

### `volatility3/framework/symbols/windows/extensions/gui.py`

* Added `tagCLIP` with clipboard format name lookup
* Added `tagCLIPDATA` with helper methods for reading and decoding clipboard data
* Registered both types in `class_types`

### GUI JSON files (Windows 10)

* Added the missing `tagCLIPDATA` structure.
* Updated `pClipBase` in `tagWINDOWSTATION` to point to `tagCLIP` instead of a hardcoded array definition.

## Current state

This is an initial prototype.

The plugin can enumerate clipboard entries from a WindowStation. However, it does not yet recover the actual clipboard contents because `hData` is a USER handle rather than a direct pointer. Resolving it requires walking `tagSHAREDINFO.aheList`, which is left for future work.

## Testing

* Tested on a Windows 10 (19045) memory image.
* The plugin loaded and executed successfully without errors.
* Clipboard-related data was independently verified to be present in the memory image.
* As expected, clipboard contents are not yet displayed because USER handle resolution has not been implemented.

## Not yet supported

* Clipboard content recovery (requires resolving `hData` through `tagSHAREDINFO.aheList`)
* Additional clipboard formats beyond the current prototype
