### PR TITLE
Match syscall blocks against the instruction that was scanned for

### DIFF
--- a/test/plugins/windows/test_direct_system_calls.py
+++ b/test/plugins/windows/test_direct_system_calls.py
@@ -1,0 +1,222 @@
+import struct
+import sys
+import unittest
+
+sys.path.insert(0, "../../volatility3")
+from volatility3.framework import exceptions
+from volatility3.plugins.windows.malware import direct_system_calls
+from volatility3.plugins.windows.malware import indirect_system_calls
+
+# A minimal x86-64 direct system call stub, matching the shape reported in
+# issue #1930:
+#
+#   4c 8b d1              mov  r10, rcx
+#   8b 05 <disp32>        mov  eax, dword ptr [rip + disp32]
+#   0f 05                 syscall
+#   c3                    ret
+#
+# The stub is 12 bytes long and the `syscall` instruction sits 9 bytes in.
+STUB_LENGTH = 12
+SYSCALL_OFFSET = 9
+
+MOV_R10_RCX = b"\x4c\x8b\xd1"
+MOV_EAX_IMM = b"\xb8\x3a\x00\x00\x00"
+XOR_RBX_RBX = b"\x48\x31\xdb"
+PUSH_POP_RBX = b"\x53\x5b"
+SYSCALL = b"\x0f\x05"
+RET = b"\xc3"
+NOP = b"\x90"
+
+# The scan rule tolerates spacing between the `syscall` and the `ret` so that
+# anti-analysis variants such as TartarusGate are still caught. Each of these
+# must therefore resolve to the start of its own stub.
+OBFUSCATED_STUBS = {
+    "classic": MOV_R10_RCX + MOV_EAX_IMM + SYSCALL + RET,
+    "eax written before r10": MOV_EAX_IMM + MOV_R10_RCX + SYSCALL + RET,
+    "nop spacing throughout": (
+        MOV_R10_RCX + NOP * 3 + MOV_EAX_IMM + NOP * 3 + SYSCALL + NOP * 2 + RET
+    ),
+    "junk before the syscall": MOV_R10_RCX + MOV_EAX_IMM + XOR_RBX_RBX + SYSCALL + RET,
+    "push and pop padding": MOV_R10_RCX + MOV_EAX_IMM + PUSH_POP_RBX + SYSCALL + RET,
+    "twenty bytes of spacing": MOV_R10_RCX + MOV_EAX_IMM + NOP * 20 + SYSCALL + RET,
+}
+
+
+def make_stub(filler: int) -> bytes:
+    """Builds a single syscall stub, using `filler` for the rip displacement.
+
+    The displacement bytes differ between stubs so that a misattributed block
+    can be told apart from the correct one in assertion failures.
+    """
+    return b"\x4c\x8b\xd1" + b"\x8b\x05" + bytes([filler]) * 4 + b"\x0f\x05" + b"\xc3"
+
+
+class FakeLayer:
+    """Stands in for a process translation layer over a fixed buffer.
+
+    `_is_valid_syscall` only ever reads from the layer, so a buffer backed by
+    a known base address is all that is required to exercise it.
+    """
+
+    def __init__(self, base: int, data: bytes) -> None:
+        self._base = base
+        self._data = data
+
+    def read(self, offset: int, length: int, pad: bool = False) -> bytes:
+        start = offset - self._base
+        if start < 0 or start + length > len(self._data):
+            raise exceptions.InvalidAddressException(
+                "FakeLayer", offset, "read outside of the backing buffer"
+            )
+        return self._data[start : start + length]
+
+
+class TestDirectSystemCallBlocks(unittest.TestCase):
+    """Tests the mapping of a `syscall` hit back onto its enclosing block."""
+
+    # Mirrors the finder built in DirectSystemCalls.__init__
+    finder = direct_system_calls.syscall_finder_type(
+        None,
+        True,
+        "/\\x0f\\x05[^\\xc3]{,24}\\xc3/",
+        ["jmp", "call", "leave", "int3"],
+        ["ret"],
+    )
+
+    # The look-behind window `_is_valid_syscall` reads before each hit
+    lookbehind = 32
+
+    def _build(self, region: bytes, region_base: int) -> FakeLayer:
+        """Wraps `region` in padding so look-behind and look-ahead succeed."""
+        pad = b"\x90" * self.lookbehind * 2
+        return FakeLayer(region_base - len(pad), pad + region + pad)
+
+    def test_packed_stubs_each_report_their_own_block(self):
+        """Each hit must resolve to the stub that contains it.
+
+        Malware that inlines a table of syscall stubs packs them back to
+        back, so the 32 byte look-behind of one hit covers the whole of the
+        preceding stub. That preceding stub is itself a well formed block,
+        and must not be reported in place of the real one.
+        """
+        base = 0x1000
+        count = 4
+        region = b"".join(make_stub(0xA0 + index) for index in range(count))
+        layer = self._build(region, base)
+
+        for index in range(count):
+            expected = base + index * STUB_LENGTH
+            hit = expected + SYSCALL_OFFSET
+
+            result = direct_system_calls.DirectSystemCalls._is_valid_syscall(
+                self.finder, layer, "intel64", [], hit
+            )
+
+            self.assertIsNotNone(result, f"no block found for hit {hit:#x}")
+            self.assertEqual(
+                result[0],
+                expected,
+                f"hit {hit:#x} was attributed to block {result[0]:#x} "
+                f"instead of {expected:#x}",
+            )
+
+    def test_block_starts_at_the_stub_not_at_preceding_padding(self):
+        """A block must not be grown backwards through benign padding.
+
+        Disassembling from part way into a run of single byte nops still
+        reaches the stub that follows it, so many offsets in the look-behind
+        window decode into a valid looking block. The reported block should
+        be the stub itself rather than the earliest of those offsets.
+        """
+        base = 0x2000
+        layer = self._build(make_stub(0xC3), base)
+        hit = base + SYSCALL_OFFSET
+
+        result = direct_system_calls.DirectSystemCalls._is_valid_syscall(
+            self.finder, layer, "intel64", [], hit
+        )
+
+        self.assertIsNotNone(result, "no block found for a lone padded stub")
+        self.assertEqual(result[0], base)
+        self.assertNotIn(
+            "nop",
+            result[1],
+            "the reported disassembly reaches back into the padding",
+        )
+
+    def test_obfuscated_stubs_report_their_own_start(self):
+        """Spaced and reordered stubs must still resolve to the stub itself.
+
+        The look-behind window covers whatever precedes the stub, so each of
+        these forms previously reported a block starting in that padding.
+        """
+        base = 0x5000
+
+        for name, stub in OBFUSCATED_STUBS.items():
+            with self.subTest(variant=name):
+                layer = self._build(stub, base)
+                hit = base + stub.index(SYSCALL)
+
+                result = direct_system_calls.DirectSystemCalls._is_valid_syscall(
+                    self.finder, layer, "intel64", [], hit
+                )
+
+                self.assertIsNotNone(result, f"{name} was not detected at all")
+                self.assertEqual(result[0], base)
+
+
+class TestIndirectSystemCallBlocks(unittest.TestCase):
+    """Guards the indirect technique, which shares the block matching code.
+
+    Indirect blocks terminate on a `jmp` rather than containing a `syscall`
+    themselves, so the instruction that the scan rule matches is the `jmp`.
+    """
+
+    lookbehind = 32
+
+    def test_indirect_block_is_still_matched(self):
+        base = 0x3000
+        # jmp [rip + disp32] dereferences this slot, which points at a
+        # `syscall` instruction inside a range owned by ntdll
+        pointer_slot = 0x3080
+        syscall_site = 0x3100
+
+        jmp_site = base + 9
+        displacement = pointer_slot - jmp_site - 6
+
+        stub = (
+            b"\x4c\x8b\xd1"  # mov  r10, rcx
+            + b"\x8b\x05"
+            + b"\x11" * 4  # mov  eax, dword ptr [rip + 0x11111111]
+            + b"\xff\x25"
+            + struct.pack("<I", displacement)  # jmp  qword ptr [rip + disp32]
+        )
+
+        buffer_base = 0x2F00
+        data = bytearray(b"\x90" * 0x400)
+        data[base - buffer_base : base - buffer_base + len(stub)] = stub
+        data[pointer_slot - buffer_base : pointer_slot - buffer_base + 8] = struct.pack(
+            "<Q", syscall_site
+        )
+        data[syscall_site - buffer_base : syscall_site - buffer_base + 2] = b"\x0f\x05"
+
+        layer = FakeLayer(buffer_base, bytes(data))
+        vads = [(syscall_site, 0x10, "\\Windows\\System32\\ntdll.dll")]
+
+        plugin = indirect_system_calls.IndirectSystemCalls
+        finder = direct_system_calls.syscall_finder_type(
+            plugin._indirect_syscall_block_target,
+            False,
+            "/\\xff\\x25[^\\xc3]{,24}\\xc3/",
+            ["call", "leave", "int3", "ret"],
+            ["jmp"],
+        )
+
+        result = plugin._is_valid_syscall(finder, layer, "intel64", vads, jmp_site)
+
+        self.assertIsNotNone(result, "the indirect syscall block was not matched")
+        self.assertEqual(result[0], base)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/volatility3/framework/plugins/windows/malware/direct_system_calls.py
+++ b/volatility3/framework/plugins/windows/malware/direct_system_calls.py
@@ -55,7 +55,8 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
     _required_framework_version = (2, 4, 0)
 
     # 2.0.0 - changes signature of `get_tasks_to_scan`
