### PR TITLE
fix: linux 6.19 taint_flag.module removal

### DIFF
--- a/volatility3/framework/constants/linux/__init__.py
+++ b/volatility3/framework/constants/linux/__init__.py
@@ -487,7 +487,7 @@ TAINT_FLAGS = {
     "L": TaintFlag(shift=1 << 14, desc="SOFTLOCKUP", when_present=True, module=False),
     "K": TaintFlag(shift=1 << 15, desc="LIVEPATCH", when_present=True, module=True),
     "X": TaintFlag(shift=1 << 16, desc="AUX", when_present=True, module=True),
-    "T": TaintFlag(shift=1 << 17, desc="RANDSTRUCT", when_present=True, module=True),
+    "T": TaintFlag(shift=1 << 17, desc="RANDSTRUCT", when_present=True, module=False),
     "N": TaintFlag(shift=1 << 18, desc="TEST", when_present=True, module=True),
     "J": TaintFlag(shift=1 << 19, desc="FWCTL", when_present=True, module=False),
 }

--- a/volatility3/framework/constants/linux/__init__.py
+++ b/volatility3/framework/constants/linux/__init__.py
@@ -489,14 +489,16 @@ TAINT_FLAGS = {
     "X": TaintFlag(shift=1 << 16, desc="AUX", when_present=True, module=True),
     "T": TaintFlag(shift=1 << 17, desc="RANDSTRUCT", when_present=True, module=True),
     "N": TaintFlag(shift=1 << 18, desc="TEST", when_present=True, module=True),
+    "J": TaintFlag(shift=1 << 19, desc="FWCTL", when_present=True, module=False),
 }
 """Flags used to taint kernel and modules, for debugging purposes.
 
-Map based on 6.12-rc5.
+Map based on 7.2.0-rc5.
 
 Documentation :
     - https://www.kernel.org/doc/Documentation/admin-guide/sysctl/kernel.rst#:~:text=guide/sysrq.rst.-,tainted,-%3D%3D%3D%3D%3D%3D%3D%0A%0ANon%2Dzero%20if
     - https://www.kernel.org/doc/Documentation/admin-guide/tainted-kernels.rst#:~:text=More%20detailed%20explanation%20for%20tainting
+    - https://docs.kernel.org/admin-guide/tainted-kernels.html#table-for-decoding-tainted-state
     - taint_flag kernel struct
     - taint_flags kernel constant
 """

--- a/volatility3/framework/symbols/linux/utilities/tainting.py
+++ b/volatility3/framework/symbols/linux/utilities/tainting.py
@@ -14,7 +14,7 @@ class Tainting(interfaces.configuration.VersionableInterface):
         - kernel: print_tainted
     """
 
-    _version = (1, 0, 0)
+    _version = (1, 0, 1)
     _required_framework_version = (2, 0, 0)
 
     framework.require_interface_version(*_required_framework_version)
@@ -91,7 +91,8 @@ class Tainting(interfaces.configuration.VersionableInterface):
         for taint_bit, taint_flag in enumerate(
             cls._get_kernel_taint_flags_list(context, kernel_module_name)
         ):
-            if is_module and not taint_flag.module:
+            # https://lore.kernel.org/all/20251022082938.26670-1-petr.pavlu@suse.com/T/#u: "taint/module: Remove unnecessary taint_flag.module field"
+            if is_module and taint_flag.has_member("module") and not taint_flag.module:
                 continue
 
             try:


### PR DESCRIPTION
Linux 6.19 removed the `taint_flag.module` attribute: https://lore.kernel.org/all/20251022082938.26670-1-petr.pavlu@suse.com/T/#u

As such, when running `linux.lsmod` for a snapshot of linux 6.19+ the whole framework backtraces:

```bash
  File "/usr/lib/python3.14/site-packages/volatility3/framework/symbols/linux/utilities/tainting.py", line 94, in _module_flags_taint_post_4_10_rc1
    if is_module and not taint_flag.module:
                         ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/volatility3/framework/objects/__init__.py", line 993, in __getattr__
    raise AttributeError(
        f"{agg_name} has no attribute: {self.vol.type_name}.{attr}"
    )
AttributeError: StructType has no attribute: symbol_table_name1!taint_flag.module
```

Also, update the taint table, and introduce a new taint flag `J`:
https://docs.kernel.org/admin-guide/tainted-kernels.html#table-for-decoding-tainted-state

Taints continue to appear when running `linux.lsmod` on a random snapshot:

```bash
Volatility 3 Framework 2.28.2
Progress:  100.00               Stacking attempts finished
Offset  Module Name     Code Size       Taints  Load Arguments  File Output
[...]
0xffffc06e6bc0  vboxsf  0x17000 OOT_MODULE,UNSIGNED_MODULE      follow_symlinks=None, disabled=None     N/A
[...]
0xffffc031b040  vboxguest       0x81000 OOT_MODULE,UNSIGNED_MODULE      r3_log_to_host=None, log_dest=None, log_flags=None, log=None, disabled=None     N/A
```

