### PR TITLE
Fix capabilities plugin on kernels before 6.3

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2375,9 +2375,8 @@ class kernel_cap_t(kernel_cap_struct):
             # In kernels >= 6.3 kernel_cap_t::val is a u64
             cap_value = self.val
         else:
-            raise exceptions.VolatilityException(
-                "Unsupported kernel capabilities implementation"
-            )
+            # Before 6.3 kernel_cap_t is a typedef of kernel_cap_struct
+            return super().get_capabilities()
 
         return cap_value & self.get_kernel_cap_full()
 


### PR DESCRIPTION
`linux.capabilities` aborts on any image whose symbols carry `kernel_cap_t` in the pre-6.3 layout:

```
VolatilityException: Unsupported kernel capabilities implementation
```

`kernel_cap_t` was added for the 6.3 rework (#985), where the struct became `{ u64 val; }`. Before 6.3 the same name exists as a typedef of `kernel_cap_struct` with a two-element `__u32 cap[]`, and `symbols/linux/__init__.py:61` maps that name to the subclass regardless. The subclass only handles `val`, so it raises even though `kernel_cap_struct.get_capabilities()` decodes the old layout correctly.

Falling back to the parent keeps the error path intact. It still raises the same exception when `cap` is missing or has an unexpected length (`extensions/__init__.py:2310` and `:2328`).

All three Debian ISFs used by the test workflow carry the old layout:

```
kernel_cap_t  size=8  fields: ['cap: array[2] of unsigned int']
```

On linux-sample-1.bin the exit code goes from 1 to 0 and the plugin lists 133 tasks instead of none. `test_linux_generic_capabilities` no longer takes its early-return path for this image, so its assertions actually run now.

`ruff check` and `ruff format --check` clean. `test/plugins/linux/linux.py` 41 passed.