-    _version = (2, 0, 0)
+    # 2.0.1 - blocks are matched against the instruction that was scanned for
+    _version = (2, 0, 1)
 
     # DLLs that are expected to host system call invocations
     valid_syscall_handlers = ("ntdll.dll", "win32u.dll")
@@ -114,6 +115,7 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
         syscall_finder: syscall_finder_type,
         data: bytes,
         address: int,
+        hit_address: int,
     ) -> Optional[Tuple[str, "capstone._cs_insn"]]:
         """
         Determines if the bytes starting at `data` represent a valid syscall instruction invocation block
@@ -126,6 +128,11 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
 
         We also track whether the 'syscall' instruction was encountered while parsing
 
+        The block must additionally decode an instruction that begins exactly at
+        `hit_address`. Since Intel instructions are variable length, a block that is
+        disassembled from the wrong offset can still satisfy every constraint above
+        while describing a neighbouring block instead of the one that was scanned for.
+
         This function is reusable for every technique we found and studied during the DEFCON research timeframe
 
         Args:
@@ -133,6 +140,7 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
             syscall_finder: the method and constraints on the malicious system call blocks that the calling plugin knows how to find
             data: the bytes from memory to search for malicious syscall invocations
             address: the address from where `data` came from in the particular process
+            hit_address: the address of the instruction that the scan rule matched, which the block must contain
         Returns:
             Optional[Tuple[str, capstone._cs_insn]]: For valid blocks, the disassembled bytes in string from and the last (termination) instruction
         """
