### PR TITLE
[linux] Add AArch64 (ARM64) Support for Linux

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -4,6 +4,13 @@ API Changes
 When an addition to the existing API is made, the minor version is bumped.
 When an API feature or function is removed or changed, the major version is bumped.
 
+2.29.0
+======
+AArch64 (ARM64) translation layer support added for Linux.
+New module: `volatility3.framework.layers.arm` with AArch64, AArch64_39, AArch64_48, AArch64_52 classes and Linux variants.
+New automagic: `LinuxAArch64Stacker` in `volatility3.framework.automagic.linux`.
+`LINUX_ARCHS` and `FRAMEWORK_ARCHS` constants updated to include "AArch64".
+
 2.25.0
 ======
 Pointer class now supports `get_raw_value()`.

--- a/doc/source/symbol-tables.rst
+++ b/doc/source/symbol-tables.rst
@@ -49,6 +49,8 @@ tables they come from, meaning the precise file names don't matter and can be or
 under the symbols directory.
 
 Linux and Mac symbol tables can be generated from a DWARF file using a tool called `dwarf2json <https://github.com/volatilityfoundation/dwarf2json>`_.
+This process applies to both x86-64 and AArch64 (ARM64) Linux kernels. The kernel
+architecture is detected automatically from the symbols in the generated JSON file.
 Currently a kernel with debugging symbols is the only suitable means for recovering all the information required by
 most Volatility plugins.  Note that in most linux distributions, the standard kernel is stripped of debugging information
 and the kernel with debugging information is stored in a package that must be acquired separately.

--- a/volatility3/framework/automagic/linux.py
+++ b/volatility3/framework/automagic/linux.py
@@ -8,7 +8,7 @@ from typing import Optional, Tuple
 from volatility3.framework import constants, interfaces
 from volatility3.framework.automagic import symbol_cache, symbol_finder
 from volatility3.framework.configuration import requirements
-from volatility3.framework.layers import intel, scanners
+from volatility3.framework.layers import arm, intel, scanners
 from volatility3.framework.symbols import linux
 
 vollog = logging.getLogger(__name__)
@@ -30,9 +30,9 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
         layer = context.layers[layer_name]
         join = interfaces.configuration.path_join
 
-        # Never stack on top of an intel layer
+        # Never stack on top of a translation layer
         # FIXME: Find a way to improve this check
