### PR TITLE
Make the renderers plugin directory a package

### DIFF
--- a/volatility3/framework/plugins/renderers/__init__.py
+++ b/volatility3/framework/plugins/renderers/__init__.py
@@ -1,0 +1,8 @@
+# This file is Copyright 2025 Volatility Foundation and licensed under the Volatility Software License 1.0
+# which is available at https://www.volatilityfoundation.org/license/vsl-v1.0
+#
+"""All core renderer plugins.
+
+These modules should only be imported from volatility3.plugins NOT
+volatility3.framework.plugins
+"""


### PR DESCRIPTION
Fixes #1936.

## Why pyarrow goes missing

Both specs gather the plugin modules twice, by two different mechanisms:

```python
datas         = ... collect_data_files('volatility3.framework.plugins', include_py_files = True) ...
hiddenimports = ... collect_submodules('volatility3.framework.plugins') ...
```

`collect_data_files` walks the filesystem, so it picks up any `.py` file it
finds. `collect_submodules` walks `pkgutil`, and `pkgutil` will not descend
into a directory with no `__init__.py`.

`volatility3/framework/plugins/renderers` has no `__init__.py`, so the two
disagree:

```
collect_data_files(..., include_py_files=True)  ->  renderers/parquet_renderer.py   (shipped)
collect_submodules(...)                         ->  []                              (not analysed)
```

Only `hiddenimports` feeds pyinstaller's dependency analysis. The renderer is
therefore copied into the binary as an inert data file, its `import pyarrow` is
never seen, and pyarrow is left out even though the workflow installs it via
`pip install -e .[full,cloud,arrow]`.

This is exactly the "the renderer code does make it into the final binary" part
of the issue.

## Why it is only this directory

`renderers` is the only subdirectory under `volatility3/framework/plugins`
without an `__init__.py`; `linux`, `mac`, `windows`, `linux/graphics`,
`linux/malware`, `linux/tracing`, `windows/malware` and `windows/registry` all
have one.

The specs also call `collect_submodules` on `volatility3.framework.automagic`
and `volatility3.framework.symbols`. I checked both: `automagic` is clean, and
the six directories under `symbols/windows` without an `__init__.py`
(`bigpools`, `consoles`, `gui`, `netscan`, `services`, `shimcache`) hold nothing
but JSON, which `collect_data_files('volatility3.framework')` already handles.
So this is the only place the gap bites.

It dates from `e7c1126b`, which moved the renderers into the new subdirectory.
Before that they sat at `volatility3/framework/plugins/parquet_renderer.py`,
directly inside a package `collect_submodules` covers.

## What the user sees

The frozen build still advertises both renderers, because the framework
discovers them at runtime with `import_files`, which uses `os.walk` and does not
care about `__init__.py` either:

```
  -r, --renderer RENDERER
                        Determines how to render the output (quick, none, csv,
                        pretty, json, jsonl, mermaid, arrow, parquet)
```

Selecting one is an unhandled traceback rather than a clean error:

```
  File "...\volatility3\framework\plugins\renderers\parquet_renderer.py", line 44, in __init__
    raise RuntimeError("Arrow output format requires the pyarrow package")
RuntimeError: Arrow output format requires the pyarrow package
[PYI-24588:ERROR] Failed to execute script 'vol' due to unhandled exception!
```

## The fix

Add the missing `__init__.py`, matching the other plugin subpackages. That is
all `pkgutil` needs. Both specs use the same `collect_submodules` line, so
neither spec needs editing and `volshell.exe` is fixed at the same time.

I preferred this over adding `hiddenimports = ['pyarrow', 'pyarrow.parquet']` to
the specs, because that names one dependency of one renderer and leaves the
discovery gap in place for the next module added to the directory, and it would
have to be duplicated in both spec files.

## Verification

Built `vol.spec` before and after on Windows with pyarrow installed, and
compared the analysis TOCs:

| | `pyarrow` entries in `Analysis-00.toc` | `vol.exe` |
| --- | --- | --- |
| before | 0 | 22.8 MB |
| after | 1362 | 53.7 MB |

Running the built exe against `win-xp-laptop-2005-06-25.img`:

```
before:  vol.exe -r parquet ... -> RuntimeError, unhandled, exit 1, 0 bytes
after:   vol.exe -r parquet ... -> exit 0, 1601 bytes, PAR1 magic
         vol.exe -r arrow   ... -> exit 0, 1200 bytes
```

Both outputs read back correctly (23 rows, 2 columns, `Variable`/`Value`) with
`pq.read_table` and `pa.ipc.open_stream`.

Non-frozen behaviour is unchanged: 197 plugins discovered with and without the
change, zero import failures, identical plugin sets. `import_files` skips
filenames starting with `__`, so the new file is not itself imported as a
plugin.

`test/renderers/test_parquet_renderers.py` passes (4 passed, 4 skipped for the
absent Linux image). `ruff format`, `ruff check` and
`test/volatility3_code_analysis.py` are clean.

`test/plugins/windows/windows.py` gives an identical 58 failed / 23 passed with
and without the change on my machine, so this is neutral for it. Those failures
are #2013, not this: the `_specific_` tests pass a bare path to
`--single-location`, which the CLI turns into `file://///E:\...` on Windows.

## One thing worth deciding

The exe goes from 22.8 MB to 53.7 MB, because pyarrow brings a lot of `.pyd`
and Arrow DLLs with it (`_dataset_parquet`, `_acero`, `_azurefs`, `_flight`
and friends). That is the cost of actually shipping the dependency the build
already installs, but it is a 2.4x jump and you may want it to be a deliberate
choice rather than a side effect of this fix. Measured with pyarrow 25.0.1 on
Python 3.14; CI is on 3.11 so the exact figures will differ.

If the size is unwelcome, the alternative is to drop `arrow` from the
`pip install` line in `build-pyinstaller.yml` and have the frozen build simply
not offer those renderers, but that needs the renderer to fail gracefully
instead of raising an unhandled `RuntimeError`, which is a separate change.
Happy to do it whichever way you prefer.

## Possible follow-up

Nothing in CI would have caught this, and nothing would catch it coming back.
A smoke test in `build-pyinstaller.yml` between the build and move steps would:

```yaml
      - name: Check the optional renderers are usable
        run: |
          ./dist/vol.exe -q -r parquet frameworkinfo > frameworkinfo.parquet
          ./dist/vol.exe -q -r arrow frameworkinfo > frameworkinfo.arrow
```

`frameworkinfo` needs no memory image, and the renderer is constructed after the
plugin runs, so this reaches the line that raises. `--help` would not: argparse
exits during parsing, well before `renderers[args.renderer]()`.

I have left it out to keep this to the one file. Happy to add it here or
separately if you want it.