@@ -140,12 +148,17 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
         found_movreax = False
         found_syscall = False
         found_end = False
+        found_hit = False
         end_inst = None
 
         disasm_bytes = ""
 
         for inst in disasm_func(data, address):
             disasm_bytes += f"{inst.address:#x}: {inst.mnemonic} {inst.op_str}; "
+
+            # track whether this decoding lines up with the scanned-for instruction
+            if inst.address == hit_address:
+                found_hit = True
 
             # an instruction of all 0x00 opcodes
             if inst.opcode.count(0) == len(inst.opcode):
@@ -194,6 +207,11 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
         # if any of these are missing, the block is invalid regardless of
         # the technique we are trying to detect now or in the future
         if not (found_movr10 and found_movreax and found_end):
+            return None
+
+        # a block that does not cover the scanned-for instruction is a misaligned
+        # decoding of the surrounding bytes rather than the block that was found
+        if not found_hit:
             return None
 
         # if the finder requires a 'syscall' instruction then bail now if we didn't find one
@@ -245,6 +263,9 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
         # the number bytes behind the yara rule hit to scan
         behind = 32
 
+        # the instruction that the scan rule matched, which a valid block must contain
+        hit_address = address
+
         address = address - behind
 
         try:
@@ -255,11 +276,18 @@ class DirectSystemCalls(interfaces.plugins.PluginInterface):
         disasm_func = cls.get_disasm_function(architecture)
 
         # since Intel does not have fixed-size instructions, we have to scan
-        # each byte offset and re-disassemble the remaining block
-        for offset in range(behind):
+        # each byte offset and re-disassemble the remaining block.
+        # Offsets are walked from the hit backwards so that the tightest block
+        # containing it is preferred, as earlier offsets may decode into either a
+        # neighbouring block or a run of padding that runs on into this one
+        for offset in reversed(range(behind)):
             # if this looks like a system call back (r10, rax, ret/jmp)
             syscall_info = cls._is_syscall_block(
-                disasm_func, syscall_finder, data[offset:], address + offset
+                disasm_func,
+                syscall_finder,
+                data[offset:],
+                address + offset,
+                hit_address,
             )
             if syscall_info:
                 disasm_bytes, end_inst = syscall_info


