### PR TITLE
Add `__folio_index` and fix `memdesc_flags_t` introduction

### DIFF
--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -2688,6 +2688,14 @@ class page(objects.StructType):
 
         return True
 
+    @property
+    def index(self) -> int:
+        if self.has_member("__folio_index"):
+            # if __folio_index exists then we are post: https://lists.openwall.net/linux-kernel/2025/05/14/1508
+            return self.__folio_index
+
+        return self.member("index")
+
     @functools.cached_property
     def pageflags_enum(self) -> Dict:
         """Returns 'pageflags' enumeration key/values
@@ -2816,12 +2824,12 @@ class page(objects.StructType):
         Returns:
             List of page flags
         """
-        flags = []
-        for name, value in self.pageflags_enum.items():
-            if self.flags & (1 << value) != 0:
-                flags.append(name)
-
-        return flags
+        # if .f exists we are post memdesc_flags_t introduction
+        # https://github.com/torvalds/linux/commit/53fbef56e07df822ea3029109ffca25328c2e5ac
+        flags = getattr(self.flags, "f", self.flags)
+        return [
+            name for name, value in self.pageflags_enum.items() if flags & (1 << value)
+        ]
 
 
 class IDR(objects.StructType):


### PR DESCRIPTION
Regarding #1943, I have been rocking the `@property...` patch locally since then without noticing any issues at all. 

In addition to that, since the introduction of `memdesc_flags_t`, `get_flags_list()` incorrectly tries to calculate flags with a `StructType` rather than an int:

```
[...]
  File "/home/canopus/dev/volatility3/volatility3/framework/symbols/linux/extensions/__init__.py", line 2828, in get_flags_list
    if self.flags & (1 << value) != 0:
       ~~~~~~~~~~~^~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for &: 'StructType' and 'int'
```

- [`__folio_index` patch](https://lists.openwall.net/linux-kernel/2025/05/14/1508)
- [`memdesc_flags_t` introduction patch](https://github.com/torvalds/linux/commit/53fbef56e07df822ea3029109ffca25328c2e5ac)

Note: even without the `flags` patch, the files were dumped successfully 