### PR TITLE
Small optimization: Use "any" to avoid iterating the entire dataclasses.fields list

### DIFF
--- a/volatility3/framework/interfaces/objects.py
+++ b/volatility3/framework/interfaces/objects.py
@@ -79,7 +79,7 @@ class ObjectInformation:
         raise KeyError(f"No {key} present in ObjectInformation")
 
     def __contains__(self, key):
-        return key in [field.name for field in dataclasses.fields(self)]
+        return any(field.name == key for field in dataclasses.fields(self))
 
 
 class ObjectInterface(metaclass=abc.ABCMeta):


### PR DESCRIPTION
Hi, this PR:

- makes use of the "any" keyword to prevent building the entire dataclasses.fields list before checking if a key exists in it. This is a really minor optimization, but worth doing if this method gets called a lot.