### PR TITLE
linux.pagecache.RecoverFs: Fix infinite list iteration loop and tarball in-memory usage

### DIFF
--- a/volatility3/framework/plugins/linux/pagecache.py
+++ b/volatility3/framework/plugins/linux/pagecache.py
@@ -528,7 +528,8 @@ class InodePages(plugins.PluginInterface):
                 max_length = inode_size - current_fp
                 page_bytes_len = min(max_length, len(page_content))
                 if current_fp >= inode_size or current_fp + page_bytes_len > inode_size:
-                    vollog.error(
+                    vollog.log(
+                        constants.LOGLEVEL_VVV,
                         "Page out of file bounds: inode 0x%x, inode size %d, page index %d",
                         inode.vol.offset,
                         inode_size,
@@ -560,8 +561,9 @@ class InodePages(plugins.PluginInterface):
         try:
             for page_obj in inode.get_pages():
                 if page_obj.mapping != inode.i_mapping:
-                    vollog.warning(
-                        f"Cached page at {page_obj.vol.offset:#x} has a mismatched address space with the inode. Skipping page"
+                    vollog.log(
+                        constants.LOGLEVEL_VVV,
+                        f"Cached page at {page_obj.vol.offset:#x} has a mismatched address space with the inode. Skipping page",
                     )
                     continue
                 page_vaddr = page_obj.vol.offset
@@ -660,7 +662,7 @@ class RecoverFs(plugins.PluginInterface):
     Troubleshooting: to fix extraction errors related to long paths, please consider using https://github.com/mxmlnkn/ratarmount.
     """
 
-    _version = (1, 0, 1)
+    _version = (1, 0, 2)
     _required_framework_version = (2, 21, 0)
 
     @classmethod
@@ -793,9 +795,11 @@ class RecoverFs(plugins.PluginInterface):
         vmlinux_module_name = self.config["kernel"]
         vmlinux = self.context.modules[vmlinux_module_name]
         vmlinux_layer = self.context.layers[vmlinux.layer_name]
-        tar_buffer = BytesIO()
+
+        output_filename = f"recovered_fs.tar.{self.config['compression_format']}"
+        output_file = self.open(output_filename)
         tar = tarfile.open(
-            fileobj=tar_buffer,
+            fileobj=output_file,
             mode=f"w:{self.config['compression_format']}",
         )
         # Set a unique timestamp for all extracted files
@@ -896,10 +900,7 @@ class RecoverFs(plugins.PluginInterface):
             yield (0, astuple(inode_out) + (extracted_file_size,))
 
         tar.close()
-        tar_buffer.seek(0)
-        output_filename = f"recovered_fs.tar.{self.config['compression_format']}"
-        with self.open(output_filename) as f:
-            f.write(tar_buffer.getvalue())
+        output_file.close()
 
     def run(self):
         headers = [

--- a/volatility3/framework/symbols/linux/extensions/__init__.py
+++ b/volatility3/framework/symbols/linux/extensions/__init__.py
@@ -1615,7 +1615,9 @@ class hlist_head(objects.StructType):
         vmlinux = linux.LinuxUtilities.get_module_from_volobj_type(self._context, self)
 
         current = self.first
-        while current and current.is_readable():
+        seen = set()
+        while current and current.is_readable() and current.vol.offset not in seen:
+            seen.add(current.vol.offset)
             yield linux.LinuxUtilities.container_of(
                 current, symbol_type, member, vmlinux
             )


### PR DESCRIPTION
Hi, this PR:

- streams the content of the live tar buffer directly to disk instead of storing it all in memory before flushing to disk;
- fixes an infinite loop in the hlist_head iteration that was causing OOM in the `linux.pagecache.RecoverFs` task as a side-effect

Fixes https://github.com/volatilityfoundation/volatility3/issues/1975