### PR TITLE
Import `IPython.terminal` submodules explicitly in Volshell

### DIFF
--- a/volatility3/cli/volshell/generic.py
+++ b/volatility3/cli/volshell/generic.py
@@ -25,7 +25,8 @@ except ImportError:
     has_capstone = False
 
 try:
-    from IPython import terminal
+    from IPython.terminal import embed, prompts
+
     from traitlets import config as traitlets_config
 
     has_ipython = True
@@ -135,16 +136,16 @@ class Volshell(interfaces.plugins.PluginInterface):
         combined_locals.update(self._construct_locals_dict())
         if has_ipython:
 
-            class LayerNamePrompt(terminal.prompts.Prompts):
+            class LayerNamePrompt(prompts.Prompts):
                 def in_prompt_tokens(self, cli=None):
                     slf = self.shell.user_ns.get("self")
                     layer_name = slf.current_layer if slf else "no_layer"
-                    return [(terminal.prompts.Token.Prompt, f"[{layer_name}]> ")]
+                    return [(prompts.Token.Prompt, f"[{layer_name}]> ")]
 
             c = traitlets_config.Config()
             c.TerminalInteractiveShell.prompts_class = LayerNamePrompt
             c.InteractiveShellEmbed.banner2 = banner
-            self.__console = terminal.embed.InteractiveShellEmbed(
+            self.__console = embed.InteractiveShellEmbed(
                 config=c, user_ns=combined_locals
             )
         else:


### PR DESCRIPTION
`volshell` crashes on startup with IPython>=9.17.0:

```python
$ python -c "import IPython; print(IPython.__version__)"
$ python -c "from IPython import terminal; print(terminal.prompts)"   # fails
$ python -c "import IPython.terminal.prompts; print('ok')"            # works

$ python volshell.py -f memory.elf -w

Volshell (Volatility 3 Framework) 2.28.2
Traceback (most recent call last):B scanning finished
  File "/home/canopus/dev/volatility3/volshell.py", line 11, in <module>
    volshell.main()
    ~~~~~~~~~~~~~^^
  File "/home/canopus/dev/volatility3/volatility3/cli/volshell/__init__.py", line 411, in main
    VolShell().run()
    ~~~~~~~~~~~~~~^^
  File "/home/canopus/dev/volatility3/volatility3/cli/volshell/__init__.py", line 403, in run
    constructed.run()
    ~~~~~~~~~~~~~~~^^
  File "/home/canopus/dev/volatility3/volatility3/cli/volshell/generic.py", line 138, in run
    class LayerNamePrompt(terminal.prompts.Prompts):
                          ^^^^^^^^^^^^^^^^
AttributeError: module 'IPython.terminal' has no attribute 'prompts'
```

`generic.py` does `from IPython import terminal`, then uses
`terminal.prompts` and `terminal.embed`.

Importing a package doesn't bind its submodules; those only existed
because `IPython/__init__.py` did `from .terminal.embed import embed`
at module level (up until 9.16.1).

IPython 9.17.0 moved that behind a module-level
`__getattr__` for startup time, so nothing imports them now.

Afaik, this should be a no-op on lesser versions of IPython

Edit: These changes make `from IPython import terminal` obsolete

(I really need to add a pre-commit hook for `ruff check` ...)