### PR TITLE
Fix architecture typo blocking scheduled_tasks on 32-bit images

### DIFF
--- a/volatility3/framework/plugins/windows/registry/scheduled_tasks.py
+++ b/volatility3/framework/plugins/windows/registry/scheduled_tasks.py
@@ -1119,7 +1119,7 @@ class ScheduledTasks(interfaces.plugins.PluginInterface, timeliner.TimeLinerInte
             requirements.ModuleRequirement(
                 name="kernel",
                 description="Windows kernel",
-                architectures=["Intel33", "Intel64"],
+                architectures=["Intel32", "Intel64"],
             ),
             requirements.VersionRequirement(
                 name="hivelist", component=hivelist.HiveList, version=(2, 0, 0)


### PR DESCRIPTION
`ScheduledTasks.get_requirements()` asks for `architectures=["Intel33", "Intel64"]`. There is no `Intel33`. Intel layers only ever report `Intel32` or `Intel64` (`framework/layers/intel.py:43` and `:478`), so on a 32-bit image the kernel requirement can never be satisfied and the plugin aborts with an error that points at the layer instead of the architecture:

```
Unsatisfied requirement plugins.ScheduledTasks.kernel.layer_name
```

The deprecated `windows.scheduled_tasks.ScheduledTasks` alias is affected the same way.

Checked against both images from the test workflow:

| image | before | after |
| --- | --- | --- |
| win-xp-laptop-2005-06-25.img (32-bit) | rc=1, unsatisfied requirement | rc=0 |
| win-10_19041-2025_03.dmp (64-bit) | rc=0, 330 rows | rc=0, 330 rows |

`ruff check` and `ruff format --check` clean. `test/plugins/windows/windows.py` 63 passed, `test/plugins/windows/test_scheduled_tasks.py` 3 passed.