### PR DESCRIPTION
## Summary

Fixes #1930. `direct_system_calls` reported the wrong assembly block for each
`syscall` it found: blocks were shifted onto their predecessor, duplicating the
first and dropping the last, exactly as described in the issue.

Two things turned up while confirming the root cause. `indirect_system_calls` is
affected by the same defect, so the fix is expressed generically and covers both.
And the misreporting is visible on the `win-10_19041-2025_03.dmp` test image
already used by CI, where it corrects 10 of 158 reported blocks without changing
the number of detections.

## Root cause

`_is_valid_syscall` reads 32 bytes behind a scan hit and, since Intel
instructions are variable length, re-disassembles from every byte offset in
that window, returning the first offset that decodes into a well formed block.

`_is_syscall_block` validates that the block writes `r10` and `rax` and reaches
a termination instruction, and separately notes whether a `syscall` was seen
anywhere. Nothing ever checked that the block covered the instruction the
scanner actually hit.

Malware that inlines a table of syscall stubs packs them back to back, so the
look-behind window of one hit spans the whole of the preceding stub. That stub
is a well formed block at a lower address, so it was returned instead. With
four 12-byte stubs at `0x1000`:

| scan hit | correct block | reported before | reported after |
| --- | --- | --- | --- |
| `0x1009` | `0x1000` | `0xfe9` | `0x1000` |
| `0x1015` | `0x100c` | `0xff5` | `0x100c` |
| `0x1021` | `0x1018` | `0x100c` | `0x1018` |
| `0x102d` | `0x1024` | `0x1018` | `0x1024` |

For the hit at `0x1021`, exactly two offsets in the window decode into a valid
block, and the one that was returned has its `syscall` at `0x1015`, not at the
hit:

```
0x100c -> mov r10, rcx; mov eax, [rip - 0x5e5e5e5f]; syscall (0x1015); ret   <- returned
0x1018 -> mov r10, rcx; mov eax, [rip - 0x5d5d5d5e]; syscall (0x1021); ret   <- correct
```

A run of benign padding in front of a stub triggers the same fault by a
different route: disassembling from part way into a nop sled still reaches the
stub behind it, so 24 offsets in the window decode into a valid block and the
lowest one wins. The reported block start was then simply `hit - 32` and the
padding appeared in the disassembly column.

Because of that second route the misreporting is not limited to packed stub
tables. Any stub with padding in front of it is affected, which in practice
means most of them. Checking the obfuscated forms that the scan rule
deliberately tolerates, every one reported a block start inside the padding:

| stub variant | correct | before | after |
| --- | --- | --- | --- |
| classic HellsGate | `0x5000` | `0x4fe8` | `0x5000` |
| eax written before r10 | `0x5000` | `0x4fe8` | `0x5000` |
| nop spacing throughout | `0x5000` | `0x4fee` | `0x5000` |
| junk instruction before the syscall | `0x5000` | `0x4feb` | `0x5000` |
| push/pop padding | `0x5000` | `0x4fea` | `0x5000` |
| twenty bytes of spacing | `0x5000` | `0x4ffc` | `0x5000` |

Detection itself was never lost, so the count of syscalls reported was right,
as the issue notes. It is the block attribution and the disassembly column
that were wrong.

## Fix

Two changes, both in `_is_valid_syscall` / `_is_syscall_block`:

1. A block must decode an instruction beginning exactly at the hit address.
   This is the invariant that was missing. It is stated in terms of the
   scanned-for instruction rather than `syscall` specifically, which is what
   makes it correct for `IndirectSystemCalls`, whose rule matches the
   terminating `jmp` and whose blocks contain no `syscall` at all.
2. Offsets are walked from the hit backwards, so the tightest block containing
   the hit is preferred over a longer decode that runs into it from padding.

Both are needed. (1) makes the result correct, (2) makes it minimal.

## Compatibility

`_is_syscall_block` takes one new argument. It is private and has no callers
outside this module, so no public API changes.

`DirectSystemCalls._version` goes from `2.0.0` to `2.0.1`, a patch bump for a
backwards compatible bug fix. `IndirectSystemCalls` declares
`VersionRequirement(component=DirectSystemCalls, version=(2, 0, 0))`, and
`versionutils.matches_required` requires an exact major match with minor at or
above the request, so `2.0.1` still satisfies it. A major bump would have
broken that requirement.