-        if isinstance(layer, intel.Intel):
+        if isinstance(layer, (intel.Intel, arm.AArch64)):
             return None
 
         linux_banners = symbol_cache.load_cache_manager().get_identifier_dictionary(
@@ -82,6 +82,16 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
                     layer_class = intel.LinuxIntelPAE
                     dtb_symbol_name = "swapper_pg_dir"
                 else:
+                    # Skip if swapper_pg_dir is in 64-bit address range without
+                    # Intel-specific symbols — this is likely an ARM64 kernel
+                    if "swapper_pg_dir" in table.symbols:
+                        swapper_addr = table.get_symbol("swapper_pg_dir").address
+                        if swapper_addr > 0xFFFFFFFF:
+                            vollog.debug(
+                                "Skipping non-Intel kernel: swapper_pg_dir at "
+                                f"0x{swapper_addr:x} without Intel page table symbols"
+                            )
+                            continue
                     layer_class = intel.LinuxIntel
                     dtb_symbol_name = "swapper_pg_dir"
 
@@ -206,6 +216,223 @@ class LinuxIntelStacker(interfaces.automagic.StackerLayerInterface):
         return addr - 0xC0000000
 
 
+class LinuxAArch64Stacker(interfaces.automagic.StackerLayerInterface):
+    stack_order = 35
+    exclusion_list = ["mac", "windows"]
+
+    # PAGE_OFFSET thresholds for VA_BITS detection
+    # PAGE_OFFSET = -(1 << VA_BITS) (unsigned 64-bit)
+    _PAGE_OFFSET_39 = (-1 << 39) & ((1 << 64) - 1)  # 0xFFFFFF8000000000
+    _PAGE_OFFSET_48 = (-1 << 48) & ((1 << 64) - 1)  # 0xFFFF000000000000
+    _PAGE_OFFSET_52 = (-1 << 52) & ((1 << 64) - 1)  # 0xFFF0000000000000
+
+    @classmethod
+    def stack(
+        cls,
+        context: interfaces.context.ContextInterface,
+        layer_name: str,
+        progress_callback: constants.ProgressCallback = None,
+    ) -> Optional[interfaces.layers.DataLayerInterface]:
+        """Attempts to identify linux AArch64 within this layer."""
+        layer = context.layers[layer_name]
+        join = interfaces.configuration.path_join
+
+        # Never stack on top of a translation layer
+        if isinstance(layer, (intel.Intel, arm.AArch64)):
+            return None
+
+        linux_banners = symbol_cache.load_cache_manager().get_identifier_dictionary(
+            operating_system="linux"
+        )
+        if not linux_banners:
+            vollog.info(
+                "No Linux banners found - if this is a linux plugin, please check your symbol files location"
+            )
+            return None
+
+        mss = scanners.MultiStringScanner([x for x in linux_banners if x is not None])
+        for _, banner in layer.scan(
+            context=context, scanner=mss, progress_callback=progress_callback
+        ):
+            dtb = None
+            vollog.debug(f"Identified banner: {repr(banner)}")
+
+            isf_path = linux_banners.get(banner, None)
+            if isf_path:
+                table_name = context.symbol_space.free_table_name("LinuxAArch64Stacker")
+                table = linux.LinuxKernelIntermedSymbols(
+                    context,
+                    "temporary." + table_name,
+                    name=table_name,
+                    isf_url=isf_path,
+                )
+                context.symbol_space.append(table)
+
+                # Check if this is an ARM64 kernel by examining swapper_pg_dir address
+                if "swapper_pg_dir" not in table.symbols:
+                    continue
+
+                swapper_addr = table.get_symbol("swapper_pg_dir").address
+
+                # Determine VA_BITS and layer class from swapper_pg_dir address
+                layer_class, va_bits = cls._detect_va_bits(table, swapper_addr)
+                if layer_class is None:
+                    continue
+
+                vollog.debug(
+                    f"AArch64 detected: VA_BITS={va_bits}, swapper_pg_dir=0x{swapper_addr:x}"
+                )
+
+                dtb, aslr_shift = cls.find_aslr(
+                    context,
+                    table_name,
+                    layer_name,
+                    progress_callback=progress_callback,
+                )
+
+                # Build the new layer
+                new_layer_name = context.layers.free_layer_name("AArch64Layer")
+                config_path = join("AArch64Helper", new_layer_name)
+                context.config[join(config_path, "memory_layer")] = layer_name
+                context.config[join(config_path, "page_map_offset")] = dtb
+                context.config[
+                    join(config_path, LinuxSymbolFinder.banner_config_key)
+                ] = str(banner, "latin-1")
+
+                layer = layer_class(
+                    context,
+                    config_path=config_path,
+                    name=new_layer_name,
+                    metadata={"os": "Linux"},
+                )
+                layer.config["kernel_virtual_offset"] = aslr_shift
+
+            if layer and dtb:
+                vollog.debug(f"DTB was found at: 0x{dtb:0x}")
+                return layer
+        vollog.debug("No suitable linux AArch64 banner could be matched")
+        return None
+
+    @classmethod
+    def _detect_va_bits(cls, table, swapper_addr):
+        """Detect VA_BITS configuration and return (layer_class, va_bits) or (None, None).
+
+        Uses swapper_pg_dir address to infer VA_BITS, and confirms this is ARM64
+        (not Intel) by checking for the absence of Intel-specific symbols.
+        """
+        # Intel x86-64 kernels have init_top_pgt or init_level4_pgt
+        has_intel_symbols = (
+            "init_top_pgt" in table.symbols or "init_level4_pgt" in table.symbols
+        )
+
+        if swapper_addr >= cls._PAGE_OFFSET_39:
+            # Could be 39-bit ARM64 or Intel x86-64/x86-32
+            if has_intel_symbols:
+                return None, None
+            # Also skip if this looks like x86-32 (address below 64-bit range)
+            if swapper_addr < 0xFFFF000000000000 and swapper_addr < cls._PAGE_OFFSET_39:
+                return None, None
+            return arm.LinuxAArch64_39, 39
+        elif swapper_addr >= cls._PAGE_OFFSET_48:
+            if has_intel_symbols:
+                return None, None
+            return arm.LinuxAArch64_48, 48
+        elif swapper_addr >= cls._PAGE_OFFSET_52:
+            return arm.LinuxAArch64_52, 52
+        else:
+            return None, None
+
+    @classmethod
+    def find_aslr(
+        cls,
+        context: interfaces.context.ContextInterface,
+        symbol_table: str,
+        layer_name: str,
+        progress_callback: constants.ProgressCallback = None,
+    ) -> Tuple[int, int]:
+        """Determines the DTB and ASLR shift for ARM64 Linux.
+
+        On ARM64, kernel image symbols are not mapped at PAGE_OFFSET (unlike x86),
+        so we cannot use a simple virtual_to_physical_address() formula. Instead,
+        we exploit the fact that all kernel image symbols share the same
+        virtual-to-physical offset (kimage_voffset). By finding init_task in
+        physical memory and knowing the virtual offset between init_task and
+        swapper_pg_dir from the ISF, we can compute swapper_pg_dir's physical
+        address directly.
+
+        Returns:
+            Tuple of (dtb_physical_address, aslr_shift)
+        """
+        init_task_symbol = symbol_table + constants.BANG + "init_task"
+        init_task_json_address = context.symbol_space.get_symbol(
+            init_task_symbol
+        ).address
+        swapper_json_address = context.symbol_space.get_symbol(
+            symbol_table + constants.BANG + "swapper_pg_dir"
+        ).address
+        swapper_signature = rb"swapper(\/0|\x00\x00)\x00\x00\x00\x00\x00\x00"
+        module = context.module(symbol_table, layer_name, 0)
+        address_mask = context.symbol_space[symbol_table].config.get(
+            "symbol_mask", None
+        )
+
+        task_symbol = module.get_type("task_struct")
+        comm_child_offset = task_symbol.relative_child_offset("comm")
+
+        # Relative offset between init_task and swapper_pg_dir in the kernel image
+        # This offset is preserved in physical memory regardless of KASLR
+        init_task_to_swapper_offset = init_task_json_address - swapper_json_address
+
+        for offset in context.layers[layer_name].scan(
+            scanner=scanners.RegExScanner(swapper_signature),
+            context=context,
+            progress_callback=progress_callback,
+        ):
+            init_task_address = offset - comm_child_offset
+            init_task = module.object(
+                object_type="task_struct", offset=init_task_address, absolute=True
+            )
+            if init_task.pid != 0:
+                continue
+            elif (
+                init_task.has_member("state")
+                and init_task.state.cast("unsigned int") != 0
+            ):
+                continue
+            elif init_task.active_mm.cast("long unsigned int") == module.get_symbol(
+                "init_mm"
+            ).address and init_task.tasks.next.cast(
+                "long unsigned int"
+            ) == init_task.tasks.prev.cast("long unsigned int"):
+                continue
+
+            aslr_shift = (
+                int.from_bytes(
+                    init_task.files.cast("bytes", length=init_task.files.vol.size),
+                    byteorder=init_task.files.vol.data_format.byteorder,
+                )
+                - module.get_symbol("init_files").address
+            )
+            if address_mask:
+                aslr_shift = aslr_shift & address_mask
+
+            # Compute DTB (swapper_pg_dir physical address) using relative offset
+            dtb = init_task_address - init_task_to_swapper_offset
+
+            if aslr_shift & 0xFFF != 0 or dtb & 0xFFF != 0:
+                continue
+            vollog.debug(
+                f"Linux AArch64 ASLR shift determined: virtual {aslr_shift:0x}, "
+                f"DTB computed at 0x{dtb:x}"
+            )
+            return dtb, aslr_shift
+
+        vollog.debug(
+            "Scanners could not determine AArch64 DTB/ASLR, using 0 for both"
+        )
+        return 0, 0
+
+
 class LinuxSymbolFinder(symbol_finder.SymbolFinder):
     """Linux symbol loader based on uname signature strings."""
 
@@ -256,9 +483,9 @@ class LinuxIntelVMCOREINFOStacker(interfaces.automagic.StackerLayerInterface):
         # Bail out by default unless we can stack properly
         layer = context.layers[layer_name]
 
-        # Never stack on top of an intel layer
+        # Never stack on top of a translation layer
         # FIXME: Find a way to improve this check
-        if isinstance(layer, intel.Intel):
+        if isinstance(layer, (intel.Intel, arm.AArch64)):
             return None
 
         linux_banners = symbol_cache.load_cache_manager().get_identifier_dictionary(

--- a/volatility3/framework/constants/architectures.py
+++ b/volatility3/framework/constants/architectures.py
@@ -1,13 +1,13 @@
-from volatility3.framework.layers import intel
+from volatility3.framework.layers import arm, intel
 
 WIN_ARCHS = ["Intel32", "Intel64"]
 """Windows supported architectures"""
 WIN_ARCHS_LAYERS = [intel.Intel]
 """Windows supported architectures layers"""
 
-LINUX_ARCHS = ["Intel32", "Intel64"]
+LINUX_ARCHS = ["Intel32", "Intel64", "AArch64"]
 """Linux supported architectures"""
-LINUX_ARCHS_LAYERS = [intel.Intel]
+LINUX_ARCHS_LAYERS = [intel.Intel, arm.AArch64]
 """Linux supported architectures layers"""
 
 MAC_ARCHS = ["Intel32", "Intel64"]
@@ -15,7 +15,7 @@ MAC_ARCHS = ["Intel32", "Intel64"]
 MAC_ARCHS_LAYERS = [intel.Intel]
 """Mac supported architectures layers"""
 
-FRAMEWORK_ARCHS = ["Intel32", "Intel64"]
+FRAMEWORK_ARCHS = ["Intel32", "Intel64", "AArch64"]
 """Framework supported architectures"""
-FRAMEWORK_ARCHS_LAYERS = [intel.Intel]
+FRAMEWORK_ARCHS_LAYERS = [intel.Intel, arm.AArch64]
 """Framework supported architectures layers"""

--- a/volatility3/framework/layers/arm.py
+++ b/volatility3/framework/layers/arm.py
@@ -1,0 +1,502 @@
+# This file is Copyright 2024 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+
+import collections
+import functools
+import logging
+import math
+import struct
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from volatility3 import classproperty
+from volatility3.framework import constants, exceptions, interfaces
+from volatility3.framework.configuration import requirements
+from volatility3.framework.layers import linear
+
+vollog = logging.getLogger(__name__)
+
+AARCH64_TRANSLATION_DEBUGGING = False
+
+
+class AArch64(linear.LinearlyMappedLayer):
+    """Translation Layer for AArch64 (ARM64) memory mapping.
+
+    Supports 4KB granule with 39-bit, 48-bit, and 52-bit virtual address spaces.
+    """
+
+    _entry_format = "<Q"
+    _page_size_in_bits = 12
+    _bits_per_register = 64
+    # Subclasses must define _maxphyaddr, _maxvirtaddr, _structure
+    _maxphyaddr = 48
+    _maxvirtaddr = 48
+    _structure = []
+    _direct_metadata = collections.ChainMap(
+        {"architecture": "AArch64"},
+        {"mapped": True},
+        interfaces.layers.TranslationLayerInterface._direct_metadata,
+    )
+
+    def __init__(
+        self,
+        context: interfaces.context.ContextInterface,
+        config_path: str,
+        name: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(
+            context=context, config_path=config_path, name=name, metadata=metadata
+        )
+        self._base_layer = self.config["memory_layer"]
+        self._swap_layers: List[str] = []
+        self._page_map_offset = self.config["page_map_offset"]
+
+        # Assign constants
+        self._initial_position = min(self._maxvirtaddr, self._bits_per_register) - 1
+        self._initial_entry = (
+            self._mask(self._page_map_offset, self._initial_position, 0) | 0x1
+        )
+        self._entry_size = struct.calcsize(self._entry_format)
+        self._entry_number = self.page_size // self._entry_size
+        self._canonical_prefix = self._mask(
+            (1 << self._bits_per_register) - 1,
+            self._bits_per_register,
+            self._maxvirtaddr,
+        )
+
+        # These can vary depending on the type of space
+        self._index_shift = math.ceil(math.log2(struct.calcsize(self._entry_format)))
+
+    @classproperty
+    @functools.lru_cache
+    def page_shift(cls) -> int:
+        """Page shift for the AArch64 memory layers."""
+        return cls._page_size_in_bits
+
+    @classproperty
+    @functools.lru_cache
+    def page_size(cls) -> int:
+        """Page size for the AArch64 memory layers (4KB)."""
+        return 1 << cls._page_size_in_bits
+
+    @classproperty
+    @functools.lru_cache
+    def page_mask(cls) -> int:
+        """Page mask for the AArch64 memory layers."""
+        return ~(cls.page_size - 1)
+
+    @classproperty
+    @functools.lru_cache
+    def bits_per_register(cls) -> int:
+        """Returns the bits_per_register to determine the range of an
+        AArch64TranslationLayer."""
+        return cls._bits_per_register
+
+    @classproperty
+    @functools.lru_cache
+    def minimum_address(cls) -> int:
+        return 0
+
+    @classproperty
+    @functools.lru_cache
+    def maximum_address(cls) -> int:
+        return (1 << cls._maxvirtaddr) - 1
+
+    @classproperty
+    def structure(cls) -> List[Tuple[str, int, bool]]:
+        return cls._structure
+
+    @staticmethod
+    def _mask(value: int, high_bit: int, low_bit: int) -> int:
+        """Returns the bits of a value between highbit and lowbit inclusive."""
+        high_mask = (1 << (high_bit + 1)) - 1
+        low_mask = (1 << low_bit) - 1
+        mask = high_mask ^ low_mask
+        return value & mask
+
+    @staticmethod
+    def _page_is_valid(entry: int) -> bool:
+        """Returns whether a particular page is valid based on its entry.
+
+        ARM64 PTE_VALID is bit 0.
+        """
+        return bool(entry & 0x1)
+
+    @staticmethod
+    def _page_is_dirty(entry: int) -> bool:
+        """Returns whether a particular page is dirty based on its entry.
+
+        ARM64 uses bit 51 (PTE_DBM / hardware dirty bit).
+        """
+        return bool(entry & (1 << 51))
+
+    def canonicalize(self, addr: int) -> int:
+        """Canonicalizes an address by performing an appropriate sign extension on the higher addresses"""
+        if self._bits_per_register <= self._maxvirtaddr:
+            return addr & self.address_mask
+        elif addr < (1 << self._maxvirtaddr - 1):
+            return addr
+        return self._mask(addr, self._maxvirtaddr, 0) + self._canonical_prefix
+
+    def decanonicalize(self, addr: int) -> int:
+        """Removes canonicalization to ensure an address fits within the correct range"""
+        if addr < (1 << self._maxvirtaddr - 1):
+            return addr
+        return addr ^ self._canonical_prefix
+
+    def _translate(self, offset: int) -> Tuple[int, int, str]:
+        """Translates a specific offset based on paging tables.
+
+        Returns the translated offset, the contiguous pagesize that the
+        translated address lives in and the layer_name that the address
+        lives in
+        """
+        entry, position = self._translate_entry(offset & self.page_mask)
+
+        # Now we're done
+        if not self._page_is_valid(entry):
+            raise exceptions.PagedInvalidAddressException(
+                self.name,
+                offset,
+                position + 1,
+                entry,
+                f"Page Fault at entry {hex(entry)} in page entry",
+            )
+
+        pfn = self._pte_pfn(entry)
+        page_offset = self._mask(offset, position, 0)
+        page = pfn << self.page_shift | page_offset
+
+        return page, 1 << (position + 1), self._base_layer
+
+    def _pte_pfn(self, entry: int) -> int:
+        """Extracts the page frame number (PFN) from the page table entry (PTE) entry"""
+        return self._mask(entry, self._maxphyaddr - 1, 0) >> self.page_shift
+
+    @functools.lru_cache(maxsize=1024)
+    def _translate_entry(self, page_address: int) -> Tuple[int, int]:
+        """Translates a page address based on paging tables.
+
+        Args:
+            page_address: The page base address
+
+        Returns:
+            the translated entry value and position
+        """
+        # Setup the entry and how far we are through the offset
+        position = self._initial_position
+        entry = self._initial_entry
+
+        if not (
+            self.minimum_address
+            <= (page_address & self.address_mask)
+            <= self.maximum_address
+        ):
+            raise exceptions.PagedInvalidAddressException(
+                self.name,
+                page_address,
+                position + 1,
+                entry,
+                "Entry outside virtual address range: " + hex(entry),
+            )
+
+        # Run through the offset in various chunks
+        for name, size, large_page in self._structure:
+            # Check we're valid
+            if not self._page_is_valid(entry):
+                raise exceptions.PagedInvalidAddressException(
+                    self.name,
+                    page_address,
+                    position + 1,
+                    entry,
+                    "Page Fault at entry " + hex(entry) + " in table " + name,
+                )
+
+            # Grab the base address of the table we'll be getting the next entry from
+            base_address = self._mask(
+                entry, self._maxphyaddr - 1, size + self._index_shift
+            )
+
+            table = self._get_valid_table(base_address)
+            if table is None:
+                raise exceptions.PagedInvalidAddressException(
+                    self.name,
+                    page_address,
+                    position + 1,
+                    entry,
+                    "Page Fault at entry " + hex(entry) + " in table " + name,
+                )
+
+            # Figure out how much of the offset we should be using
+            start = position
+            position -= size
+            index = self._mask(page_address, start, position + 1) >> (position + 1)
+
+            # Read the data for the next entry
+            entry_data_start = index << self._index_shift
+            entry_data = table[entry_data_start : entry_data_start + self._entry_size]
+
+            if AARCH64_TRANSLATION_DEBUGGING:
+                vollog.log(
+                    constants.LOGLEVEL_VVVV,
+                    f"Entry {hex(entry)} at index {hex(index)} gives data {hex(struct.unpack(self._entry_format, entry_data)[0])} as {name}",
+                )
+
+            # Read out the new entry from memory
+            (entry,) = struct.unpack(self._entry_format, entry_data)
+
+            # Check if we're a block descriptor (large page)
+            # ARM64: (entry & 0x3) == 0x1 means block descriptor (valid but not table)
+            # This is the ARM64 equivalent of Intel's PSE bit
+            if large_page and (entry & 0x3) == 0x1:
+                # We're a block descriptor, the rest is finished below
+                break
+
+        return entry, position
+
+    @functools.lru_cache(maxsize=1025)
+    def _get_valid_table(self, base_address: int) -> Optional[bytes]:
+        """Extracts the table, validates it and returns it if it's valid."""
+        try:
+            table = self._context.layers.read(
+                self._base_layer, base_address, self.page_size
+            )
+        except exceptions.InvalidAddressException:
+            # Some memory capture tools (e.g., AVML) have off-by-one errors
+            # in segment boundaries, causing reads at the end of a segment to
+            # fail for the last few bytes. Use padded read as a fallback.
+            try:
+                table = self._context.layers.read(
+                    self._base_layer, base_address, self.page_size, pad=True
+                )
+            except exceptions.InvalidAddressException:
+                return None
+
+        # If the table is entirely duplicates, then mark the whole table as bad
+        if table == table[: self._entry_size] * self._entry_number:
+            return None
+        return table
+
+    def is_valid(self, offset: int, length: int = 1) -> bool:
+        """Returns whether the address offset can be translated to a valid
+        address."""
+        try:
+            return all(
+                self._context.layers[layer].is_valid(mapped_offset)
+                for _, _, mapped_offset, _, layer in self.mapping(offset, length)
+            )
+        except exceptions.InvalidAddressException:
+            return False
+
+    def is_dirty(self, offset: int) -> bool:
+        """Returns whether the page at offset is marked dirty"""
+        return self._page_is_dirty(self._translate_entry(offset & self.page_mask)[0])
+
+    def mapping(
+        self, offset: int, length: int, ignore_errors: bool = False
+    ) -> Iterable[Tuple[int, int, int, int, str]]:
+        """Returns a sorted iterable of (offset, sublength, mapped_offset, mapped_length, layer)
+        mappings.
+
+        This allows translation layers to provide maps of contiguous
+        regions in one layer
+        """
+        stashed_offset = stashed_mapped_offset = stashed_size = stashed_mapped_size = (
+            stashed_map_layer
+        ) = None
+        for offset, size, mapped_offset, mapped_size, map_layer in self._mapping(
+            offset, length, ignore_errors
+        ):
+            if (
+                stashed_offset is None
+                or (stashed_offset + stashed_size != offset)
+                or (stashed_mapped_offset + stashed_mapped_size != mapped_offset)
+                or (stashed_map_layer != map_layer)
+            ):
+                # The block isn't contiguous
+                if stashed_offset is not None:
+                    yield (
+                        stashed_offset,
+                        stashed_size,
+                        stashed_mapped_offset,
+                        stashed_mapped_size,
+                        stashed_map_layer,
+                    )
+                # Update all the stashed values after output
+                stashed_offset = offset
+                stashed_mapped_offset = mapped_offset
+                stashed_size = size
+                stashed_mapped_size = mapped_size
+                stashed_map_layer = map_layer
+            else:
+                # Part of an existing block
+                stashed_size += size
+                stashed_mapped_size += mapped_size
+        # Yield whatever's left
+        if (
+            stashed_offset is not None
+            and stashed_mapped_offset is not None
+            and stashed_size is not None
+            and stashed_mapped_size is not None
+            and stashed_map_layer is not None
+        ):
+            yield (
+                stashed_offset,
+                stashed_size,
+                stashed_mapped_offset,
+                stashed_mapped_size,
+                stashed_map_layer,
+            )
+
+    def _mapping(
+        self, offset: int, length: int, ignore_errors: bool = False
+    ) -> Iterable[Tuple[int, int, int, int, str]]:
+        """Returns a sorted iterable of (offset, sublength, mapped_offset, mapped_length, layer)
+        mappings.
+
+        This allows translation layers to provide maps of contiguous
+        regions in one layer
+        """
+        if length == 0:
+            try:
+                mapped_offset, _, layer_name = self._translate(offset)
+                if not self._context.layers[layer_name].is_valid(mapped_offset):
+                    raise exceptions.InvalidAddressException(
+                        layer_name=layer_name, invalid_address=mapped_offset
+                    )
+            except exceptions.InvalidAddressException:
+                if not ignore_errors:
+                    raise
+                return None
+            yield offset, length, mapped_offset, length, layer_name
+            return None
+        while length > 0:
+            skip_mask = None
+            try:
+                chunk_offset, page_size, layer_name = self._translate(offset)
+                # Page align the chunk size value
+                chunk_size = min(page_size - (offset % page_size), length)
+                if not self._context.layers[layer_name].is_valid(
+                    chunk_offset, chunk_size
+                ):
+                    skip_mask = chunk_size - 1
+                    raise exceptions.InvalidAddressException(
+                        layer_name=layer_name, invalid_address=chunk_offset
+                    )
+            except (
+                exceptions.PagedInvalidAddressException,
+                exceptions.InvalidAddressException,
+            ) as excp:
+                if not ignore_errors:
+                    raise
+                if skip_mask is None:
+                    if isinstance(excp, exceptions.PagedInvalidAddressException):
+                        skip_mask = (1 << excp.invalid_bits) - 1
+                    else:
+                        skip_mask = (1 << self._page_size_in_bits) - 1
+                length_diff = skip_mask + 1 - (offset & skip_mask)
+                length -= length_diff
+                offset += length_diff
+            else:
+                yield offset, chunk_size, chunk_offset, chunk_size, layer_name
+                length -= chunk_size
+                offset += chunk_size
+
+    @property
+    def dependencies(self) -> List[str]:
+        """Returns a list of the lower layer names that this layer is dependent
+        upon."""
+        return [self._base_layer] + self._swap_layers
+
+    @classmethod
+    def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
+        return [
+            requirements.TranslationLayerRequirement(
+                name="memory_layer", optional=False
+            ),
+            requirements.LayerListRequirement(name="swap_layers", optional=True),
+            requirements.IntRequirement(name="page_map_offset", optional=False),
+            requirements.IntRequirement(name="kernel_virtual_offset", optional=True),
+            requirements.StringRequirement(name="kernel_banner", optional=True),
+        ]
+
+
+class AArch64_39(AArch64):
+    """AArch64 with 39-bit virtual address space, 3-level page table (4KB granule)."""
+
+    _maxphyaddr = 48
+    _maxvirtaddr = 39
+    _structure = [
+        ("level 1 table", 9, True),
+        ("level 2 table", 9, True),
+        ("level 3 table", 9, False),
+    ]
+
+
+class AArch64_48(AArch64):
+    """AArch64 with 48-bit virtual address space, 4-level page table (4KB granule)."""
+
+    _maxphyaddr = 48
+    _maxvirtaddr = 48
+    _structure = [
+        ("level 0 table", 9, False),
+        ("level 1 table", 9, True),
+        ("level 2 table", 9, True),
+        ("level 3 table", 9, False),
+    ]
+
+
+class AArch64_52(AArch64):
+    """AArch64 with 52-bit virtual address space, 5-level page table (4KB granule)."""
+
+    _maxphyaddr = 52
+    _maxvirtaddr = 52
+    _structure = [
+        ("level -1 table", 4, False),
+        ("level 0 table", 9, False),
+        ("level 1 table", 9, True),
+        ("level 2 table", 9, True),
+        ("level 3 table", 9, False),
+    ]
+
+
+class LinuxAArch64(AArch64):
+    """Linux-specific AArch64 PTE handling.
+
+    Handles PROT_NONE pages where PTE_VALID (bit 0) is clear but
+    PTE_PRESENT_INVALID (bit 11, PTE_NG) is set.
+    No PTE inversion is needed (ARM64 Linux does not use XOR inversion like x86).
+    """
+
+    @staticmethod
+    def _page_is_valid(entry: int) -> bool:
+        """Returns whether a particular page is valid based on its entry.
+
+        ARM64 Linux page presence check:
+        - PTE_VALID (bit 0) set, OR
+        - PTE_PRESENT_INVALID (bit 11) set with PTE_VALID clear
+          (used for PROT_NONE pages)
+
+        See arch/arm64/include/asm/pgtable.h pte_present()
+        """
+        PTE_VALID = 1 << 0
+        PTE_PRESENT_INVALID = 1 << 11
+        if entry & PTE_VALID:
+            return True
+        return (entry & (PTE_PRESENT_INVALID | PTE_VALID)) == PTE_PRESENT_INVALID
+
+
+### These must be full separate classes so that JSON configs re-create them properly
+
+
+class LinuxAArch64_39(LinuxAArch64, AArch64_39):
+    pass
+
+
+class LinuxAArch64_48(LinuxAArch64, AArch64_48):
+    pass
+
+
+class LinuxAArch64_52(LinuxAArch64, AArch64_52):
+    pass

--- a/volatility3/framework/plugins/linux/bash.py
+++ b/volatility3/framework/plugins/linux/bash.py
@@ -16,6 +16,7 @@ from volatility3.framework.objects import utility
 from volatility3.framework.symbols.linux import bash
 from volatility3.plugins import timeliner
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 
 class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
@@ -30,7 +31,7 @@ class Bash(plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/boottime.py
+++ b/volatility3/framework/plugins/linux/boottime.py
@@ -9,6 +9,7 @@ from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.plugins import timeliner
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 
 class Boottime(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
@@ -23,7 +24,7 @@ class Boottime(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface)
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="timeliner",

--- a/volatility3/framework/plugins/linux/capabilities.py
+++ b/volatility3/framework/plugins/linux/capabilities.py
@@ -12,6 +12,7 @@ from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols.linux import extensions
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class Capabilities(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/ebpf.py
+++ b/volatility3/framework/plugins/linux/ebpf.py
@@ -8,6 +8,7 @@ from volatility3.framework import renderers, interfaces, exceptions
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.configuration import requirements
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class EBPF(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/elfs.py
+++ b/volatility3/framework/plugins/linux/elfs.py
@@ -16,6 +16,7 @@ from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.linux.extensions import elf
 from volatility3.framework.constants import linux as linux_constants
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 
 vollog = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ class Elfs(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/envars.py
+++ b/volatility3/framework/plugins/linux/envars.py
@@ -10,6 +10,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class Envars(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/iomem.py
+++ b/volatility3/framework/plugins/linux/iomem.py
@@ -8,6 +8,7 @@ from volatility3.framework import renderers, interfaces, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ class IOMem(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             )
         ]
 

--- a/volatility3/framework/plugins/linux/ip.py
+++ b/volatility3/framework/plugins/linux/ip.py
@@ -8,6 +8,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.symbols.linux import network
 from volatility3.framework.symbols.linux.extensions import network as net_extensions
+from volatility3.framework.constants import architectures
 
 
 class Addr(plugins.PluginInterface):
@@ -23,7 +24,7 @@ class Addr(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="Net", component=network.NetSymbols, version=(1, 0, 0)
@@ -145,7 +146,7 @@ class Link(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="Net", component=network.NetSymbols, version=(1, 0, 0)

--- a/volatility3/framework/plugins/linux/kmsg.py
+++ b/volatility3/framework/plugins/linux/kmsg.py
@@ -16,6 +16,7 @@ from volatility3.framework import (
 )
 from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -541,7 +542,7 @@ class Kmsg(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/library_list.py
+++ b/volatility3/framework/plugins/linux/library_list.py
@@ -12,6 +12,7 @@ from volatility3.framework.objects import utility
 from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.linux.extensions import elf
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 
 vollog = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ class LibraryList(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/lsof.py
+++ b/volatility3/framework/plugins/linux/lsof.py
@@ -13,6 +13,7 @@ from volatility3.framework.objects import utility
 from volatility3.framework.symbols import linux
 from volatility3.plugins.linux import pslist
 from volatility3.plugins import timeliner
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -118,7 +119,7 @@ class Lsof(plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/malware/check_afinfo.py
+++ b/volatility3/framework/plugins/linux/malware/check_afinfo.py
@@ -12,6 +12,7 @@ from volatility3.framework import renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.renderers import format_hints
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ class Check_afinfo(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
         ]
 

--- a/volatility3/framework/plugins/linux/malware/check_creds.py
+++ b/volatility3/framework/plugins/linux/malware/check_creds.py
@@ -6,6 +6,7 @@ from volatility3.framework import interfaces, renderers
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.configuration import requirements
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 
 class Check_creds(interfaces.plugins.PluginInterface):
@@ -20,7 +21,7 @@ class Check_creds(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/malware/keyboard_notifiers.py
+++ b/volatility3/framework/plugins/linux/malware/keyboard_notifiers.py
@@ -9,6 +9,7 @@ from volatility3.framework import interfaces, renderers, exceptions
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import linux
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class Keyboard_notifiers(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="linux_utilities_modules",

--- a/volatility3/framework/plugins/linux/malware/malfind.py
+++ b/volatility3/framework/plugins/linux/malware/malfind.py
@@ -10,6 +10,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.linux import pslist, proc
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class Malfind(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/malware/netfilter.py
+++ b/volatility3/framework/plugins/linux/malware/netfilter.py
@@ -18,6 +18,7 @@ from volatility3.framework import (
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols.linux import network
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -752,7 +753,7 @@ class Netfilter(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="linux_utilities_module_gatherers",

--- a/volatility3/framework/plugins/linux/malware/process_spoofing.py
+++ b/volatility3/framework/plugins/linux/malware/process_spoofing.py
@@ -13,6 +13,7 @@ from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.framework.symbols import linux
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class ProcessSpoofing(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/malware/tty_check.py
+++ b/volatility3/framework/plugins/linux/malware/tty_check.py
@@ -12,6 +12,7 @@ from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.symbols import linux
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ class Tty_Check(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="linux_utilities_modules",

--- a/volatility3/framework/plugins/linux/module_extract.py
+++ b/volatility3/framework/plugins/linux/module_extract.py
@@ -10,6 +10,7 @@ from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.framework.objects import utility
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -28,8 +29,8 @@ class ModuleExtract(interfaces.plugins.PluginInterface):
         return [
             requirements.ModuleRequirement(
                 name="kernel",
-                description="Windows kernel",
-                architectures=["Intel32", "Intel64"],
+                description="Linux kernel",
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.IntRequirement(
                 name="base",

--- a/volatility3/framework/plugins/linux/mountinfo.py
+++ b/volatility3/framework/plugins/linux/mountinfo.py
@@ -11,6 +11,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.symbols import linux
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 
 vollog = logging.getLogger(__name__)
@@ -44,7 +45,7 @@ class MountInfo(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/pidhashtable.py
+++ b/volatility3/framework/plugins/linux/pidhashtable.py
@@ -11,6 +11,7 @@ from volatility3.framework.renderers import format_hints
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.configuration import requirements
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class PIDHashTable(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/proc.py
+++ b/volatility3/framework/plugins/linux/proc.py
@@ -13,6 +13,7 @@ from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class Maps(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/psaux.py
+++ b/volatility3/framework/plugins/linux/psaux.py
@@ -9,6 +9,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 
 class PsAux(plugins.PluginInterface):
@@ -24,7 +25,7 @@ class PsAux(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/pslist.py
+++ b/volatility3/framework/plugins/linux/pslist.py
@@ -14,6 +14,7 @@ from volatility3.framework.symbols import intermed
 from volatility3.framework.symbols.linux.extensions import elf
 from volatility3.plugins import timeliner
 from volatility3.plugins.linux import elfs
+from volatility3.framework.constants import architectures
 
 
 @dataclasses.dataclass
@@ -42,7 +43,7 @@ class PsList(interfaces.plugins.PluginInterface, timeliner.TimeLinerInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="elfs", component=elfs.Elfs, version=(2, 0, 0)

--- a/volatility3/framework/plugins/linux/psscan.py
+++ b/volatility3/framework/plugins/linux/psscan.py
@@ -11,6 +11,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.layers import scanners
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ class PsScan(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/pstree.py
+++ b/volatility3/framework/plugins/linux/pstree.py
@@ -8,6 +8,7 @@ from volatility3.framework import interfaces, renderers
 from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class PsTree(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/sockscan.py
+++ b/volatility3/framework/plugins/linux/sockscan.py
@@ -16,6 +16,7 @@ from volatility3.framework import symbols
 from volatility3.plugins.linux import lsof, pslist, sockstat
 from volatility3.framework.layers import scanners
 from volatility3.framework.symbols.linux import network
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class Sockscan(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="SockHandlers", component=sockstat.SockHandlers, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/sockstat.py
+++ b/volatility3/framework/plugins/linux/sockstat.py
@@ -14,6 +14,7 @@ from volatility3.framework.symbols import linux
 from volatility3.plugins.linux import lsof
 from volatility3.plugins.linux import pslist
 from volatility3.framework.symbols.linux import network
+from volatility3.framework.constants import architectures
 
 
 vollog = logging.getLogger(__name__)
@@ -458,7 +459,7 @@ class Sockstat(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="SockHandlers", component=SockHandlers, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/tracing/perf_events.py
+++ b/volatility3/framework/plugins/linux/tracing/perf_events.py
@@ -10,6 +10,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.interfaces import plugins
 from volatility3.framework.objects import utility
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class PerfEvents(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/vmaregexscan.py
+++ b/volatility3/framework/plugins/linux/vmaregexscan.py
@@ -13,6 +13,7 @@ from volatility3.framework.layers import scanners
 from volatility3.framework.objects import utility
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class VmaRegExScan(plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
             requirements.VersionRequirement(
                 name="pslist", component=pslist.PsList, version=(4, 0, 0)

--- a/volatility3/framework/plugins/linux/vmayarascan.py
+++ b/volatility3/framework/plugins/linux/vmayarascan.py
@@ -10,6 +10,7 @@ from volatility3.framework.configuration import requirements
 from volatility3.framework.renderers import format_hints
 from volatility3.plugins import yarascan
 from volatility3.plugins.linux import pslist
+from volatility3.framework.constants import architectures
 
 vollog = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ class VmaYaraScan(interfaces.plugins.PluginInterface):
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Linux kernel",
-                architectures=["Intel32", "Intel64"],
+                architectures=architectures.LINUX_ARCHS,
             ),
         ]
 


### PR DESCRIPTION
# [linux] Add AArch64 (ARM64) Support for Linux Memory Analysis

## Summary
- Adds ARM64 page table translation for Linux memory images
- Supports 4KB granule with 39-bit, 48-bit, and 52-bit virtual address spaces
- 51 of 59 Linux plugins verified working on ARM64

## Motivation
I have ARM64 deployed servers (AWS Graviton mostly), which I wanted to
be able to do memory forensics on and there did not appear to be a mainlined 
Volatility3 ARM64 support. PR #1088 has prior work but remains in DRAFT
so I thought I would try contribute or at least make this an available option for
people in dire ARM64 response need. Yep this PR is AI assisted, I am more of 
a kernel hacker than qualified kernel engineer if anything and won't pretend to 
be a mem management ARM64 expert (working on it ;)) but have manually 
reviewed, tested and tweaked. Hopefully someone more versed in this space than I 
can review and catch any issues.

## Architecture & Design Decisions

### Translation Layer (`volatility3/framework/layers/arm.py`)
- Sibling to Intel layer (both inherit `LinearlyMappedLayer`), not a child
- ARM64 descriptor type detection: `(entry & 0x3) == 0x1` for block descriptors
- PTE bits: PTE_VALID (bit 0), PTE_PRESENT_INVALID (bit 11), PTE_DBM dirty (bit 51)
- `LinuxAArch64` mixin handles PROT_NONE pages (PTE_PRESENT_INVALID set, PTE_VALID clear)
- No PTE inversion needed (unlike x86 Linux)
- Padded read fallback in `_get_valid_table` 

### VA_BITS Configurations
| VA_BITS | Levels | PAGE_OFFSET | Layer Class |
|---------|--------|-------------|-------------|
| 39 | 3 | `0xFFFFFF8000000000` | LinuxAArch64_39 |
| 48 | 4 | `0xFFFF000000000000` | LinuxAArch64_48 |
| 52 | 5 | `0xFFF0000000000000` | LinuxAArch64_52 |

### Automagic Stacker (`LinuxAArch64Stacker`)
- Detects ARM64 kernels by `swapper_pg_dir` address range
- VA_BITS inferred from PAGE_OFFSET = -(1 << VA_BITS)
- KASLR detection via relative symbol offsets (init_task <-> swapper_pg_dir)
- DTB from physical address of swapper_pg_dir

### Plugin Compatibility
- 31 plugins updated: hardcoded `["Intel32", "Intel64"]` -> `architectures.LINUX_ARCHS`
- 2 plugins kept Intel-only: `check_idt.py` (IDT is x86), `check_syscall.py` (x86 syscall table)
- 12 plugins already used `architectures.LINUX_ARCHS` (auto-supported)

## Files Changed

| File | Change |
|------|--------|
| `framework/layers/arm.py` | **NEW** -- AArch64 translation layer (503 lines) |
| `framework/automagic/linux.py` | Add LinuxAArch64Stacker (~215 lines), guard checks |
| `framework/constants/architectures.py` | Add AArch64 to LINUX_ARCHS, FRAMEWORK_ARCHS |
| 31 plugin files | Update architecture requirements |

## Testing

Validated across **three ARM64 hosts spanning two distributions and three
kernel versions**, using Lima on Apple Silicon (native `vmType: vz`, no
emulation). The full Linux plugin set was swept top-to-bottom against a fresh
LiME capture via AVML on each host and the results compared.

### Environments

| Host | Distro | Kernel | VA_BITS / granule | Layer class | ISF toolchain |
|------|--------|--------|-------------------|-------------|---------------|
| ubuntu2504-arm64 | Ubuntu 25.04 | 6.17.0-6-generic | 48-bit / 4KB | `LinuxAArch64_48` | `linux-image-*-dbgsym` (ddebs) |
| fedora42-arm64 | Fedora 42 | 6.14.0-63.fc42 | 48-bit / 4KB | `LinuxAArch64_48` | `dnf debuginfo-install kernel-core` |
| fedora43-arm64 | Fedora 43 | 6.17.1-300.fc43 | 48-bit / 4KB | `LinuxAArch64_48` | `dnf debuginfo-install kernel-core` |

- **Memory capture**: AVML -> LiME format (`avml acquire`, ~6-8GB).
- **Note on VA_BITS**: stock Fedora aarch64 kernels (42 and 43) are built with
  `CONFIG_ARM64_VA_BITS_48=y` / `CONFIG_ARM64_4K_PAGES=y`, identical to Ubuntu.
  All three therefore exercise the `LinuxAArch64_48` path. The 39-bit and 52-bit
  (LPA2) layer classes remain implemented-per-spec but not yet exercised by a
  real image, since no readily-available stock distro ships those configs.
- **Cross-distro value**: the three hosts still validate the stacker/layer
  against three distinct kernel builds (6.17 Ubuntu, 6.14 Fedora, 6.17 Fedora)
  and two independent symbol-generation toolchains (Ubuntu ddebs vs Fedora
  `debuginfo-install`), confirming the ISF path is distro-agnostic.

### Plugin Results

The same set of failures appears on **all three hosts** (including the
originally-validated Ubuntu host), so none are Fedora or kernel-specific
regressions introduced by this work. Every page-table-translation-dependent
plugin (pslist, pstree, proc.Maps, elfs, lsof, malfind, psscan, pagecache.Files)
returns correct, data-bearing output on all three hosts.

**Working (identical on all three hosts):** all core and malware plugins —
linux.pslist, linux.pstree, linux.lsmod, linux.lsof, linux.mountinfo,
linux.proc.Maps, linux.envars, linux.psaux, linux.kmsg, linux.bash,
linux.ip.Addr, linux.ip.Link, linux.sockstat, linux.sockscan, linux.capabilities,
linux.iomem, linux.library_list, linux.check_creds, linux.check_afinfo,
linux.check_modules, linux.pidhashtable, linux.keyboard_notifiers,
linux.tty_check, linux.malware.process_spoofing, linux.pagecache.Files,
linux.pagecache.InodePages, linux.ptrace, linux.kthreads, linux.modxview,
linux.graphics.fbdev, linux.tracing.ftrace, linux.tracing.tracepoints,
linux.tracing.perf_events, linux.ebpf, linux.netfilter, linux.psscan,
linux.hidden_modules, linux.elfs, linux.malfind, linux.vmayarascan,
linux.vmaregexscan, linux.vmcoreinfo, and the `linux.malware.*` variants.
(`linux.sockscan` — flagged for further investigation in the original single-host
run — returns correct socket rows on all three hosts here.)

**Working with required args:** linux.module_extract (needs `--base`, confirmed
producing a valid extracted `.elf`), linux.vmayarascan (`--yara-string`),
linux.vmaregexscan (`--pattern`).

**Correctly excluded (x86-only, by design):** linux.check_idt, linux.check_syscall
(and their `linux.malware.*` variants).

**Pre-existing issues, not ARM64 regressions (fail identically on Ubuntu):**
- `linux.kallsyms` — plugin bug (`pointer_to_string takes a Pointer`),
  architecture-independent.
- `linux.pscallstack` — depends on x86 `thread_struct.sp`; no ARM64 equivalent
  wired up yet (pre-existing ARM64 limitation).
- `linux.pagecache.RecoverFs` — file-*content* recovery calls `page.to_paddr()`,
  whose `vmemmap_start` calculation is currently Intel-only (see Known
  Limitations). The inode/page enumeration itself works; only content dumping is
  affected.

**Kernel-version issue (not ARM64-specific):**
- `linux.boottime` fails only on Fedora 43 (kernel 6.17): the `tk_core` symbol
  the plugin keys on was removed in 6.17 (now `timekeeper_data`). An x86 6.17
  image would fail identically; this is unrelated to AArch64 support.


#### Debug Output
Confirmation 

```
% uname -a
Darwin hostname.local 24.3.0 Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:24 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6030 arm64

% ./vol.py -vv -f memory.lime linux.psaux
INFO     volatility3.cli: Volatility plugins path: ['/Users/jmprbx/git/volatility3/volatility3/plugins', '/Users/jmprbx/git/volatility3/volatility3/framework/plugins']
INFO     volatility3.cli: Volatility symbols path: ['/Users/jmprbx/git/volatility3/volatility3/symbols', '/Users/jmprbx/git/volatility3/volatility3/framework/symbols', '/Users/jmprbx/.cache/volatility3/symbols']
INFO     volatility3.plugins.yarascan: Neither yara-x nor yara-python (>3.8.0) module was found, plugin (and dependent plugins) not available
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/Users/jmprbx/git/volatility3/volatility3/framework/plugins/yarascan.py", line 19, in <module>
    import yara_x
ModuleNotFoundError: No module named 'yara_x'
...
...
Volatility 3 Framework 2.28.2
INFO     volatility3.framework.automagic: Detected a linux category plugin
INFO     volatility3.framework.automagic: Running automagic: ConstructionMagic
INFO     volatility3.framework.automagic: Running automagic: SymbolCacheMagic
INFO     volatility3.framework.automagic: Running automagic: LayerStacker
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
DEBUG    volatility3.framework.automagic.linux: No suitable linux banner could be matched
DEBUG    volatility3.framework.automagic.linux: Identified banner: b'Linux version 6.17.0-6-generic (buildd@bos03-arm64-073) (aarch64-linux-gnu-gcc (Ubuntu 15.2.0-4ubuntu4) 15.2.0, GNU ld (GNU Binutils for Ubuntu) 2.45) #6-Ubuntu SMP PREEMPT_DYNAMIC Tue Oct  7 14:22:06 UTC 2025 (Ubuntu 6.17.0-6.6-generic 6.17.1)\n\x00'
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
DEBUG    volatility3.framework.symbols: Unresolved reference: LintelStacker1!assoc_array_ptr
DEBUG    volatility3.framework.symbols: Unresolved reference: LintelStacker1!netns_ipvs
DEBUG    volatility3.framework.symbols: Unresolved reference: LintelStacker1!mtd_info
...
...
DEBUG    volatility3.framework.symbols: Unresolved reference: LintelStacker1!ib_pkey_cache
DEBUG    volatility3.framework.automagic.linux: Linux ASLR shift values determined: physical -ffff7ffdde090000 virtual 170000
DEBUG    volatility3.framework.automagic.linux: Skipping non-Intel kernel: swapper_pg_dir at 0xffff800082be7000 without Intel page table symbols
DEBUG    volatility3.framework.automagic.linux: No suitable linux banner could be matched
DEBUG    volatility3.framework.automagic.linux: Identified banner: b'Linux version 6.17.0-6-generic (buildd@bos03-arm64-073) (aarch64-linux-gnu-gcc (Ubuntu 15.2.0-4ubuntu4) 15.2.0, GNU ld (GNU Binutils for Ubuntu) 2.45) #6-Ubuntu SMP PREEMPT_DYNAMIC Tue Oct  7 14:22:06 UTC 2025 (Ubuntu 6.17.0-6.6-generic 6.17.1)\n\x00'
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
DEBUG    volatility3.framework.automagic.linux: AArch64 detected: VA_BITS=48, swapper_pg_dir=0xffff800082be7000
...
...
DEBUG    volatility3.framework.automagic.linux: Linux AArch64 ASLR shift determined: virtual 170000, DTB computed at 0x1e4b57000
DEBUG    volatility3.framework.automagic.linux: DTB was found at: 0x1e4b57000
DEBUG    volatility3.framework.automagic.stacker: physical_layer maximum_address: 6372782104
DEBUG    volatility3.framework.automagic.stacker: Stacked layers: ['AArch64Layer', 'LimeLayer', 'FileLayer']
INFO     volatility3.framework.automagic: Running automagic: SymbolFinder  
INFO     volatility3.framework.automagic: Running automagic: LinuxSymbolFinder
DEBUG    volatility3.framework.automagic.symbol_finder: Identified banner: b'Linux version 6.17.0-6-generic (buildd@bos03-arm64-073) (aarch64-linux-gnu-gcc (Ubuntu 15.2.0-4ubuntu4) 15.2.0, GNU ld (GNU Binutils for Ubuntu) 2.45) #6-Ubuntu SMP PREEMPT_DYNAMIC Tue Oct  7 14:22:06 UTC 2025 (Ubuntu 6.17.0-6.6-generic 6.17.1)\n\x00'
DEBUG    volatility3.framework.automagic.symbol_finder: Using symbol library: file:///Users/jmprbx/git/volatility3/volatility3/symbols/linux/linux-6.17.0-6-generic-arm64.json.xz
INFO     volatility3.schemas: Dependency for validation unavailable: jsonschema
DEBUG    volatility3.schemas: All validations will report success, even with malformed input
DEBUG    volatility3.framework.automagic.symbol_finder: producer_name: dwarf2json, producer_version: 0.9.0
DEBUG    volatility3.framework.automagic.symbol_finder: Types:
DEBUG    volatility3.framework.automagic.symbol_finder: 	{'kind': 'dwarf', 'name': 'vmlinux-6.17.0-6-generic', 'hash_type': 'sha256', 'hash_value': 'e456c93687f552414e1a5aa38380ab1531eccad82ba0c65a1e4071a4d3ccf74a'}
DEBUG    volatility3.framework.automagic.symbol_finder: Symbols:
DEBUG    volatility3.framework.automagic.symbol_finder: 	{'kind': 'dwarf', 'name': 'vmlinux-6.17.0-6-generic', 'hash_type': 'sha256', 'hash_value': 'e456c93687f552414e1a5aa38380ab1531eccad82ba0c65a1e4071a4d3ccf74a'}
DEBUG    volatility3.framework.automagic.symbol_finder: 	{'kind': 'symtab', 'name': 'vmlinux-6.17.0-6-generic', 'hash_type': 'sha256', 'hash_value': 'e456c93687f552414e1a5aa38380ab1531eccad82ba0c65a1e4071a4d3ccf74a'}
INFO     volatility3.framework.automagic: Running automagic: KernelModule
DEBUG    volatility3.cli: Successfully constructed linux.psaux.PsAux (1, 1, 1)

PID	PPID	COMM	ARGS
1	0	systemd	/sbin/init
2	0	kthreadd	[kthreadd]
3	2	pool_workqueue_	[pool_workqueue_]
4	2	kworker/R-rcu_g	[kworker/R-rcu_g]
5	2	kworker/R-sync_	[kworker/R-sync_]
6	2	kworker/R-kvfre	[kworker/R-kvfre]
...
...
4756	2043	bash	/bin/bash --login
6852	2	kworker/u24:4	[kworker/u24:4]
8737	2	kworker/u24:0	[kworker/u24:0]
8743	2	kworker/1:0	[kworker/1:0]
8750	2	kworker/u24:1	[kworker/u24:1]
12308	2	kworker/0:0	[kworker/0:0]
12337	4756	sudo	sudo avml acquire --source /proc/kcore mem.lime
12339	12337	sudo	sudo avml acquire --source /proc/kcore mem.lime
12340	12339	avml	avml acquire --source /proc/kcore mem.lime
```

## Testing Reproduction Steps (End-to-End)
These might change by the time someone reviews but it should get you close
enough easily enough to reproducing the testing environments I used.

### 1. Create an ARM64 Ubuntu VM with Lima

```bash
# Install lima (macOS)
brew install lima

# Create VM from Ubuntu template with ARM64 architecture
# This uses Apple Virtualization.framework on Apple Silicon
limactl create --name=ubuntu-arm64 template://ubuntu

# (Optional) Before starting, edit ~/.lima/ubuntu-arm64/lima.yaml to:
#   - Increase resources: cpus: 8, memory: 10GiB, disk: 40GiB
#   - Mount the volatility3 repo:
#     mounts:
#       - location: "~/git/volatility3"
#         writable: true

limactl start ubuntu-arm64
```

### 2. Install AVML in the VM

```bash
limactl shell ubuntu-arm64 -- bash -c '
  AVML_VERSION="0.20.0"
  curl -L -o /tmp/avml \
    "https://github.com/microsoft/avml/releases/download/v${AVML_VERSION}/avml-${AVML_VERSION}-aarch64"
  chmod +x /tmp/avml
  sudo mv /tmp/avml /usr/local/bin/avml
  avml --version
'
```

### 3. Install kernel debug symbols (for dwarf2json)

```bash
limactl shell ubuntu-arm64 -- bash -c '
  # Install the dbgsym keyring
  sudo apt-get install -y ubuntu-dbgsym-keyring

  # Add the debug symbol repository
  CODENAME=$(lsb_release -cs)
  echo "deb http://ddebs.ubuntu.com ${CODENAME} main restricted universe multiverse
  deb http://ddebs.ubuntu.com ${CODENAME}-updates main restricted universe multiverse" | \
    sudo tee /etc/apt/sources.list.d/ddebs.list

  sudo apt-get update

  # Install debug symbols for the running kernel
  KVER=$(uname -r)
  sudo apt-get install -y linux-image-${KVER}-dbgsym

  # Verify the vmlinux file exists
  ls -la /usr/lib/debug/boot/vmlinux-${KVER}
'
```

### 4. Install dwarf2json and generate the symbol table

```bash
limactl shell ubuntu-arm64 -- bash -c '
  # Option A: Build from source (requires Go 1.21+)
  sudo apt-get install -y golang-go
  git clone https://github.com/volatilityfoundation/dwarf2json.git dwarf2json-src
  cd dwarf2json-src && go build -o ./dwarf2json .

  # Generate the ISF JSON symbol table
  KVER=$(uname -r)
  sudo /tmp/dwarf2json linux \
    --elf /usr/lib/debug/boot/vmlinux-${KVER} \
    | xz > /tmp/linux-${KVER}-arm64.json.xz

  # Place it in the volatility3 symbols directory
  mkdir -p ~/git/volatility3/volatility3/symbols/linux/
  cp /tmp/linux-${KVER}-arm64.json.xz ~/git/volatility3/volatility3/symbols/linux/
'
```

### 5. Capture memory with AVML

```bash
limactl shell ubuntu-arm64 -- bash -c '
  # Capture full physical memory in LiME format
  sudo avml acquire --source /proc/kcore ~/memory.lime

  # Verify the dump
  ls -lh ~/memory.lime
'
```

### 6. Run volatility3 on the captured image

```bash
# From the host (macOS), using the repo on this branch:
cd ~/git/volatility3

# Install volatility3 in development mode
pip install -e .

# Copy the memory image from the VM to the host (or use the mounted path)
limactl copy ubuntu-arm64:/home/<user>.linux/memory.lime memory.lime

# Run plugins against the ARM64 memory image
python -m volatility3 -f /tmp/memory.lime linux.pslist
python -m volatility3 -f /tmp/memory.lime linux.lsmod
python -m volatility3 -f /tmp/memory.lime linux.pstree
python -m volatility3 -f /tmp/memory.lime linux.mountinfo

# Run all working plugins (see Plugin Results above)
for plugin in linux.pslist linux.pstree linux.lsmod linux.lsof linux.bash \
  linux.envars linux.psaux linux.kmsg linux.capabilities linux.iomem \
  linux.boottime linux.ip.Addr linux.sockstat linux.proc.Maps; do
  echo "=== ${plugin} ==="
  python -m volatility3 -f /tmp/memory.lime ${plugin} | head -20
done
```

### Fedora ARM64 (steps 1-4 differ from Ubuntu)

The flow is identical to the Ubuntu procedure above except VM creation, debug
symbols, and dwarf2json. Steps 5-6 (capture + run) are the same.

```bash
# 1. Create + start a Fedora ARM64 VM (fedora-42 or fedora-43 template)
limactl create --name=fedora43-arm64 \
  --set '.cpus=8 | .memory="10GiB" | .disk="60GiB" | .mounts += [{"location":"~/git/volatility3","writable":true}]' \
  template:fedora-43
limactl start fedora43-arm64

# 2. Install AVML (asset is avml-aarch64, not version-suffixed) and capture.
#    Fedora's /tmp is tmpfs (RAM-backed) — write the image to /var/tmp instead.
limactl shell fedora43-arm64 -- bash -c '
  curl -sL -o /tmp/avml https://github.com/microsoft/avml/releases/download/v0.20.0/avml-aarch64
  chmod +x /tmp/avml && sudo mv /tmp/avml /usr/local/bin/avml
  sudo avml acquire /var/tmp/memory.lime      # LiME format; uses /proc/kcore
'

# 3. Install kernel debug symbols via dnf (this replaces the Ubuntu ddebs step)
limactl shell fedora43-arm64 -- bash -c '
  sudo dnf install -y dnf-plugins-core
  sudo dnf debuginfo-install -y kernel-core-$(uname -r)
  # vmlinux lands at /usr/lib/debug/lib/modules/$(uname -r)/vmlinux
'

# 4. Build dwarf2json from source (no prebuilt arm64 binary published) and
#    generate the ISF
limactl shell fedora43-arm64 -- bash -c '
  sudo dnf install -y golang git
  git clone https://github.com/volatilityfoundation/dwarf2json.git /tmp/d2j
  cd /tmp/d2j && go build -o /tmp/dwarf2json .
  KVER=$(uname -r)
  /tmp/dwarf2json linux --elf /usr/lib/debug/lib/modules/${KVER}/vmlinux \
    | xz > /Users/nreeves/git/volatility3/volatility3/symbols/linux/fedora43-${KVER}.json.xz
'
```

## Known Limitations
- 4KB granule only (16KB and 64KB granule not implemented)
- Linux only (no macOS ARM64 / iOS support yet)
- Validated on 48-bit VA across Ubuntu and Fedora (39-bit and 52-bit/LPA2
  implementations are based on spec; stock distros do not ship those configs, so
  they remain unexercised by a real image)
- No swap layer support for ARM64
- Page-cache file *content* recovery (`linux.pagecache.RecoverFs`,
  `page.to_paddr()`) is Intel-only: the `vmemmap_start` back-translation from a
  `struct page *` to a physical address is not yet implemented for AArch64.
  Inode/page enumeration (`pagecache.Files`, `pagecache.InodePages`) is
  unaffected.

## References
- ARM Architecture Reference Manual (DDI 0487)
- Linux kernel source: arch/arm64/include/asm/pgtable.h, memory.h, pgtable-hwdef.h
- Prior work: PR #1088 by Abyss-W4tcher and ikelos