### PR TITLE
Discard modscan results whose base is not page aligned

### DIFF
--- a/test/plugins/windows/windows.py
+++ b/test/plugins/windows/windows.py
@@ -1039,6 +1039,35 @@ class TestWindowsModScan:
         for expected_row in expected_rows:
             assert test_volatility.match_output_row(expected_row, json_out)
 
+    def test_windows_generic_modscan_bases_are_page_aligned(
+        self, volatility, python, image
+    ):
+        """Pool matches whose base is not page aligned are false positives.
+
+        A loaded module is always mapped on a page boundary, so a base with
+        any of the low twelve bits set means the "MmLd" tag was found in
+        unrelated data rather than in a real pool allocation. A base of zero
+        is allowed, since that means the field could not be read.
+        """
+        rc, out, _err = test_volatility.runvol_plugin(
+            "windows.modscan.ModScan",
+            image,
+            volatility,
+            python,
+            globalargs=("-r", "json"),
+        )
+        assert rc == 0
+        json_out = json.loads(out)
+        assert len(json_out) > 0
+
+        misaligned = [row for row in json_out if row["Base"] % 0x1000 != 0]
+        assert misaligned == [], (
+            f"{len(misaligned)} module(s) reported with a base that is neither "
+            f"page aligned nor zero, e.g. "
+            f"base={misaligned[0]['Base']:#x} size={misaligned[0]['Size']:#x} "
+            f"offset={misaligned[0]['Offset']:#x}"
+        )
+
 
 class TestWindowsMutantScan:
     def test_windows_specific_mutantscan(self, volatility, python):

--- a/volatility3/framework/plugins/windows/modscan.py
+++ b/volatility3/framework/plugins/windows/modscan.py
@@ -4,7 +4,7 @@
 import logging
 from typing import Iterable
 
-from volatility3.framework import interfaces
+from volatility3.framework import exceptions, interfaces
 from volatility3.framework.configuration import requirements
 from volatility3.plugins.windows import poolscanner, modules, pedump
 
@@ -17,7 +17,8 @@ class ModScan(modules.Modules):
     _required_framework_version = (2, 0, 0)
 
     # 3.0.0 changed the signature of enumeration methods (scan_modules)
-    _version = (3, 0, 0)
+    # 3.0.1 scan_modules discards results whose base is not page aligned
+    _version = (3, 0, 1)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -76,6 +77,10 @@ class ModScan(modules.Modules):
 
         kernel = context.modules[kernel_module_name]
 
+        # taken from the kernel's own layer, which is always the virtual layer,
+        # so that this holds regardless of which layer the scan itself runs against
+        page_size = context.layers[kernel.layer_name].page_size
+
         constraints = poolscanner.PoolScanner.builtin_constraints(
             kernel.symbol_table_name, [b"MmLd"]
         )
@@ -84,4 +89,21 @@ class ModScan(modules.Modules):
             context, kernel_module_name, constraints
         ):
             _constraint, mem_object, _header = result
+
+            try:
+                dll_base = mem_object.DllBase
+            except exceptions.InvalidAddressException:
+                continue
+
+            # A loaded module is always mapped on a page boundary, so a base with
+            # any of the low bits set means the pool tag was matched in unrelated
+            # data rather than in a real allocation. A base of zero is kept, since
+            # that means the base could not be determined rather than that the
+            # entry itself is invalid.
+            if dll_base % page_size:
+                vollog.debug(
+                    f"Skipping module at {mem_object.vol.offset:#x} with base {dll_base:#x} that is not page aligned"
+                )
+                continue
+
             yield mem_object


### PR DESCRIPTION
## Summary

Fixes #1633. `ModScan.scan_modules` yielded every pool match for the `MmLd` tag
without inspecting it, so the tag appearing inside unrelated kernel data
produced a module row. Results are now discarded unless the base is page
aligned, keeping a base of zero as the issue title asks for.

This reproduces on `win-10_19041-2025_03.dmp` from `volatility3-test-data`, so
no special sample is needed to see it.

## The false positive

One row on that image:

| field | value |
| --- | --- |
| Base | `0xccccccebebc0` |
| Size | `0x83485708` (2.2 GB) |
| Name | *unreadable* |
| Offset | `0xf80436391342` |

Three independent things are wrong with it: the base is not page aligned and
carries the `0xcc` fill pattern, the size is larger than the image, and the pool
offset is not 16 byte aligned. That offset also falls inside ntoskrnl's own
mapped range, so the literal bytes `MmLd` occurred in kernel code and the pool
scanner matched them.

It was also the only row on that image whose `BaseDllName` could not be read.

## Why page alignment

A loaded module is mapped on a page boundary, so a base with any of the low bits
set cannot describe a real allocation. A base of zero is kept, because that means
the base could not be determined rather than that the entry is bogus.

This mirrors how `driverscan.scan_drivers` already treats `DriverStart`:

```python
# Many/most rootkits zero out their DriverStart member for anti-forensics
# so we accept a driver start that is either 0 or is points into kernel memory
if mem_object.DriverStart == 0 or mem_object.DriverStart > kernel_space_start:
    yield mem_object
```

Same place in the code, same tolerance of zero, so this follows the existing
idiom rather than introducing a new one.

## Where the page size comes from

`page_size` is read from the kernel's own layer rather than from the layer the
matched object was found in. The kernel layer is always the Intel virtual layer,
whereas `FileLayer` has no `page_size` at all, so taking it from the object's
layer would break if scanning moves to the physical layer. That matters for
#1949, which does exactly that.

Please note #1949 also edits `scan_modules`, so one of these will need a small
rebase. Happy to be the one that moves.

## Effect

`windows.modscan` on `win-10_19041-2025_03.dmp`:

| | before | after |
| --- | --- | --- |
| rows | 177 | 176 |
| rows with an unaligned base | 1 | 0 |
| rows with an unreadable name | 1 | 0 |

The stronger check is against the list walk. `windows.modules` reports 176
modules on that image, and after this change the set of bases reported by
`modscan` is identical to it, with no entry on either side that the other
lacks. Before the change, the unaligned row was the only difference between the
two plugins.

On `win-xp-laptop-2005-06-25.img` the output is unchanged at 150 rows, with
nothing dropped or added, so the check is inert where there is nothing wrong to
find.

## Tests

Adds `test_windows_generic_modscan_bases_are_page_aligned` to
`test/plugins/windows/windows.py`. It takes the `image` fixture, so it runs
against the images CI already supplies, and it fails on `develop` and passes
with this change. I verified that by reverting only the plugin and re-running.

`ruff format`, `ruff check` and `test/volatility3_code_analysis.py` are all
clean.

## One note on running the existing tests

`test_windows_generic_modscan` fails on my machine, before and after this
change, because `runvol_plugin` passes the image path straight to
`--single-location`, which expects a URL. On Windows that becomes
`\\\\E:\Codes\...` and every image backed test fails with an unsatisfied layer
requirement. I confirmed the failure is unrelated by reproducing it on a clean
checkout, and worked around it locally by passing a `file://` URL. It looks like
the same thing #1959 is aimed at, so I have left it alone.

## Possible follow-up

`driverscan` additionally requires the address to point into kernel space via
`Modules.get_kernel_space_start`. The equivalent check would catch this same row
and probably others, but it is a wider behaviour change than the issue asks for,
so I have not included it. Happy to add it here or separately if you would like
it.