The deprecated shim at `windows/direct_system_calls.py` is untouched; it
forwards to this class via `PluginRenameClass`.

## Tests

`test/plugins/windows/test_direct_system_calls.py` adds four tests, following
the buffer-driven `unittest` style already used by
`test/plugins/windows/test_scheduled_tasks.py`, so no memory image is needed:

- packed stubs each report their own block (the reported bug)
- a block starts at the stub rather than at preceding padding (the second route)
- six obfuscated stub variants each report their own start, so the fix is shown
  not to narrow detection of the anti-analysis forms the rule allows for
- an indirect block is still matched (covers the `wants_syscall_inst=False`
  path, including target resolution and the VAD path check)

All of them fail on `develop` and pass with this change. I verified this by
reverting only the plugin change and re-running, rather than by assuming.

`ruff format --check` and `ruff check` are clean across the tree, and
`test/volatility3_code_analysis.py` reports "All configurable classes passed
validation!".

## Differential check against the current behaviour

Since this changes a heuristic scanner, I also ran the old and new
`_is_valid_syscall` side by side over generated buffers (random filler, sparse
`0f 05` bytes, scattered stubs, and packed stub tables) and compared every
result. 8628 scan hits across 1600 buffers and 8 seeds:

| outcome | count |
| --- | --- |
| block attribution corrected | 4777 |
| identical result | 15 |
| neither found a block | (remainder) |
| **block dropped that genuinely covered the hit** | **0** |
| row suppressed because no block covers the hit | 14 (0.162%) |

The important number is the zero: there is no case where the fix discards a
block that actually contains the scanned-for instruction, so no detection is
lost.

The 14 suppressed rows are cases where the old code reported a block that
terminates before the hit, so it was describing a different syscall. For
example, for a hit at `0x1012a` the old code returned a block at `0x1010a`
whose `ret` lands at `0x10125`:

```
0x10118: mov r10, rcx
0x1011e: mov eax, 0x3a
0x10123: syscall
0x10125: ret          <- block ends here, five bytes before the hit
```

Those rows were false positives and are now correctly dropped, so output may
shrink very slightly on real images. Flagging it explicitly since it is a
visible behaviour change beyond the block addresses. I am happy to share the
comparison harness if it is useful, though it needs both versions loaded side
by side so it does not belong in the tree.

## Confirmed on the CI test image

The bug is also visible on `win-10_19041-2025_03.dmp` from `volatility3-test-data`,
so it does not require a crafted sample. Edge inlines its own syscall stubs, and
the gap in front of the first stub in each renderer is filled with `0xaa`, which
decodes as `stosb byte ptr [rdi], al`. That neither writes `eax`/`r10`, nor
appears in `invalid_ops`, nor terminates the block, so the old scan walked
straight through it into the stub:

```
before  0x1eda87e701c  stosb; stosb; stosb; stosb; mov r10, rcx; mov eax, 0x55;
                       test byte ptr [0x7ffe0308], 1; jne ...; syscall; ret
after   0x1eda87e7020  mov r10, rcx; mov eax, 0x55;
                       test byte ptr [0x7ffe0308], 1; jne ...; syscall; ret
```

`windows.malware.direct_system_calls` on that image:

| | before | after |
| --- | --- | --- |
| rows reported | 158 | 158 |
| rows with a corrected block address | — | 10 |
| rows lost | — | 0 |

`windows.malware.indirect_system_calls` output is byte for byte identical, and
both plugins exit 0 with no exceptions. The row count being unchanged is the
point: the ten differences are all block addresses and disassembly strings, not
appearances or disappearances of detections.

## What I have not been able to check

I have not run this against the sample from the issue, so the packed stub table
case in the report is covered by the unit tests rather than by a real image. The
padding case above is the same defect reached by a different route, and it does
reproduce on real memory. If it would help to confirm against the original
sample, I am happy to work with the reporter.

## A question for maintainers

`test.yaml` invokes pytest against `windows.py` and `linux.py` by path, so
neither the existing `test_scheduled_tasks.py` nor this new file runs in CI.
The root `conftest.py` also makes `--volatility` required, so these image-free
tests need a dummy value to collect at all.

I have deliberately left CI untouched to keep this PR to the bug fix. If you
would like these unit tests wired into CI I am happy to do it here or in a
follow-up, whichever you prefer.
